### PR TITLE
A fix for v1.6 under Borland C++

### DIFF
--- a/scripts/makefile.bc32
+++ b/scripts/makefile.bc32
@@ -52,7 +52,9 @@ LDFLAGS=-L$(ZLIB_DIR) -M $(LDEBUG)
 
 # Pre-built configuration
 # See scripts\pnglibconf.mak for more options
+!ifndef PNGLIBCONF_H_PREBUILT
 PNGLIBCONF_H_PREBUILT = scripts\pnglibconf.h.prebuilt
+!endif
 
 ## Variables
 OBJS = \

--- a/scripts/makefile.bor
+++ b/scripts/makefile.bor
@@ -60,7 +60,9 @@ LDFLAGS=-M -L$(ZLIB_DIR) $(MODEL_ARG) $(LDEBUG)
 
 # Pre-built configuration
 # See scripts\pnglibconf.mak for more options
+!ifndef PNGLIBCONF_H_PREBUILT
 PNGLIBCONF_H_PREBUILT = scripts\pnglibconf.h.prebuilt
+!endif
 
 ## Variables
 

--- a/scripts/makefile.tc3
+++ b/scripts/makefile.tc3
@@ -16,7 +16,9 @@ CP=copy
 
 # Pre-built configuration
 # See scripts\pnglibconf.mak for more options
+!ifndef PNGLIBCONF_H_PREBUILT
 PNGLIBCONF_H_PREBUILT = scripts\pnglibconf.h.prebuilt
+!endif
 
 O=.obj
 E=.exe


### PR DESCRIPTION
The macros passed in the command line to Borland make are ignored if
similarly-named macros are already defined in makefiles. This behavior
is different from POSIX make and other make programs.

Surround the macro definitions with ifndef guards.
