### PR TITLE
add CMake config file that follows CMake conventions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1128,6 +1128,30 @@ if(NOT SKIP_INSTALL_EXPORT AND NOT SKIP_INSTALL_ALL)
           FILE libpng${PNGLIB_ABI_VERSION}.cmake)
 endif()
 
+# Create a CMake Config File that can be used via find_package(PNG CONFIG)
+if(NOT SKIP_INSTALL_CONFIG_FILE AND NOT SKIP_INSTALL_ALL)
+  install(TARGETS ${PNG_LIBRARY_TARGETS}
+          EXPORT PNGTargets
+          RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+          LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+          ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+          FRAMEWORK DESTINATION ${CMAKE_INSTALL_LIBDIR})
+
+  include(CMakePackageConfigHelpers)
+  write_basic_package_version_file(PNGConfigVersion.cmake
+                                   VERSION ${PNGLIB_VERSION}
+                                   COMPATIBILITY SameMinorVersion)
+
+  install(EXPORT PNGTargets
+          FILE PNGTargets.cmake
+          NAMESPACE PNG::
+          DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/PNG)
+
+  install(FILES PNGConfig.cmake
+                ${CMAKE_CURRENT_BINARY_DIR}/PNGConfigVersion.cmake
+          DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/PNG)
+endif()
+
 # TODO: Create MSVC import lib for MinGW-compiled shared lib.
 # pexports libpng.dll > libpng.def
 # lib /def:libpng.def /machine:x86

--- a/PNGConfig.cmake
+++ b/PNGConfig.cmake
@@ -1,0 +1,15 @@
+include(CMakeFindDependencyMacro)
+
+find_dependency(ZLIB REQUIRED)
+
+include("${CMAKE_CURRENT_LIST_DIR}/PNGTargets.cmake")
+
+if(NOT TARGET PNG::PNG)
+  if(TARGET PNG::png_shared)
+    add_library(PNG::PNG INTERFACE IMPORTED)
+    target_link_libraries(PNG::PNG INTERFACE PNG::png_shared)
+  elseif(TARGET PNG::png_static)
+    add_library(PNG::PNG INTERFACE IMPORTED)
+    target_link_libraries(PNG::PNG INTERFACE PNG::png_static)
+  endif()
+endif()


### PR DESCRIPTION
New functionality:

- add a CMake config file to the install, so an installed libpng can be found via `find_package(libpng)`
- mark API header includes as SYSTEM headers in install, so warnings in these headers can be disabled

Changed behavior:

- export the target `libpng` as `libpng::libpng` which follows the CMake convention for exported targets (previous it was just `libpng`)
- install CMake files to `lib/cmake/libpng` instead of `lib/libpng` to follow the CMake convention