### PR TITLE
Fixes pertaining background color and grayscale conversions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -506,6 +506,9 @@ set(pngunknown_sources
 set(pngimage_sources
   contrib/libtests/pngimage.c
 )
+set(pngadhoc_sources
+  contrib/libtests/pngadhoc.c
+)
 set(pngfix_sources
   contrib/tools/pngfix.c
 )
@@ -745,6 +748,10 @@ if(PNG_TESTS AND PNG_SHARED)
 
   png_add_test(NAME pngimage-quick COMMAND pngimage OPTIONS --list-combos --log FILES ${PNGSUITE_PNGS})
   png_add_test(NAME pngimage-full COMMAND pngimage OPTIONS --exhaustive --list-combos --log FILES ${PNGSUITE_PNGS})
+
+  add_executable(pngadhoc ${pngadhoc_sources})
+  target_link_libraries(pngadhoc png)
+  png_add_test(NAME pngadhoc COMMAND pngadhoc)
 endif()
 
 if(PNG_SHARED)

--- a/Makefile.am
+++ b/Makefile.am
@@ -12,7 +12,7 @@ PNGLIB_BASENAME= libpng@PNGLIB_MAJOR@@PNGLIB_MINOR@
 ACLOCAL_AMFLAGS = -I scripts
 
 # test programs - run on make check, make distcheck
-check_PROGRAMS= pngtest pngunknown pngstest pngvalid pngimage pngcp
+check_PROGRAMS= pngtest pngunknown pngstest pngvalid pngimage pngcp pngadhoc
 if HAVE_CLOCK_GETTIME
 check_PROGRAMS += timepng
 endif
@@ -56,6 +56,9 @@ png_fix_itxt_SOURCES = contrib/tools/png-fix-itxt.c
 pngcp_SOURCES = contrib/tools/pngcp.c
 pngcp_LDADD = libpng@PNGLIB_MAJOR@@PNGLIB_MINOR@.la
 
+pngadhoc_SOURCES = contrib/libtests/pngadhoc.c
+pngadhoc_LDADD = libpng@PNGLIB_MAJOR@@PNGLIB_MINOR@.la
+
 # Generally these are single line shell scripts to run a test with a particular
 # set of parameters:
 TESTS =\
@@ -75,7 +78,7 @@ TESTS =\
    tests/pngstest-sRGB tests/pngstest-sRGB-alpha tests/pngunknown-IDAT\
    tests/pngunknown-discard tests/pngunknown-if-safe tests/pngunknown-sAPI\
    tests/pngunknown-sTER tests/pngunknown-save tests/pngunknown-vpAg\
-   tests/pngimage-quick tests/pngimage-full
+   tests/pngimage-quick tests/pngimage-full tests/pngadhoc
 
 # man pages
 dist_man_MANS= libpng.3 libpngpf.3 png.5
@@ -244,6 +247,7 @@ contrib/libtests/pngstest.o: pnglibconf.h
 contrib/libtests/pngunknown.o: pnglibconf.h
 contrib/libtests/pngimage.o: pnglibconf.h
 contrib/libtests/pngvalid.o: pnglibconf.h
+contrib/libtests/pngadhoc.o: pnglibconf.h
 contrib/libtests/readpng.o: pnglibconf.h
 contrib/libtests/tarith.o: pnglibconf.h
 contrib/libtests/timepng.o: pnglibconf.h

--- a/Makefile.in
+++ b/Makefile.in
@@ -102,7 +102,7 @@ build_triplet = @build@
 host_triplet = @host@
 check_PROGRAMS = pngtest$(EXEEXT) pngunknown$(EXEEXT) \
 	pngstest$(EXEEXT) pngvalid$(EXEEXT) pngimage$(EXEEXT) \
-	pngcp$(EXEEXT) $(am__EXEEXT_1)
+	pngcp$(EXEEXT) pngadhoc$(EXEEXT) $(am__EXEEXT_1)
 @HAVE_CLOCK_GETTIME_TRUE@am__append_1 = timepng
 bin_PROGRAMS = pngfix$(EXEEXT) png-fix-itxt$(EXEEXT)
 @PNG_ARM_NEON_TRUE@am__append_2 = arm/arm_init.c\
@@ -240,6 +240,9 @@ pngunknown_DEPENDENCIES = libpng@PNGLIB_MAJOR@@PNGLIB_MINOR@.la
 am_pngvalid_OBJECTS = contrib/libtests/pngvalid.$(OBJEXT)
 pngvalid_OBJECTS = $(am_pngvalid_OBJECTS)
 pngvalid_DEPENDENCIES = libpng@PNGLIB_MAJOR@@PNGLIB_MINOR@.la
+am_pngadhoc_OBJECTS = contrib/libtests/pngadhoc.$(OBJEXT)
+pngadhoc_OBJECTS = $(am_pngadhoc_OBJECTS)
+pngadhoc_DEPENDENCIES = libpng@PNGLIB_MAJOR@@PNGLIB_MINOR@.la
 am_timepng_OBJECTS = contrib/libtests/timepng.$(OBJEXT)
 timepng_OBJECTS = $(am_timepng_OBJECTS)
 timepng_DEPENDENCIES = libpng@PNGLIB_MAJOR@@PNGLIB_MINOR@.la
@@ -274,6 +277,7 @@ am__depfiles_remade = ./$(DEPDIR)/png.Plo ./$(DEPDIR)/pngerror.Plo \
 	contrib/libtests/$(DEPDIR)/pngstest.Po \
 	contrib/libtests/$(DEPDIR)/pngunknown.Po \
 	contrib/libtests/$(DEPDIR)/pngvalid.Po \
+	contrib/libtests/$(DEPDIR)/pngadhoc.Po \
 	contrib/libtests/$(DEPDIR)/timepng.Po \
 	contrib/tools/$(DEPDIR)/png-fix-itxt.Po \
 	contrib/tools/$(DEPDIR)/pngcp.Po \
@@ -317,12 +321,14 @@ SOURCES = $(libpng@PNGLIB_MAJOR@@PNGLIB_MINOR@_la_SOURCES) \
 	$(nodist_libpng@PNGLIB_MAJOR@@PNGLIB_MINOR@_la_SOURCES) \
 	$(png_fix_itxt_SOURCES) $(pngcp_SOURCES) $(pngfix_SOURCES) \
 	$(pngimage_SOURCES) $(pngstest_SOURCES) $(pngtest_SOURCES) \
-	$(pngunknown_SOURCES) $(pngvalid_SOURCES) $(timepng_SOURCES)
+	$(pngunknown_SOURCES) $(pngvalid_SOURCES) $(pngadhoc_SOURCES) \
+	$(timepng_SOURCES)
 DIST_SOURCES =  \
 	$(am__libpng@PNGLIB_MAJOR@@PNGLIB_MINOR@_la_SOURCES_DIST) \
 	$(png_fix_itxt_SOURCES) $(pngcp_SOURCES) $(pngfix_SOURCES) \
 	$(pngimage_SOURCES) $(pngstest_SOURCES) $(pngtest_SOURCES) \
-	$(pngunknown_SOURCES) $(pngvalid_SOURCES) $(timepng_SOURCES)
+	$(pngunknown_SOURCES) $(pngvalid_SOURCES) $(pngadhoc_SOURCES) \
+	$(timepng_SOURCES)
 am__can_run_installinfo = \
   case $$AM_UPDATE_INFO_DIR in \
     n|no|NO) false;; \
@@ -732,6 +738,8 @@ pngfix_LDADD = libpng@PNGLIB_MAJOR@@PNGLIB_MINOR@.la
 png_fix_itxt_SOURCES = contrib/tools/png-fix-itxt.c
 pngcp_SOURCES = contrib/tools/pngcp.c
 pngcp_LDADD = libpng@PNGLIB_MAJOR@@PNGLIB_MINOR@.la
+pngadhoc_SOURCES = contrib/libtests/pngadhoc.c
+pngadhoc_LDADD = libpng@PNGLIB_MAJOR@@PNGLIB_MINOR@.la
 
 # Generally these are single line shell scripts to run a test with a particular
 # set of parameters:
@@ -752,7 +760,7 @@ TESTS = \
    tests/pngstest-sRGB tests/pngstest-sRGB-alpha tests/pngunknown-IDAT\
    tests/pngunknown-discard tests/pngunknown-if-safe tests/pngunknown-sAPI\
    tests/pngunknown-sTER tests/pngunknown-save tests/pngunknown-vpAg\
-   tests/pngimage-quick tests/pngimage-full
+   tests/pngimage-quick tests/pngimage-full tests/pngadhoc
 
 
 # man pages
@@ -1069,6 +1077,12 @@ contrib/libtests/pngvalid.$(OBJEXT): contrib/libtests/$(am__dirstamp) \
 pngvalid$(EXEEXT): $(pngvalid_OBJECTS) $(pngvalid_DEPENDENCIES) $(EXTRA_pngvalid_DEPENDENCIES) 
 	@rm -f pngvalid$(EXEEXT)
 	$(AM_V_CCLD)$(LINK) $(pngvalid_OBJECTS) $(pngvalid_LDADD) $(LIBS)
+contrib/libtests/pngadhoc.$(OBJEXT): contrib/libtests/$(am__dirstamp) \
+	contrib/libtests/$(DEPDIR)/$(am__dirstamp)
+
+pngadhoc$(EXEEXT): $(pngadhoc_OBJECTS) $(pngadhoc_DEPENDENCIES) $(EXTRA_pngadhoc_DEPENDENCIES) 
+	@rm -f pngadhoc$(EXEEXT)
+	$(AM_V_CCLD)$(LINK) $(pngadhoc_OBJECTS) $(pngadhoc_LDADD) $(LIBS)
 contrib/libtests/timepng.$(OBJEXT): contrib/libtests/$(am__dirstamp) \
 	contrib/libtests/$(DEPDIR)/$(am__dirstamp)
 
@@ -1151,6 +1165,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@contrib/libtests/$(DEPDIR)/pngstest.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@contrib/libtests/$(DEPDIR)/pngunknown.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@contrib/libtests/$(DEPDIR)/pngvalid.Po@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@contrib/libtests/$(DEPDIR)/pngadhoc.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@contrib/libtests/$(DEPDIR)/timepng.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@contrib/tools/$(DEPDIR)/png-fix-itxt.Po@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@contrib/tools/$(DEPDIR)/pngcp.Po@am__quote@ # am--include-marker
@@ -1809,6 +1824,13 @@ tests/pngimage-full.log: tests/pngimage-full
 	--log-file $$b.log --trs-file $$b.trs \
 	$(am__common_driver_flags) $(AM_LOG_DRIVER_FLAGS) $(LOG_DRIVER_FLAGS) -- $(LOG_COMPILE) \
 	"$$tst" $(AM_TESTS_FD_REDIRECT)
+tests/pngadhoc.log: tests/pngadhoc
+	@p='tests/pngadhoc'; \
+	b='tests/pngadhoc'; \
+	$(am__check_pre) $(LOG_DRIVER) --test-name "$$f" \
+	--log-file $$b.log --trs-file $$b.trs \
+	$(am__common_driver_flags) $(AM_LOG_DRIVER_FLAGS) $(LOG_DRIVER_FLAGS) -- $(LOG_COMPILE) \
+	"$$tst" $(AM_TESTS_FD_REDIRECT)
 .test.log:
 	@p='$<'; \
 	$(am__set_b); \
@@ -2088,6 +2110,7 @@ distclean: distclean-am
 	-rm -f contrib/libtests/$(DEPDIR)/pngstest.Po
 	-rm -f contrib/libtests/$(DEPDIR)/pngunknown.Po
 	-rm -f contrib/libtests/$(DEPDIR)/pngvalid.Po
+	-rm -f contrib/libtests/$(DEPDIR)/pngadhoc.Po
 	-rm -f contrib/libtests/$(DEPDIR)/timepng.Po
 	-rm -f contrib/tools/$(DEPDIR)/png-fix-itxt.Po
 	-rm -f contrib/tools/$(DEPDIR)/pngcp.Po
@@ -2173,6 +2196,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f contrib/libtests/$(DEPDIR)/pngstest.Po
 	-rm -f contrib/libtests/$(DEPDIR)/pngunknown.Po
 	-rm -f contrib/libtests/$(DEPDIR)/pngvalid.Po
+	-rm -f contrib/libtests/$(DEPDIR)/pngadhoc.Po
 	-rm -f contrib/libtests/$(DEPDIR)/timepng.Po
 	-rm -f contrib/tools/$(DEPDIR)/png-fix-itxt.Po
 	-rm -f contrib/tools/$(DEPDIR)/pngcp.Po
@@ -2300,6 +2324,7 @@ contrib/libtests/pngstest.o: pnglibconf.h
 contrib/libtests/pngunknown.o: pnglibconf.h
 contrib/libtests/pngimage.o: pnglibconf.h
 contrib/libtests/pngvalid.o: pnglibconf.h
+contrib/libtests/pngadhoc.o: pnglibconf.h
 contrib/libtests/readpng.o: pnglibconf.h
 contrib/libtests/tarith.o: pnglibconf.h
 contrib/libtests/timepng.o: pnglibconf.h

--- a/contrib/libtests/pngadhoc.c
+++ b/contrib/libtests/pngadhoc.c
@@ -1,0 +1,153 @@
+/* pngadhoc.c
+ *
+ * Copyright (c) 2019 Vladimir Panteleev
+ *
+ * This code is released under the libpng license.
+ * For conditions of distribution and use, see the disclaimer
+ * and license in png.h
+ *
+ * Ad-hoc libpng regression tests.
+ */
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+/* Define the following to use this test against your installed libpng, rather
+ * than the one being built here:
+ */
+#ifdef PNG_FREESTANDING_TESTS
+#  include <png.h>
+#else
+#  include "../../png.h"
+#endif
+
+struct buffer
+{
+   png_bytep data;
+   size_t length;
+};
+
+static void
+png_write_callback(png_structp png_ptr, png_bytep data, png_size_t length)
+{
+   struct buffer *buffer = (struct buffer *)png_get_io_ptr(png_ptr);
+   buffer->data = realloc(buffer->data, buffer->length + length);
+   if (buffer->data == NULL)
+      png_error(png_ptr, "OOM while writing PNG");
+   memcpy(buffer->data + buffer->length, data, length);
+   buffer->length += length;
+}
+
+static void
+png_read_callback(png_structp png_ptr, png_bytep data, png_size_t length)
+{
+   struct buffer *buffer = (struct buffer *)png_get_io_ptr(png_ptr);
+   if (buffer->length < length)
+      png_error(png_ptr, "EOF while reading PNG");
+   memcpy(data, buffer->data, length);
+   buffer->data += length;
+   buffer->length -= length;
+}
+
+static int
+png_test_bKGD_rgb_to_gray()
+{
+#if defined(PNG_SEQUENTIAL_READ_SUPPORTED) && \
+   defined(PNG_bKGD_SUPPORTED) && \
+   defined(PNG_READ_BACKGROUND_SUPPORTED) && \
+   defined(PNG_READ_EXPAND_SUPPORTED) && \
+   defined(PNG_READ_STRIP_ALPHA_SUPPORTED) && \
+   defined(PNG_READ_RGB_TO_GRAY_SUPPORTED)
+
+   png_structp png_ptr = png_create_write_struct(PNG_LIBPNG_VER_STRING,
+      0, 0, 0);
+   png_infop info_ptr = NULL;
+   png_byte row[4];
+   struct buffer write_buffer, read_buffer;
+   png_color_16 write_background = {0, 255, 255, 255, 0};
+   png_color_16p read_background;
+
+   if (png_ptr == NULL)
+   {
+      fprintf(stderr, "OOM allocating write structure\n");
+      return 1;
+   }
+
+   info_ptr = png_create_info_struct(png_ptr);
+   if (info_ptr == NULL)
+      png_error(png_ptr, "OOM allocating info structure");
+
+   write_buffer.data = NULL;
+   write_buffer.length = 0;
+   png_set_write_fn(png_ptr, &write_buffer, &png_write_callback, NULL);
+
+   png_set_IHDR(
+      png_ptr, info_ptr,
+      1, 1,
+      8,
+      PNG_COLOR_TYPE_RGBA,
+      PNG_INTERLACE_NONE,
+      PNG_COMPRESSION_TYPE_DEFAULT,
+      PNG_FILTER_TYPE_DEFAULT);
+   png_set_bKGD(png_ptr, info_ptr, &write_background);
+   png_write_info(png_ptr, info_ptr);
+
+   row[0] = row[1] = row[2] = 0;
+   row[3] = 0; // Transparent
+   png_write_row(png_ptr, row);
+   png_write_end(png_ptr, NULL);
+   png_destroy_write_struct(&png_ptr, &info_ptr);
+
+   png_ptr = png_create_read_struct(PNG_LIBPNG_VER_STRING,
+      0, 0, 0);
+   if (png_ptr == NULL)
+   {
+      fprintf(stderr, "OOM allocating write structure\n");
+      return 1;
+   }
+
+   info_ptr = png_create_info_struct(png_ptr);
+   if (info_ptr == NULL)
+      png_error(png_ptr, "OOM allocating info structure");
+
+   read_buffer = write_buffer;
+   png_set_read_fn(png_ptr, &read_buffer, &png_read_callback);
+
+   png_read_info(png_ptr, info_ptr);
+
+   png_set_rgb_to_gray(png_ptr,
+      PNG_ERROR_ACTION_NONE,
+      PNG_RGB_TO_GRAY_DEFAULT,
+      PNG_RGB_TO_GRAY_DEFAULT);
+
+   png_set_expand(png_ptr);
+   png_set_strip_alpha(png_ptr);
+   /* as per manual */
+   if (png_get_bKGD(png_ptr, info_ptr, &read_background))
+      png_set_background(png_ptr, read_background,
+         PNG_BACKGROUND_GAMMA_FILE, 1/*needs to be expanded*/, 1);
+   else
+      png_error(png_ptr, "No bKGD");
+
+   png_read_row(png_ptr, row, NULL);
+   if (row[0] != 255)
+      png_error(png_ptr, "Wrong color with bKGD");
+
+   png_destroy_read_struct(&png_ptr, &info_ptr, NULL);
+
+   free(write_buffer.data);
+#endif
+
+   return 0;
+}
+
+int
+main(void)
+{
+   int ret;
+
+   ret = png_test_bKGD_rgb_to_gray();
+   if (ret) return ret;
+
+   return 0;
+}

--- a/contrib/libtests/pngadhoc.c
+++ b/contrib/libtests/pngadhoc.c
@@ -141,12 +141,105 @@ png_test_bKGD_rgb_to_gray()
    return 0;
 }
 
+static int
+png_test_bKGD_tRNS_4bit()
+{
+#if defined(PNG_SEQUENTIAL_READ_SUPPORTED) && \
+   defined(PNG_bKGD_SUPPORTED) && \
+   defined(PNG_READ_BACKGROUND_SUPPORTED) && \
+   defined(PNG_READ_EXPAND_SUPPORTED) && \
+   defined(PNG_READ_STRIP_ALPHA_SUPPORTED) && \
+   defined(PNG_READ_RGB_TO_GRAY_SUPPORTED)
+
+   png_structp png_ptr = png_create_write_struct(PNG_LIBPNG_VER_STRING,
+      0, 0, 0);
+   png_infop info_ptr = NULL;
+   png_byte row[1];
+   struct buffer write_buffer, read_buffer;
+   png_color_16 write_background = {0, 0, 0, 0, 15};
+   png_color_16 trans = {0, 0, 0, 0, 10};
+   png_color_16p read_background;
+
+   if (png_ptr == NULL)
+   {
+      fprintf(stderr, "OOM allocating write structure\n");
+      return 1;
+   }
+
+   info_ptr = png_create_info_struct(png_ptr);
+   if (info_ptr == NULL)
+      png_error(png_ptr, "OOM allocating info structure");
+
+   write_buffer.data = NULL;
+   write_buffer.length = 0;
+   png_set_write_fn(png_ptr, &write_buffer, &png_write_callback, NULL);
+
+   png_set_IHDR(
+      png_ptr, info_ptr,
+      1, 1,
+      4,
+      PNG_COLOR_TYPE_GRAY,
+      PNG_INTERLACE_NONE,
+      PNG_COMPRESSION_TYPE_DEFAULT,
+      PNG_FILTER_TYPE_DEFAULT);
+   png_set_bKGD(png_ptr, info_ptr, &write_background);
+   png_set_tRNS(png_ptr, info_ptr, NULL, 1, &trans);
+   png_write_info(png_ptr, info_ptr);
+
+   row[0] = 10 << 4;
+   png_write_row(png_ptr, row);
+   png_write_end(png_ptr, NULL);
+   png_destroy_write_struct(&png_ptr, &info_ptr);
+
+   png_ptr = png_create_read_struct(PNG_LIBPNG_VER_STRING,
+      0, 0, 0);
+   if (png_ptr == NULL)
+   {
+      fprintf(stderr, "OOM allocating write structure\n");
+      return 1;
+   }
+
+   info_ptr = png_create_info_struct(png_ptr);
+   if (info_ptr == NULL)
+      png_error(png_ptr, "OOM allocating info structure");
+
+   read_buffer = write_buffer;
+   png_set_read_fn(png_ptr, &read_buffer, &png_read_callback);
+
+   png_read_info(png_ptr, info_ptr);
+
+   png_set_expand(png_ptr);
+   png_set_strip_alpha(png_ptr);
+   /* as per manual */
+   if (png_get_bKGD(png_ptr, info_ptr, &read_background))
+   {
+      png_set_background(png_ptr, read_background,
+         PNG_BACKGROUND_GAMMA_FILE, 1/*needs to be expanded*/, 1);
+   }
+   else
+      png_error(png_ptr, "No bKGD");
+
+   png_read_row(png_ptr, row, NULL);
+   if (row[0] != 255)
+      png_error(png_ptr, "Wrong color with bKGD/tRNS");
+
+   png_destroy_read_struct(&png_ptr, &info_ptr, NULL);
+
+   free(write_buffer.data);
+#endif
+
+   return 0;
+}
+
 int
 main(void)
 {
    int ret;
 
    ret = png_test_bKGD_rgb_to_gray();
+   if (ret) return ret;
+
+   ret = png_test_bKGD_tRNS_4bit();
    if (ret) return ret;
 
    return 0;

--- a/pngrtran.c
+++ b/pngrtran.c
@@ -1202,6 +1202,10 @@ png_init_palette_transformations(png_structrp png_ptr)
 #endif /* READ_EXPAND && READ_BACKGROUND */
 }
 
+#ifdef PNG_READ_RGB_TO_GRAY_SUPPORTED
+static int png_do_rgb_to_gray_1(png_structrp png_ptr, png_color_16p color, png_byte bit_depth);
+#endif
+
 static void /* PRIVATE */
 png_init_rgb_transformations(png_structrp png_ptr)
 {
@@ -1238,10 +1242,10 @@ png_init_rgb_transformations(png_structrp png_ptr)
     * because PNG_BACKGROUND_EXPAND is cancelled below.
     */
    if ((png_ptr->transformations & PNG_BACKGROUND_EXPAND) != 0 &&
-       (png_ptr->transformations & PNG_EXPAND) != 0 &&
-       (png_ptr->color_type & PNG_COLOR_MASK_COLOR) == 0)
-       /* i.e., GRAY or GRAY_ALPHA */
+       (png_ptr->transformations & PNG_EXPAND) != 0)
    {
+      /* i.e., GRAY or GRAY_ALPHA */
+      if ((png_ptr->color_type & PNG_COLOR_MASK_COLOR) == 0)
       {
          /* Expand background and tRNS chunks */
          int gray = png_ptr->background.gray;
@@ -1282,6 +1286,33 @@ png_init_rgb_transformations(png_structrp png_ptr)
             png_ptr->trans_color.red = png_ptr->trans_color.green =
                png_ptr->trans_color.blue = (png_uint_16)trans_gray;
          }
+      }
+      else
+      {
+#ifdef PNG_READ_RGB_TO_GRAY_SUPPORTED
+         if ((png_ptr->transformations & PNG_RGB_TO_GRAY) != 0)
+         {
+            /* Populate the backgrounds' gray fields using the same
+             * algorithm as RGB->gray conversion, to enable correct
+             * tRNS/bKGD handling with png_set_rgb_to_gray. */
+
+            png_byte bit_depth = png_ptr->bit_depth == 16 ? 16 : 8;
+            int rgb_error =
+               png_do_rgb_to_gray_1(png_ptr, &png_ptr->background, bit_depth);
+
+            if (rgb_error != 0)
+            {
+               png_ptr->rgb_to_gray_status=1;
+               if ((png_ptr->transformations & PNG_RGB_TO_GRAY) ==
+                   PNG_RGB_TO_GRAY_WARN)
+                  png_warning(png_ptr, "nongray background color");
+
+               if ((png_ptr->transformations & PNG_RGB_TO_GRAY) ==
+                   PNG_RGB_TO_GRAY_ERR)
+                  png_error(png_ptr, "nongray background color");
+            }
+         }
+#endif
       }
    } /* background expand and (therefore) no alpha association. */
 #endif /* READ_EXPAND && READ_BACKGROUND */
@@ -3188,6 +3219,55 @@ png_do_rgb_to_gray(png_structrp png_ptr, png_row_infop row_info, png_bytep row)
    }
    return rgb_error;
 }
+
+/* Convert a single color to grayscale. */
+static int
+png_do_rgb_to_gray_1(png_structrp png_ptr, png_color_16p color, png_byte bit_depth)
+{
+   /* Reuse the logic in png_do_rgb_to_gray and construct a fake "row"
+    * containing just the value we need to convert. */
+   png_byte row[3 /* channels */ * 2 /* max bytes per channel */];
+   png_row_info row_info;
+   row_info.width = 1;
+   row_info.color_type = PNG_COLOR_TYPE_RGB;
+   row_info.bit_depth = bit_depth;
+
+   png_bytep dp = row;
+   if (png_ptr->bit_depth == 16)
+   {
+      *(dp++) = (png_byte)((color->red >> 8) & 0xff);
+      *(dp++) = (png_byte)(color->red & 0xff);
+      *(dp++) = (png_byte)((color->green >> 8) & 0xff);
+      *(dp++) = (png_byte)(color->green & 0xff);
+      *(dp++) = (png_byte)((color->blue >> 8) & 0xff);
+      *(dp++) = (png_byte)(color->blue & 0xff);
+   }
+   else
+   {
+      *(dp++) = (png_byte)color->red;
+      *(dp++) = (png_byte)color->green;
+      *(dp++) = (png_byte)color->blue;
+   }
+
+   int rgb_error =
+      png_do_rgb_to_gray(png_ptr, &row_info, row);
+
+   png_bytep sp = row;
+   if (png_ptr->bit_depth == 16)
+   {
+      png_byte hi, lo;
+      hi=*(sp)++;
+      lo=*(sp)++;
+      color->gray = (png_uint_16)((hi << 8) | (lo));
+   }
+   else
+   {
+      color->gray = *sp;
+   }
+
+   return rgb_error;
+}
+
 #endif
 
 #if defined(PNG_READ_BACKGROUND_SUPPORTED) ||\

--- a/pngrtran.c
+++ b/pngrtran.c
@@ -1279,12 +1279,14 @@ png_init_rgb_transformations(png_structrp png_ptr)
          }
 
          png_ptr->background.red = png_ptr->background.green =
-            png_ptr->background.blue = (png_uint_16)gray;
+            png_ptr->background.blue = png_ptr->background.gray =
+            (png_uint_16)gray;
 
          if ((png_ptr->transformations & PNG_EXPAND_tRNS) == 0)
          {
             png_ptr->trans_color.red = png_ptr->trans_color.green =
-               png_ptr->trans_color.blue = (png_uint_16)trans_gray;
+               png_ptr->trans_color.blue = png_ptr->trans_color.gray =
+               (png_uint_16)trans_gray;
          }
       }
       else


### PR DESCRIPTION
After adding libpng support to my image library, I wrote some test code which generated PNG files with all valid combinations of relevant parameters, and asked libpng to parse each into every compatible format supported by my image library. Some of these combinations produced unexpected results, which seem to be caused by bugs in libpng.

This pull request includes two patches which attempt to rectify these bugs. Please see the individual commits' commit messages for details.

FWIW - the source code for my test suite that identified this bug is here:
https://github.com/CyberShadow/ae/blob/master/utils/graphics/libpng.d