### PR TITLE
SECURITY: disable build of filter_neon.S on arm

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,7 +153,7 @@ if(TARGET_ARCH MATCHES "^(ARM|arm|aarch)")
         arm/arm_init.c
         arm/filter_neon_intrinsics.c
         arm/palette_neon_intrinsics.c)
-    if(NOT MSVC)
+    if(NOT MSVC AND NOT TARGET_ARCH MATCHES "^(ARM64|arm64|aarch64)")
       list(APPEND libpng_arm_sources arm/filter_neon.S)
     endif()
     if(PNG_ARM_NEON STREQUAL "on")

--- a/Makefile.am
+++ b/Makefile.am
@@ -107,9 +107,11 @@ libpng@PNGLIB_MAJOR@@PNGLIB_MINOR@_la_SOURCES = png.c pngerror.c\
 	png.h pngconf.h pngdebug.h pnginfo.h pngpriv.h pngstruct.h pngusr.dfa
 
 if PNG_ARM_NEON
+if PNG_ARM_NEON_ASM
+libpng@PNGLIB_MAJOR@@PNGLIB_MINOR@_la_SOURCES += arm/filter_neon.S
+endif
 libpng@PNGLIB_MAJOR@@PNGLIB_MINOR@_la_SOURCES += arm/arm_init.c\
-	arm/filter_neon.S arm/filter_neon_intrinsics.c \
-	arm/palette_neon_intrinsics.c
+	arm/filter_neon_intrinsics.c arm/palette_neon_intrinsics.c
 endif
 
 if PNG_MIPS_MSA

--- a/configure.ac
+++ b/configure.ac
@@ -425,6 +425,16 @@ AM_CONDITIONAL([PNG_ARM_NEON],
       *)    test "$enable_arm_neon" != '' ;;
     esac])
 
+# Add the assembler implementation source file.  This only works on 32-bit
+# ARM and causes problems even if empty on 64-bit ARM.
+AM_CONDITIONAL([PNG_ARM_NEON_ASM],
+   [test "$enable_arm_neon" != 'no' &&
+    case "$host_cpu" in
+      arm64*|aarch64*) false ;;
+      arm*) true ;;
+      *)    test "$enable_arm_neon" != '' ;;
+    esac])
+
 # MIPS MSA
 # ========
 


### PR DESCRIPTION
This fixes the bug https://github.com/pnggroup/libpng/issues/505
"libpng does not support PAC/BTI on aarch64 targets" which arises
because the build mechanisms (both cmake and configure) assemble
arm/filter_neon.S even though it ends up completely empty.  The empty
file effectively poisons the so that the PAC/BTI support gets disabled.

The fix is minimal; it simply removes arm/filter_neon.S from the list of
sources included in the build.  Note that this was already done in cmake
for MSVC - it's not clear whether this change was a partial fix for the
same issue.

The fix will cause attempts to use the assembler implementation to fail
at build time.  As described in PR506:

https://github.com/pnggroup/libpng/pull/506

This should only cause problems with certain older GCC compilers and
only then if someone tries to build with the assembler optimization
enabled in which case the build probably had a security problem.

QUESTION: does the PAC/BTI security issue affect 32-bit ARM?  If not
this change may might be an issue for someone given that filter_neon.S
would apparently be safe on 32-bit.  Nevertheless this PR is safe
because it fails in a noisy way and is easy to undo.

TESTING: pull the changes then type "autoreconf" if using configure (not
required for cmake).

Signed-off-by: John Bowler <jbowler@acm.org>
