### PR TITLE
Do not build unused Adler32 code

### DIFF
--- a/png.h
+++ b/png.h
@@ -3204,9 +3204,12 @@ PNG_EXPORT(245, int, png_image_write_to_memory, (png_imagep image, void *memory,
 #ifdef PNG_MIPS_MSA_API_SUPPORTED
 #  define PNG_MIPS_MSA   6 /* HARDWARE: MIPS Msa SIMD instructions supported */
 #endif
-#define PNG_IGNORE_ADLER32 8
+#ifdef PNG_DISABLE_ADLER32_CHECK_SUPPORTED
+#  define PNG_IGNORE_ADLER32 8 /* SOFTWARE: disable Adler32 check on IDAT */
+#endif
 #ifdef PNG_POWERPC_VSX_API_SUPPORTED
-#  define PNG_POWERPC_VSX   10 /* HARDWARE: PowerPC VSX SIMD instructions supported */
+#  define PNG_POWERPC_VSX   10 /* HARDWARE: PowerPC VSX SIMD instructions
+                                * supported */
 #endif
 #define PNG_OPTION_NEXT  12 /* Next option - numbers must be even */
 

--- a/pngrutil.c
+++ b/pngrutil.c
@@ -421,8 +421,7 @@ png_inflate_claim(png_structrp png_ptr, png_uint_32 owner)
             png_ptr->flags |= PNG_FLAG_ZSTREAM_INITIALIZED;
       }
 
-#if ZLIB_VERNUM >= 0x1290 && \
-   defined(PNG_SET_OPTION_SUPPORTED) && defined(PNG_IGNORE_ADLER32)
+#ifdef PNG_DISABLE_ADLER32_CHECK_SUPPORTED
       if (((png_ptr->options >> PNG_IGNORE_ADLER32) & 3) == PNG_OPTION_ON)
          /* Turn off validation of the ADLER32 checksum in IDAT chunks */
          ret = inflateValidate(&png_ptr->zstream, 0);

--- a/scripts/pnglibconf.dfa
+++ b/scripts/pnglibconf.dfa
@@ -336,6 +336,34 @@ option BENIGN_ERRORS
 option BENIGN_WRITE_ERRORS requires BENIGN_ERRORS disabled
 option BENIGN_READ_ERRORS requires BENIGN_ERRORS
 
+# Adler32 checksum
+#
+# This option allows the check of the Adler32 checksum performed by zlib to
+# be turned off for IDAT chunks (only).  Unless this option is enabled and
+# turned on (not the default even if enabled) a failed Adler32 at the end of the
+# stream will result in a decompression (inflate) failure on read even though
+# the entire image might have been read successfully.
+#
+# This option relies on an undocumented function 'inflateValidate' which is
+# present in only some versions of zlib.  If the function is not present in the
+# zlib used with libpng code which uses -lpng is likely to fail to link or to
+# launch in the case of a DLL.
+#
+# Therefore this option is currently disabled by default; it has to be turned on
+# in pngusr.dfa and then the application program has to explicitly turn the
+# functionality on by calling png_set_option.
+#
+# Furthermore the option is explicitly turned off here if the zlib version
+# number is below that required - libpng wouldn't compile in that case if the
+# option were turned on.
+option DISABLE_ADLER32_CHECK requires READ enables SET_OPTION disabled
+
+# ZLIB_VERNUM must be used here, not PNG_ZLIB_VERNUM, because
+# scripts/options.awk ends up putting this test adhead of the setting of
+# PNG_ZLIB_VERNUM (apparently above, but not because of the two-pass processing)
+@#if ZLIB_VERNUM < 0x1290
+@#   define PNG_NO_DISABLE_ADLER32_CHECK
+@#endif
 
 # Generic options - affect both read and write.
 

--- a/scripts/pnglibconf.h.prebuilt
+++ b/scripts/pnglibconf.h.prebuilt
@@ -1,3 +1,4 @@
+/* 1.6.41.git STANDARD API DEFINITION */
 /* pnglibconf.h - library build configuration */
 
 /* libpng version 1.6.41.git */
@@ -27,6 +28,7 @@
 #define PNG_COLORSPACE_SUPPORTED
 #define PNG_CONSOLE_IO_SUPPORTED
 #define PNG_CONVERT_tIME_SUPPORTED
+/*#undef PNG_DISABLE_ADLER32_CHECK_SUPPORTED*/
 #define PNG_EASY_ACCESS_SUPPORTED
 /*#undef PNG_ERROR_NUMBERS_SUPPORTED*/
 #define PNG_ERROR_TEXT_SUPPORTED


### PR DESCRIPTION
This removes the default build of an undocumented feature to disable Adler32 checksums on those systems where it was the default.

The PR is motived by github #187 however it fixes a much more general problem (#187 is limited to an issue where libpng "crashes" on some manufacturer systems).  The fix is based on a suggestion by @sgowdev who is the originator of the issue.

When libpng disables the checking of Adler32 checksums it does so by an undocumented and therefore possibly unsupported call to a zlib function which does not exist in some versions of zlib.

Fortunately libpng only does this if the caller of libpng explicitly asks for it to happen.  Unfortunately the call to the undocumented function is still in the compiled and built libpng and this means that on some systems (as identified in #187) libpng can fail to load or maybe even crash.

The libpng authors are currently unaware of any program or system that uses this feature and none has been identified by the contributors to #187.

In this fix an option is added to *enable* the code so that by default the code is *disabled* - this is a simple generalization of the suggestion by @sgowdev.

BENEFITS: the problem is eliminated, users of the functionality, if any, are idenfified, the functionality can be implemented correctly in the future or it can be removed.  Hardly anyone complains.

COSTS: someone will complain that they have to enable an option in a libpng build to use a feature that never worked consistently in the first place.

This patch has been tested both with the option enabled and with it disabled via pngusr.dfa.  Tests, checks pass with cmake and configure, make distcheck passes on configure.