### PR TITLE
Reject reads that exceed our buffer length in png_push_fill_buffer.

### DIFF
--- a/pngpread.c
+++ b/pngpread.c
@@ -455,11 +455,11 @@ png_push_fill_buffer(png_structp png_ptr, png_bytep buffer, size_t length)
    {
       size_t save_size;
 
-      if (length < png_ptr->current_buffer_size)
+      if (length <= png_ptr->current_buffer_size)
          save_size = length;
 
       else
-         save_size = png_ptr->current_buffer_size;
+         png_error(png_ptr, "Truncated data");
 
       memcpy(ptr, png_ptr->current_buffer_ptr, save_size);
       png_ptr->buffer_size -= save_size;


### PR DESCRIPTION
Previously, `png_push_fill_buffer` would simply truncate the read, leaving the remainder of the output buffer in an uninitialized state. This can lead to undefined behavior when handling truncated or malformed inputs.