### PR TITLE
cmake: Let pngpriv.h control most architecture optimizations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,182 +137,50 @@ endif()
 if(PNG_HARDWARE_OPTIMIZATIONS)
 
 # Set definitions and sources for ARM.
-if(PNG_TARGET_ARCHITECTURE MATCHES "^(arm|aarch)")
-  if(PNG_TARGET_ARCHITECTURE MATCHES "^(arm64|aarch64)")
-    set(PNG_ARM_NEON_POSSIBLE_VALUES on off)
-    set(PNG_ARM_NEON "on"
-        CACHE STRING "Enable ARM NEON optimizations: on|off; on is default")
-  else()
-    set(PNG_ARM_NEON_POSSIBLE_VALUES check on off)
-    set(PNG_ARM_NEON "off"
-        CACHE STRING "Enable ARM NEON optimizations: check|on|off; off is default")
-  endif()
-  set_property(CACHE PNG_ARM_NEON
-               PROPERTY STRINGS ${PNG_ARM_NEON_POSSIBLE_VALUES})
-  list(FIND PNG_ARM_NEON_POSSIBLE_VALUES ${PNG_ARM_NEON} index)
-  if(index EQUAL -1)
-    message(FATAL_ERROR "PNG_ARM_NEON must be one of [${PNG_ARM_NEON_POSSIBLE_VALUES}]")
-  elseif(NOT PNG_ARM_NEON STREQUAL "off")
-    set(libpng_arm_sources
-        arm/arm_init.c
-        arm/filter_neon_intrinsics.c
-        arm/palette_neon_intrinsics.c)
-    if(PNG_ARM_NEON STREQUAL "on")
-      add_definitions(-DPNG_ARM_NEON_OPT=2)
-    elseif(PNG_ARM_NEON STREQUAL "check")
-      add_definitions(-DPNG_ARM_NEON_CHECK_SUPPORTED)
-    endif()
-  else()
-    add_definitions(-DPNG_ARM_NEON_OPT=0)
-  endif()
-endif()
+set(libpng_arm_sources
+    arm/arm_init.c
+    arm/filter_neon_intrinsics.c
+    arm/palette_neon_intrinsics.c)
 
 # Set definitions and sources for PowerPC.
-if(PNG_TARGET_ARCHITECTURE MATCHES "^(powerpc|ppc64)")
-  set(PNG_POWERPC_VSX_POSSIBLE_VALUES on off)
-  set(PNG_POWERPC_VSX "on"
-      CACHE STRING "Enable POWERPC VSX optimizations: on|off; on is default")
-  set_property(CACHE PNG_POWERPC_VSX
-               PROPERTY STRINGS ${PNG_POWERPC_VSX_POSSIBLE_VALUES})
-  list(FIND PNG_POWERPC_VSX_POSSIBLE_VALUES ${PNG_POWERPC_VSX} index)
-  if(index EQUAL -1)
-    message(FATAL_ERROR "PNG_POWERPC_VSX must be one of [${PNG_POWERPC_VSX_POSSIBLE_VALUES}]")
-  elseif(NOT PNG_POWERPC_VSX STREQUAL "off")
-    set(libpng_powerpc_sources
-        powerpc/powerpc_init.c
-        powerpc/filter_vsx_intrinsics.c)
-    if(PNG_POWERPC_VSX STREQUAL "on")
-      add_definitions(-DPNG_POWERPC_VSX_OPT=2)
-    endif()
-  else()
-    add_definitions(-DPNG_POWERPC_VSX_OPT=0)
-  endif()
-endif()
+set(libpng_powerpc_sources
+    powerpc/powerpc_init.c
+    powerpc/filter_vsx_intrinsics.c)
 
 # Set definitions and sources for Intel.
-if(PNG_TARGET_ARCHITECTURE MATCHES "^(i[3-6]86|x86|amd64)")
-  set(PNG_INTEL_SSE_POSSIBLE_VALUES on off)
-  set(PNG_INTEL_SSE "on"
-      CACHE STRING "Enable INTEL_SSE optimizations: on|off; on is default")
-  set_property(CACHE PNG_INTEL_SSE
-               PROPERTY STRINGS ${PNG_INTEL_SSE_POSSIBLE_VALUES})
-  list(FIND PNG_INTEL_SSE_POSSIBLE_VALUES ${PNG_INTEL_SSE} index)
-  if(index EQUAL -1)
-    message(FATAL_ERROR "PNG_INTEL_SSE must be one of [${PNG_INTEL_SSE_POSSIBLE_VALUES}]")
-  elseif(NOT PNG_INTEL_SSE STREQUAL "off")
-    set(libpng_intel_sources
-        intel/intel_init.c
-        intel/filter_sse2_intrinsics.c)
-    if(PNG_INTEL_SSE STREQUAL "on")
-      add_definitions(-DPNG_INTEL_SSE_OPT=1)
-    endif()
-  else()
-    add_definitions(-DPNG_INTEL_SSE_OPT=0)
-  endif()
-endif()
+set(libpng_intel_sources
+    intel/intel_init.c
+    intel/filter_sse2_intrinsics.c)
 
 # Set definitions and sources for MIPS.
-if(PNG_TARGET_ARCHITECTURE MATCHES "^(mipsel|mips64el)")
-  set(PNG_MIPS_MSA_POSSIBLE_VALUES on off)
-  set(PNG_MIPS_MSA "on"
-      CACHE STRING "Enable MIPS_MSA optimizations: on|off; on is default")
-  set_property(CACHE PNG_MIPS_MSA
-               PROPERTY STRINGS ${PNG_MIPS_MSA_POSSIBLE_VALUES})
-  list(FIND PNG_MIPS_MSA_POSSIBLE_VALUES ${PNG_MIPS_MSA} index_msa)
-  if(index_msa EQUAL -1)
-    message(FATAL_ERROR "PNG_MIPS_MSA must be one of [${PNG_MIPS_MSA_POSSIBLE_VALUES}]")
-  endif()
-
-  set(PNG_MIPS_MMI_POSSIBLE_VALUES on off)
-  set(PNG_MIPS_MMI "on"
-      CACHE STRING "Enable MIPS_MMI optimizations: on|off; on is default")
-  set_property(CACHE PNG_MIPS_MMI
-               PROPERTY STRINGS ${PNG_MIPS_MMI_POSSIBLE_VALUES})
-  list(FIND PNG_MIPS_MMI_POSSIBLE_VALUES ${PNG_MIPS_MMI} index_mmi)
-  if(index_mmi EQUAL -1)
-    message(FATAL_ERROR "PNG_MIPS_MMI must be one of [${PNG_MIPS_MMI_POSSIBLE_VALUES}]")
-  endif()
-
-  if(PNG_MIPS_MSA STREQUAL "on" AND PNG_MIPS_MMI STREQUAL "on")
-    set(libpng_mips_sources
-        mips/mips_init.c
-        mips/filter_msa_intrinsics.c
-        mips/filter_mmi_inline_assembly.c)
-    add_definitions(-DPNG_MIPS_MSA_OPT=2)
-    add_definitions(-DPNG_MIPS_MMI_OPT=1)
-  elseif(PNG_MIPS_MSA STREQUAL "on")
-    set(libpng_mips_sources
-        mips/mips_init.c
-        mips/filter_msa_intrinsics.c)
-    add_definitions(-DPNG_MIPS_MSA_OPT=2)
-    add_definitions(-DPNG_MIPS_MMI_OPT=0)
-  elseif(PNG_MIPS_MMI STREQUAL "on")
-    set(libpng_mips_sources
-        mips/mips_init.c
-        mips/filter_mmi_inline_assembly.c)
-    add_definitions(-DPNG_MIPS_MSA_OPT=0)
-    add_definitions(-DPNG_MIPS_MMI_OPT=1)
-    else()
-    add_definitions(-DPNG_MIPS_MSA_OPT=0)
-    add_definitions(-DPNG_MIPS_MMI_OPT=0)
-    endif()
-endif()
+set(libpng_mips_sources
+    mips/mips_init.c
+    mips/filter_msa_intrinsics.c
+    mips/filter_mmi_inline_assembly.c)
 
 # Set definitions and sources for LoongArch.
-if(PNG_TARGET_ARCHITECTURE MATCHES "^(loongarch)")
-  include(CheckCCompilerFlag)
-  set(PNG_LOONGARCH_LSX_POSSIBLE_VALUES on off)
-  set(PNG_LOONGARCH_LSX "on"
-      CACHE STRING "Enable LOONGARCH_LSX optimizations: on|off; on is default")
-  set_property(CACHE PNG_LOONGARCH_LSX
-               PROPERTY STRINGS ${PNG_LOONGARCH_LSX_POSSIBLE_VALUES})
-  list(FIND PNG_LOONGARCH_LSX_POSSIBLE_VALUES ${PNG_LOONGARCH_LSX} index)
-  if(index EQUAL -1)
-    message(FATAL_ERROR "PNG_LOONGARCH_LSX must be one of [${PNG_LOONGARCH_LSX_POSSIBLE_VALUES}]")
-  elseif(NOT PNG_LOONGARCH_LSX STREQUAL "off")
-    CHECK_C_COMPILER_FLAG("-mlsx" COMPILER_SUPPORTS_LSX)
-    if(COMPILER_SUPPORTS_LSX)
-      set(libpng_loongarch_sources
-          loongarch/loongarch_lsx_init.c
-          loongarch/filter_lsx_intrinsics.c)
-      set_source_files_properties(${libpng_loongarch_sources}
-                                  PROPERTIES
-                                  COMPILE_FLAGS "-mlsx")
-      add_definitions(-DPNG_LOONGARCH_LSX_OPT=1)
-    else()
-      message(FATAL_ERROR "Compiler does not support -mlsx option")
-    endif()
-  else()
-    add_definitions(-DPNG_LOONGARCH_LSX_OPT=0)
-  endif()
+set(libpng_loongarch_sources
+    loongarch/loongarch_lsx_init.c
+    loongarch/filter_lsx_intrinsics.c)
+include(CheckCCompilerFlag)
+check_c_compiler_flag("-mlsx" COMPILER_SUPPORTS_LSX)
+if(COMPILER_SUPPORTS_LSX)
+  set_source_files_properties(${libpng_loongarch_sources}
+                              PROPERTIES
+                              COMPILE_FLAGS "-mlsx")
 endif()
 
 else(PNG_HARDWARE_OPTIMIZATIONS)
 
-# Set definitions and sources for ARM.
-if(PNG_TARGET_ARCHITECTURE MATCHES "^(arm|aarch)")
-  add_definitions(-DPNG_ARM_NEON_OPT=0)
-endif()
-
-# Set definitions and sources for PowerPC.
-if(PNG_TARGET_ARCHITECTURE MATCHES "^(powerpc|ppc64)")
-  add_definitions(-DPNG_POWERPC_VSX_OPT=0)
-endif()
-
-# Set definitions and sources for Intel.
-if(PNG_TARGET_ARCHITECTURE MATCHES "^(i[3-6]86|x86|amd64)")
-  add_definitions(-DPNG_INTEL_SSE_OPT=0)
-endif()
-
-# Set definitions and sources for MIPS.
-if(PNG_TARGET_ARCHITECTURE MATCHES "^(mipsel|mips64el)")
-  add_definitions(-DPNG_MIPS_MSA_OPT=0)
-endif()
-
-# Set definitions and sources for LoongArch.
-if(PNG_TARGET_ARCHITECTURE MATCHES "^(loongarch)")
-  add_definitions(-DPNG_LOONGARCH_LSX_OPT=0)
-endif()
+# Disable opt for all arches
+add_definitions(
+  -DPNG_ARM_NEON_OPT=0
+  -DPNG_ARM_NEON_OPT=0
+  -DPNG_POWERPC_VSX_OPT=0
+  -DPNG_INTEL_SSE_OPT=0
+  -DPNG_MIPS_MSA_OPT=0
+  -DPNG_LOONGARCH_LSX_OPT=0
+)
 
 endif(PNG_HARDWARE_OPTIMIZATIONS)
 


### PR DESCRIPTION
An attempt to fix #372. Based on the conversation there, removes option logic surrounding ARM optimization.

Alternatively, could restore `PNG_ARM_NEON` option with only `check` and `off` values (or `on` and `off` values).