### PR TITLE
Add eXIf support to push mode

### DIFF
--- a/pngpread.c
+++ b/pngpread.c
@@ -295,6 +295,14 @@ png_push_read_chunk(png_structrp png_ptr, png_inforp info_ptr)
    }
 
 #endif
+#ifdef PNG_READ_eXIf_SUPPORTED
+   else if (png_ptr->chunk_name == png_eXIf)
+   {
+      PNG_PUSH_SAVE_BUFFER_IF_FULL
+      png_handle_eXIf(png_ptr, info_ptr, png_ptr->push_length);
+   }
+
+#endif
 #ifdef PNG_READ_sRGB_SUPPORTED
    else if (chunk_name == png_sRGB)
    {


### PR DESCRIPTION
libpng already supports eXIf as of v1.6.31.
However, it seems like support was added for normal mode and not added to push mode.

Notice PNG_READ_eXIf_SUPPORTED is in pngread.c:
https://github.com/pnggroup/libpng/blob/libpng16/pngread.c#L178
but is missing from pngpread.c:
https://github.com/pnggroup/libpng/blob/libpng16/pngpread.c#L274

This commit adds eXIf support to push mode.