### PR TITLE
Skip reassignment of the initialization value

### DIFF
--- a/pngrutil.c
+++ b/pngrutil.c
@@ -3164,17 +3164,15 @@ png_check_chunk_length(png_const_structrp png_ptr, png_uint_32 length)
 # endif
    if (png_ptr->chunk_name == png_IDAT)
    {
-      png_alloc_size_t idat_limit = PNG_UINT_31_MAX;
       size_t row_factor =
          (size_t)png_ptr->width
          * (size_t)png_ptr->channels
          * (png_ptr->bit_depth > 8? 2: 1)
          + 1
          + (png_ptr->interlaced? 6: 0);
-      if (png_ptr->height > PNG_UINT_32_MAX/row_factor)
-         idat_limit = PNG_UINT_31_MAX;
-      else
-         idat_limit = png_ptr->height * row_factor;
+      png_alloc_size_t idat_limit =
+         (png_ptr->height > PNG_UINT_32_MAX/row_factor) ?
+         PNG_UINT_31_MAX : png_ptr->height * row_factor;
       row_factor = row_factor > 32566? 32566 : row_factor;
       idat_limit += 6 + 5*(idat_limit/row_factor+1); /* zlib+deflate overhead */
       idat_limit=idat_limit < PNG_UINT_31_MAX? idat_limit : PNG_UINT_31_MAX;


### PR DESCRIPTION
This was incorrect: <strike>Reversed condition changed to `less` instead of `less or equal` because the value still should be `PNG_UINT_31_MAX`.</strike>
Reassignment of the same value is a common kind of copy-paste errors.
Hence static analysis emits warning in this case.
A better way to avoid reassignment is in the updated commit.