### PR TITLE
Emscripten wasm side module library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -949,6 +949,24 @@ if(PNG_SHARED AND PNG_TOOLS)
   list(APPEND PNG_BIN_TARGETS png-fix-itxt)
 endif()
 
+if(EMSCRIPTEN)
+    set(LIBPNG_WASM_SOURCES
+        ${pngfix_sources}
+    )
+    add_executable(libpng_wasm
+        ${LIBPNG_WASM_SOURCES}
+    )
+    target_include_directories(libpng_wasm PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+    )
+    target_link_libraries(libpng_wasm ${ZLIB_LIBRARIES} ${M_LIBRARY})
+    set_target_properties(libpng_wasm PROPERTIES COMPILE_FLAGS "-Os -fPIC -s SIDE_MODULE=1 ")
+    set_target_properties(libpng_wasm PROPERTIES LINK_FLAGS    "-Os -fPIC -s WASM=1 -s SIDE_MODULE=1 -s STANDALONE_WASM --no-entry")
+    set(CMAKE_EXECUTABLE_SUFFIX ".wasm")
+    list(APPEND PNG_BIN_TARGETS libpng_wasm)
+endif()
+
+
 # Create a symlink from src to dest (if possible), or, alternatively,
 # copy src to dest if different.
 function(create_symlink DEST_FILE)


### PR DESCRIPTION
As Emscripten libraries require executable code rather than static this fixes issues for WASM using side module. 
.wasm extension target 

Can be interpreted as .a with this executable byte code 

This can be used for patching your own libpng frameworks.
Emscripten comes with a em port however versions are not always up to date with latest changes so this is convenient for cmake / developers / frameworks.

I think also we can assume libpng is being compiled by Emscripten via emmake  

Example Cmake commands:
```
mkdir -p build_$TYPE
	    cd build_$TYPE
	    rm -f CMakeCache.txt *.a *.o *.wasm

	    ZLIB_ROOT="$LIBS_ROOT/zlib/"
	    ZLIB_INCLUDE_DIR="$LIBS_ROOT/zlib/include"
	    ZLIB_LIBRARY="$LIBS_ROOT/zlib/lib/$TYPE/zlib.wasm"

	    $EMSDK/upstream/emscripten/emcmake cmake .. \
	    	${DEFS} \
	    	-DCMAKE_TOOLCHAIN_FILE=$EMSDK/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake \
	    	-DCMAKE_C_STANDARD=17 \
	    	-DEMSCRIPTEN=ON \
			-DCMAKE_CXX_STANDARD=17 \
			-DCMAKE_CXX_STANDARD_REQUIRED=ON \
			-DCMAKE_CXX_FLAGS="-DUSE_PTHREADS=1 -std=c++17 -Wno-implicit-function-declaration -frtti -fPIC ${FLAG_RELEASE}" \
			-DCMAKE_C_FLAGS="-DUSE_PTHREADS=1 -std=c17 -Wno-implicit-function-declaration -frtti -fPIC ${FLAG_RELEASE}" \
			-DCMAKE_CXX_EXTENSIONS=OFF \
			-DCMAKE_INSTALL_PREFIX=Release \
			-DZLIB_ROOT=${ZLIB_ROOT} \
			-DZLIB_LIBRARY=${ZLIB_LIBRARY} \
			-DZLIB_INCLUDE_DIR=${ZLIB_INCLUDE_DIR} \
			-DZLIB_INCLUDE_DIRS=${ZLIB_INCLUDE_DIR} \
			-DCMAKE_BUILD_TYPE=Release \
			-DBUILD_SHARED_LIBS=ON \
			-DPNG_EXECUTABLES=OFF \
			-DPNG_BUILD_ZLIB=OFF
	    cmake --build . --target install --config Release
	    cd ..
```


