### PR TITLE
Build error on Win 10 with zlib latest ver 1.2.12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -588,7 +588,7 @@ if(PNG_SHARED)
     set_target_properties(png PROPERTIES PREFIX "lib")
     set_target_properties(png PROPERTIES IMPORT_PREFIX "lib")
   endif()
-  target_link_libraries(png ${ZLIB_LIBRARIES} ${M_LIBRARY})
+  target_link_libraries(png zlib ${M_LIBRARY})
 
   if(UNIX AND AWK)
     if(HAVE_LD_VERSION_SCRIPT)
@@ -623,7 +623,7 @@ if(PNG_STATIC)
     # MSVC does not append 'lib'. Do it here, to have consistent name.
     set_target_properties(png_static PROPERTIES PREFIX "lib")
   endif()
-  target_link_libraries(png_static ${ZLIB_LIBRARIES} ${M_LIBRARY})
+  target_link_libraries(png_static zlib ${M_LIBRARY})
 endif()
 
 if(PNG_FRAMEWORK)
@@ -640,7 +640,7 @@ if(PNG_FRAMEWORK)
                         XCODE_ATTRIBUTE_INSTALL_PATH "@rpath"
                         PUBLIC_HEADER "${libpng_public_hdrs}"
                         OUTPUT_NAME png)
-  target_link_libraries(png_framework ${ZLIB_LIBRARIES} ${M_LIBRARY})
+  target_link_libraries(png_framework zlib ${M_LIBRARY})
 endif()
 
 if(NOT PNG_LIB_TARGETS)
@@ -849,7 +849,7 @@ if(PNG_SHARED AND PNG_EXECUTABLES)
   set(PNG_BIN_TARGETS pngfix)
 
   add_executable(png-fix-itxt ${png_fix_itxt_sources})
-  target_link_libraries(png-fix-itxt ${ZLIB_LIBRARIES} ${M_LIBRARY})
+  target_link_libraries(png-fix-itxt zlib ${M_LIBRARY})
   list(APPEND PNG_BIN_TARGETS png-fix-itxt)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -594,11 +594,7 @@ if(PNG_SHARED)
     set_target_properties(png PROPERTIES PREFIX "lib")
     set_target_properties(png PROPERTIES IMPORT_PREFIX "lib")
   endif()
-<<<<<<< HEAD
   target_link_libraries(png ${ZLIB_LIBRARIES}libzlib.dll ${M_LIBRARY})
-=======
-  target_link_libraries(png ${ZLIB_LIBRARIES}/libzlib.dll ${M_LIBRARY})
->>>>>>> 7291eab7ae820efe6fae77d6aaab9384be1a9875
 
   if(UNIX AND AWK)
     if(HAVE_LD_VERSION_SCRIPT)
@@ -633,11 +629,7 @@ if(PNG_STATIC)
     # MSVC does not append 'lib'. Do it here, to have consistent name.
     set_target_properties(png_static PROPERTIES PREFIX "lib")
   endif()
-<<<<<<< HEAD
   target_link_libraries(png_static ${ZLIB_LIBRARIES}libzlibsatic.a ${M_LIBRARY})
-=======
-  target_link_libraries(png_static ${ZLIB_LIBRARIES}/libzlib.dll.a ${M_LIBRARY})
->>>>>>> 7291eab7ae820efe6fae77d6aaab9384be1a9875
 endif()
 
 if(PNG_FRAMEWORK)
@@ -654,11 +646,7 @@ if(PNG_FRAMEWORK)
                         XCODE_ATTRIBUTE_INSTALL_PATH "@rpath"
                         PUBLIC_HEADER "${libpng_public_hdrs}"
                         OUTPUT_NAME png)
-<<<<<<< HEAD
   target_link_libraries(png_framework ${ZLIB_LIBRARIES}libzlib.dll ${M_LIBRARY})
-=======
-  target_link_libraries(png_framework ${ZLIB_LIBRARIES}/libzlib.dll ${M_LIBRARY})
->>>>>>> 7291eab7ae820efe6fae77d6aaab9384be1a9875
 endif()
 
 if(NOT PNG_LIB_TARGETS)
@@ -867,11 +855,7 @@ if(PNG_SHARED AND PNG_EXECUTABLES)
   set(PNG_BIN_TARGETS pngfix)
 
   add_executable(png-fix-itxt ${png_fix_itxt_sources})
-<<<<<<< HEAD
   target_link_libraries(png-fix-itxt ${ZLIB_LIBRARIES}libzlib.dll ${M_LIBRARY})
-=======
-  target_link_libraries(png-fix-itxt ${ZLIB_LIBRARIES}/libzlib.dll ${M_LIBRARY})
->>>>>>> 7291eab7ae820efe6fae77d6aaab9384be1a9875
   list(APPEND PNG_BIN_TARGETS png-fix-itxt)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -594,7 +594,7 @@ if(PNG_SHARED)
     set_target_properties(png PROPERTIES PREFIX "lib")
     set_target_properties(png PROPERTIES IMPORT_PREFIX "lib")
   endif()
-  target_link_libraries(png ${ZLIB_LIBRARIES} ${M_LIBRARY})
+  target_link_libraries(png ${ZLIB_LIBRARIES}libzlib.dll ${M_LIBRARY})
 
   if(UNIX AND AWK)
     if(HAVE_LD_VERSION_SCRIPT)
@@ -629,7 +629,7 @@ if(PNG_STATIC)
     # MSVC does not append 'lib'. Do it here, to have consistent name.
     set_target_properties(png_static PROPERTIES PREFIX "lib")
   endif()
-  target_link_libraries(png_static ${ZLIB_LIBRARIES} ${M_LIBRARY})
+  target_link_libraries(png_static ${ZLIB_LIBRARIES}libzlibsatic.a ${M_LIBRARY})
 endif()
 
 if(PNG_FRAMEWORK)
@@ -646,7 +646,7 @@ if(PNG_FRAMEWORK)
                         XCODE_ATTRIBUTE_INSTALL_PATH "@rpath"
                         PUBLIC_HEADER "${libpng_public_hdrs}"
                         OUTPUT_NAME png)
-  target_link_libraries(png_framework ${ZLIB_LIBRARIES} ${M_LIBRARY})
+  target_link_libraries(png_framework ${ZLIB_LIBRARIES}libzlib.dll ${M_LIBRARY})
 endif()
 
 if(NOT PNG_LIB_TARGETS)
@@ -855,7 +855,7 @@ if(PNG_SHARED AND PNG_EXECUTABLES)
   set(PNG_BIN_TARGETS pngfix)
 
   add_executable(png-fix-itxt ${png_fix_itxt_sources})
-  target_link_libraries(png-fix-itxt ${ZLIB_LIBRARIES} ${M_LIBRARY})
+  target_link_libraries(png-fix-itxt ${ZLIB_LIBRARIES}libzlib.dll ${M_LIBRARY})
   list(APPEND PNG_BIN_TARGETS png-fix-itxt)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -588,7 +588,7 @@ if(PNG_SHARED)
     set_target_properties(png PROPERTIES PREFIX "lib")
     set_target_properties(png PROPERTIES IMPORT_PREFIX "lib")
   endif()
-  target_link_libraries(png zlib ${M_LIBRARY})
+  target_link_libraries(png ${ZLIB_LIBRARIES}/libzlib.dll ${M_LIBRARY})
 
   if(UNIX AND AWK)
     if(HAVE_LD_VERSION_SCRIPT)
@@ -623,7 +623,7 @@ if(PNG_STATIC)
     # MSVC does not append 'lib'. Do it here, to have consistent name.
     set_target_properties(png_static PROPERTIES PREFIX "lib")
   endif()
-  target_link_libraries(png_static zlib ${M_LIBRARY})
+  target_link_libraries(png_static ${ZLIB_LIBRARIES}/libzlib.dll.a ${M_LIBRARY})
 endif()
 
 if(PNG_FRAMEWORK)
@@ -640,7 +640,7 @@ if(PNG_FRAMEWORK)
                         XCODE_ATTRIBUTE_INSTALL_PATH "@rpath"
                         PUBLIC_HEADER "${libpng_public_hdrs}"
                         OUTPUT_NAME png)
-  target_link_libraries(png_framework zlib ${M_LIBRARY})
+  target_link_libraries(png_framework ${ZLIB_LIBRARIES}/libzlib.dll ${M_LIBRARY})
 endif()
 
 if(NOT PNG_LIB_TARGETS)
@@ -849,7 +849,7 @@ if(PNG_SHARED AND PNG_EXECUTABLES)
   set(PNG_BIN_TARGETS pngfix)
 
   add_executable(png-fix-itxt ${png_fix_itxt_sources})
-  target_link_libraries(png-fix-itxt zlib ${M_LIBRARY})
+  target_link_libraries(png-fix-itxt ${ZLIB_LIBRARIES}/libzlib.dll ${M_LIBRARY})
   list(APPEND PNG_BIN_TARGETS png-fix-itxt)
 endif()
 


### PR DESCRIPTION
Fixes issue while bulding with winlib's mingw64 on windows 10.

Target "libpng" requests linking to directory "<zlib_build_dir>".
  Targets may link only to libraries.  CMake is dropping the item.

specify zlib's dir location rather than make ld.exe look in default locations.
Also use zlib lib names as created by latest 1.2.12 ver