### PR TITLE
Relax pngtest-all message testing

### DIFF
--- a/tests/pngtest-all
+++ b/tests/pngtest-all
@@ -41,11 +41,17 @@ check_stdout(){
    # $1: the test file (a bad PNG which must produce a warning, etc)
    # $2: a string which must occur at the end of line on stdout for success
    # result: an error message on descriptor 3 if the string is NOT found
+   #
+   # WARNING: when this script is executed on MSYS2 (Windows Cygwin variant)
+   # pngtest outputs lines terminated with <cr><lf> however the MSYS2 shell
+   # expects <lf> (\n) terminated lines so the <cr> ends up in the shell
+   # variable 'line' below.  The pattern matching ignores this because of the
+   # '*' at the end of the pattern match.
    found=
    while read line
    do
       case "$line" in
-         *"$2") found=1;;
+         *"$2"*) found=1;;
       esac
       echo "$line" # preserve the original output verbatim
    done


### PR DESCRIPTION
Previously the 'make check' test pngtest-all looked for given messages at EOL.  The match failed with Windows/MSYS2 because of the Windows <cr><lf> line endings output by pngtest.  This changes the test to look for the message anywhere in a line; this might give false matches but the specific messages being searched for are not likely to cause this problem.