### PR TITLE
Proper solution for #254 and #240:

### DIFF
--- a/scripts/dfn.awk
+++ b/scripts/dfn.awk
@@ -172,7 +172,7 @@ $1 ~ /^PNG_DFN_END_SORT/{
    sub(/ *$/, "", line)
 
    # Remove trailing CR
-   sub(/$/, "", line)
+   sub(/\r$/, "", line)
 
    if (sort) {
       if (split(line, parts) < sort) {

--- a/scripts/vers.c
+++ b/scripts/vers.c
@@ -8,8 +8,7 @@
  * and license in png.h
  */
 
-#define PNG_EXPORTA(ordinal, type, name, args, attributes)\
-        PNG_DFN " @" SYMBOL_PREFIX "@@" name "@;"
+#define PNG_EXPORTA(ordinal, type, name, args, attributes) PNG_DFN " @" SYMBOL_PREFIX "@@" name "@;"
 
 PNG_DFN "@" PNGLIB_LIBNAME "@ {global:"
 

--- a/scripts/vers.c
+++ b/scripts/vers.c
@@ -8,9 +8,9 @@
  * and license in png.h
  */
 
-#define PNG_EXPORTA(ordinal, type, name, args, attributes) PNG_DFN " @" SYMBOL_PREFIX "@@" name "@;"
-
 PNG_DFN "@" PNGLIB_LIBNAME "@ {global:"
+
+#define PNG_EXPORTA(ordinal, type, name, args, attributes) PNG_DFN " @" SYMBOL_PREFIX "@@" name "@;"
 
 #include "../png.h"
 


### PR DESCRIPTION
gathering of versions of symbols gathers also macro definition itself

Happens also under synology spksrc toochain with GCC_DEBUG_INFO = 1 (have no idea why in all issues debugging matters)

Also added escaped \r in dfn.awk for better maintanability (otherwise some editor went mad)