### PR TITLE
Fix Arm Neon optimization detection when building for iOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,6 +164,8 @@ if(TARGET_ARCH MATCHES "^(ARM|arm|aarch)")
   else()
     add_definitions(-DPNG_ARM_NEON_OPT=0)
   endif()
+else()
+  add_definitions(-DPNG_ARM_NEON_OPT=0)
 endif()
 
 # Set definitions and sources for PowerPC.


### PR DESCRIPTION
When [cross-compiling for iOS](https://cmake.org/cmake/help/latest/manual/cmake-toolchains.7.html#cross-compiling-for-ios-tvos-or-watchos), CMake does not define the `CMAKE_OSX_ARCHITECTURES` variable. As a result, [this branch](https://github.com/glennrp/libpng/blob/61bfdb0cb02a6f3a62c929dbc9e832894c0a8df2/CMakeLists.txt#L95-L123) of CMake script does not get executed, so `PNG_ARM_NEON_OPT` is not defined as well as source files for Neon are not added to the project.

The `PNG_ARM_NEON_OPT` then gets defined [here](https://github.com/glennrp/libpng/blob/61bfdb0cb02a6f3a62c929dbc9e832894c0a8df2/pngpriv.h#L132) which results in linker errors as source files are not in the project.