### PR TITLE
Restore STDERR in pngtest.c

### DIFF
--- a/pngtest.c
+++ b/pngtest.c
@@ -45,6 +45,11 @@
 
 #include "png.h"
 
+/* This hack was introduced for historical reasons, and we are
+ * still keeping it in libpng-1.6.x for compatibility reasons.
+ */
+#define STDERR stdout
+
 /* Generate a compiler error if there is an old png.h in the search path. */
 typedef png_libpng_version_1_6_44_git Your_png_h_is_not_version_1_6_44_git;
 
@@ -102,11 +107,6 @@ typedef png_libpng_version_1_6_44_git Your_png_h_is_not_version_1_6_44_git;
 #ifndef PNG_STDIO_SUPPORTED
 typedef FILE * png_FILE_p;
 #endif
-
-/* This hack was introduced for historical reasons, and we are
- * still keeping it in libpng-1.6.x for compatibility reasons.
- */
-#define STDERR stdout
 
 #ifndef PNG_DEBUG
 #  define PNG_DEBUG 0


### PR DESCRIPTION
In "test: Add consistency checks for the PNG_LIBPNG_VER* number" [0] the `STDERR` macro was moved from outside an `ifdef` to inside an `ifdef`. This broke the code in the `else` of this `ifdef` which also uses the `STDERR` macro. Move `STDERR` back to where it was to avoid compile errors in the `else` case.

[0] https://github.com/pnggroup/libpng/commit/cc8006c48d90cca8bf380fa69469b08f4edb00c5

Fixes: https://github.com/pnggroup/libpng/issues/560