### PR TITLE
Cmake Fix broken changes related to /scripts/cmake/ change in 1.6.41

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -386,7 +386,7 @@ else()
                        COMMAND "${CMAKE_COMMAND}"
                                "-DINPUT=${_GC_INPUT}"
                                "-DOUTPUT=${_GC_OUTPUT}"
-                               -P "${CMAKE_CURRENT_BINARY_DIR}/genchk.cmake"
+                               -P "${CMAKE_CURRENT_BINARY_DIR}/scripts/cmake/genchk.cmake"
                        DEPENDS "${_GC_INPUT}" ${_GC_DEPENDS}
                        WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
   endfunction()
@@ -409,7 +409,7 @@ else()
                        COMMAND "${CMAKE_COMMAND}"
                                "-DINPUT=${_GO_INPUT}"
                                "-DOUTPUT=${_GO_OUTPUT}"
-                               -P "${CMAKE_CURRENT_BINARY_DIR}/genout.cmake"
+                               -P "${CMAKE_CURRENT_BINARY_DIR}/scripts/cmake/genout.cmake"
                        DEPENDS "${_GO_INPUT}" ${_GO_DEPENDS}
                        WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
   endfunction()
@@ -428,7 +428,7 @@ else()
     add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${_GSO_OUTPUT}"
                        COMMAND "${CMAKE_COMMAND}"
                                "-DOUTPUT=${_GSO_OUTPUT}"
-                               -P "${CMAKE_CURRENT_BINARY_DIR}/gensrc.cmake"
+                               -P "${CMAKE_CURRENT_BINARY_DIR}/scripts/cmake/gensrc.cmake"
                        DEPENDS ${_GSO_DEPENDS}
                        WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
   endfunction()
@@ -558,7 +558,7 @@ else()
   add_custom_target(png_genprebuilt
                     COMMAND "${CMAKE_COMMAND}"
                             "-DOUTPUT=scripts/pnglibconf.h.prebuilt"
-                            -P "${CMAKE_CURRENT_BINARY_DIR}/gensrc.cmake"
+                            -P "${CMAKE_CURRENT_BINARY_DIR}/scripts/cmake/gensrc.cmake"
                     WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
 
   # A single target handles generation of all generated files.
@@ -1002,13 +1002,13 @@ endfunction()
 
 # Create source generation scripts.
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/scripts/cmake/genchk.cmake.in
-               ${CMAKE_CURRENT_BINARY_DIR}/genchk.cmake
+               ${CMAKE_CURRENT_BINARY_DIR}/scripts/cmake/genchk.cmake
                @ONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/scripts/cmake/genout.cmake.in
-               ${CMAKE_CURRENT_BINARY_DIR}/genout.cmake
+               ${CMAKE_CURRENT_BINARY_DIR}/scripts/cmake/genout.cmake
                @ONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/scripts/cmake/gensrc.cmake.in
-               ${CMAKE_CURRENT_BINARY_DIR}/gensrc.cmake
+               ${CMAKE_CURRENT_BINARY_DIR}/scripts/cmake/gensrc.cmake
                @ONLY)
 
 # libpng is a library so default to 'lib'

--- a/scripts/cmake/AUTHORS.md
+++ b/scripts/cmake/AUTHORS.md
@@ -33,3 +33,4 @@ Author List
  * Tyler Kropp
  * Vadim Barkov
  * Vicky Pfau
+ * Dan Rosser


### PR DESCRIPTION
Changes to CMakeLists.txt

Critical Bug as 1.6.41/1.6.42/1.6.43 cannot compile with this change :

> Moved the CMake files (except for the main CMakeLists.txt) to
>     scripts/cmake and moved the list of their contributing authors to
>     scripts/cmake/AUTHORS.md
> 

<img width="564" alt="Screenshot 2024-02-16 at 12 18 27 pm" src="https://github.com/pnggroup/libpng/assets/830748/fcb8c3e3-fe71-4953-aefe-5b76d2d270b6">

- Tested 1.6.41 - Fails to compile
- Tested 1.6.42 - Fails to compile
- Tested 1.6.43 - Fails to compile


After proposed changes linking code to correct folder
Building now! 
<img width="606" alt="Screenshot 2024-02-16 at 1 13 07 pm" src="https://github.com/pnggroup/libpng/assets/830748/264eb6aa-1ae6-496b-8839-e10ac99ce4eb">

Added emscripten WASM target also now works 
<img width="910" alt="Screenshot 2024-02-16 at 12 58 52 pm" src="https://github.com/pnggroup/libpng/assets/830748/47e49c96-60a5-4323-bc26-6ee4a2465040">

