### PR TITLE
Enable Intel SSE in configure builds

### DIFF
--- a/pngpriv.h
+++ b/pngpriv.h
@@ -187,11 +187,6 @@
 #endif
 
 #ifndef PNG_INTEL_SSE_OPT
-#   ifdef PNG_INTEL_SSE
-      /* Only check for SSE if the build configuration has been modified to
-       * enable SSE optimizations.  This means that these optimizations will
-       * be off by default.  See contrib/intel for more details.
-       */
 #      if defined(__SSE4_1__) || defined(__AVX__) || defined(__SSSE3__) || \
        defined(__SSE2__) || defined(_M_X64) || defined(_M_AMD64) || \
        (defined(_M_IX86_FP) && _M_IX86_FP >= 2)
@@ -199,9 +194,6 @@
 #      else
 #         define PNG_INTEL_SSE_OPT 0
 #      endif
-#   else
-#      define PNG_INTEL_SSE_OPT 0
-#   endif
 #endif
 
 #if PNG_INTEL_SSE_OPT > 0


### PR DESCRIPTION
At present configure and general Makefile builds have the Intel SSE optimizations hardwired off by a special #define PNG_INTEL_SSE which disables the auto-detection of Intel SSE support.  This was done by Glenn in 2017 here:

https://github.com/pnggroup/libpng/commit/bef76802de97c7ba917c4d397d

Since then CMakeLists.txt has been modified in such a way that it bypasses this requirement.  As a consequence cmake and configure builds produce different results.

The CMakeLists.txt changes also broke the support for Apple Universal Binaries and, possibly, for GCC multilib in general.  This is fixed by https://github.com/pnggroup/libpng/pull/575 which will also have the side effect of bringing "no option" cmake and configure builds into line.  Consequently cmake will no longer build with Intel SSE optimizations by default.

This resolves this by removing the check on PNG_INTEL_SSE in pngpriv.h; instead of switching Intel SSE off (by default) in cmake builds it is switched on (by default) in both configure and "raw" makefile builds.

The original motivation for the check was to avoid perturbing the 1.6 relesae by adding possibly broken hardware optimizations mid-cycle. Since then, however, this rule has been ignored and multiple hardware optimizations have been added that are on by default without moving to a new major release.