### PR TITLE
Add libpng:: namespace

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@
 # Revised by Alex Gaynor, 2020
 # Revised by Owen Rudge, 2020
 # Revised by Gleb Mazovetskiy, 2021
+# Revised by Hendrik Sieck, 2021
 # Revised by Christopher Sean Morrison, 2022
 
 # This code is released under the libpng license.
@@ -1031,6 +1032,7 @@ endif()
 # Create an export file that CMake users can include() to import our targets.
 if(NOT SKIP_INSTALL_EXPORT AND NOT SKIP_INSTALL_ALL)
   install(EXPORT libpng
+          NAMESPACE "libpng::"
           DESTINATION lib/libpng
           FILE lib${PNG_LIB_NAME}.cmake)
 endif()


### PR DESCRIPTION
This PR adds a `libpng::` namespace to `CMakeLists.txt`. I'm pasting/quoting the answer of https://stackoverflow.com/a/48526017:

The [cmake-developer documentation](https://cmake.org/cmake/help/latest/manual/cmake-developer.7.html?highlight=namespace) gives the following advice on namespaces:

> When providing imported targets, these should be namespaced (hence the `Foo::` prefix); CMake will recognize that values passed to `target_link_libraries()` that contain `::` in their name are supposed to be imported targets (rather than just library names), and will produce appropriate diagnostic messages if that target does not exist (see policy *CMP0028*).

And the [*CMP0028* policy documentation](https://cmake.org/cmake/help/latest/policy/CMP0028.html) says on the "common pattern" in the use of namespaces:

> The use of double-colons is a common pattern used to namespace `IMPORTED` targets and `ALIAS` targets. When computing the link dependencies of a target, the name of each dependency could either be a target, or a file on disk. Previously, if a target was not found with a matching name, the name was considered to refer to a file on disk. This can lead to confusing error messages if there is a typo in what should be a target name.