### PR TITLE
CMakeLists: Fix gawk error with MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -348,7 +348,7 @@ find_program(AWK NAMES gawk awk)
 
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
-if(NOT AWK OR ANDROID OR IOS)
+if(NOT AWK OR ANDROID OR IOS OR MSVC)
   # No awk available to generate sources; use pre-built pnglibconf.h
   configure_file(${CMAKE_CURRENT_SOURCE_DIR}/scripts/pnglibconf.h.prebuilt
                  ${CMAKE_CURRENT_BINARY_DIR}/pnglibconf.h)
@@ -576,7 +576,7 @@ else()
                             "${CMAKE_CURRENT_BINARY_DIR}/scripts/symbols.chk" png_scripts_symbols_chk
                             "${CMAKE_CURRENT_BINARY_DIR}/scripts/symbols.out" png_scripts_symbols_out
                             "${CMAKE_CURRENT_BINARY_DIR}/scripts/vers.out" png_scripts_vers_out)
-endif(NOT AWK OR ANDROID OR IOS)
+endif(NOT AWK OR ANDROID OR IOS OR MSVC)
 
 # List the source code files.
 set(libpng_public_hdrs
@@ -590,7 +590,7 @@ set(libpng_private_hdrs
     pnginfo.h
     pngstruct.h
 )
-if(AWK AND NOT ANDROID AND NOT IOS)
+if(AWK AND NOT ANDROID AND NOT IOS AND NOT MSVC)
   list(APPEND libpng_private_hdrs "${CMAKE_CURRENT_BINARY_DIR}/pngprefix.h")
 endif()
 set(libpng_sources


### PR DESCRIPTION
For Windows users building with CMake and MSVC, if they have Git Bash on their path, CMake picks up gawk and then fails with the following error:

```
Building project libpng (1.6.39)
CMake Deprecation Warning at CMakeLists.txt:13 (cmake_minimum_required):
  Compatibility with CMake < 2.8.12 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.


CMake Deprecation Warning at CMakeLists.txt:14 (cmake_policy):
  Compatibility with CMake < 2.8.12 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.


-- Configuring done (0.2s)
-- Generating done (0.1s)
-- Build files have been written to: R:/src/test/gvsbuild/build/build/x64/debug/libpng/_gvsbuild-cmake
[1/59] Generating scripts/symbols.chk
FAILED: scripts/symbols.chk R:/src/test/gvsbuild/build/build/x64/debug/libpng/_gvsbuild-cmake/scripts/symbols.chk
cmd.exe /C "cd /D R:\src\test\gvsbuild\build\build\x64\debug\libpng\_gvsbuild-cmake && R:\src\test\gvsbuild\build\tools\cmake-3.26.4-windows-x86_64\bin\cmake.exe -DINPUT=R:/src/test/gvsbuild/build/build/x64/debug/libpng/_gvsbuild-cmake/scripts/symbols.out -DOUTPUT=R:/src/test/gvsbuild/build/build/x64/debug/libpng/_gvsbuild-cmake/scripts/symbols.chk -P R:/src/test/gvsbuild/build/build/x64/debug/libpng/_gvsbuild-cmake/scripts/genchk.cmake"
gawk: fatal: can't open source file `R:/src/test/gvsbuild/build/build/x64/debug/libpng/_gvsbuild-cmake/scripts/checksym.awk' for reading (No such file or directory)
```

This PR updates the CMakeLists to not use awk when building with MSVC. This would be a unique setup that someone would want to use awk during a non-MSYS2/Cygwin build.