### PR TITLE
ARM64: Export Neon symbols for shared library

### DIFF
--- a/arm/arm_init.c
+++ b/arm/arm_init.c
@@ -14,6 +14,7 @@
 #define _POSIX_SOURCE 1
 
 #include "../pngpriv.h"
+#include "../png.h"
 
 #ifdef PNG_READ_SUPPORTED
 
@@ -57,7 +58,7 @@ static int png_have_neon(png_structp png_ptr);
 #  error "ALIGNED_MEMORY is required; set: -DPNG_ALIGNED_MEMORY_SUPPORTED"
 #endif
 
-void
+void PNGAPI
 png_init_filter_functions_neon(png_structp pp, unsigned int bpp)
 {
    /* The switch statement is compiled in for ARM_NEON_API, the call to

--- a/arm/filter_neon_intrinsics.c
+++ b/arm/filter_neon_intrinsics.c
@@ -12,6 +12,7 @@
  */
 
 #include "../pngpriv.h"
+#include "../png.h"
 
 #ifdef PNG_READ_SUPPORTED
 
@@ -47,7 +48,7 @@
 
 #if PNG_ARM_NEON_OPT > 0
 
-void
+void PNGAPI
 png_read_filter_row_up_neon(png_row_infop row_info, png_bytep row,
    png_const_bytep prev_row)
 {
@@ -68,7 +69,7 @@ png_read_filter_row_up_neon(png_row_infop row_info, png_bytep row,
    }
 }
 
-void
+void PNGAPI
 png_read_filter_row_sub3_neon(png_row_infop row_info, png_bytep row,
    png_const_bytep prev_row)
 {
@@ -115,7 +116,7 @@ png_read_filter_row_sub3_neon(png_row_infop row_info, png_bytep row,
    PNG_UNUSED(prev_row)
 }
 
-void
+void PNGAPI
 png_read_filter_row_sub4_neon(png_row_infop row_info, png_bytep row,
    png_const_bytep prev_row)
 {
@@ -147,7 +148,7 @@ png_read_filter_row_sub4_neon(png_row_infop row_info, png_bytep row,
    PNG_UNUSED(prev_row)
 }
 
-void
+void PNGAPI
 png_read_filter_row_avg3_neon(png_row_infop row_info, png_bytep row,
    png_const_bytep prev_row)
 {
@@ -215,7 +216,7 @@ png_read_filter_row_avg3_neon(png_row_infop row_info, png_bytep row,
    }
 }
 
-void
+void PNGAPI
 png_read_filter_row_avg4_neon(png_row_infop row_info, png_bytep row,
    png_const_bytep prev_row)
 {
@@ -284,7 +285,7 @@ paeth(uint8x8_t a, uint8x8_t b, uint8x8_t c)
    return e;
 }
 
-void
+void PNGAPI
 png_read_filter_row_paeth3_neon(png_row_infop row_info, png_bytep row,
    png_const_bytep prev_row)
 {
@@ -352,7 +353,7 @@ png_read_filter_row_paeth3_neon(png_row_infop row_info, png_bytep row,
    }
 }
 
-void
+void PNGAPI
 png_read_filter_row_paeth4_neon(png_row_infop row_info, png_bytep row,
    png_const_bytep prev_row)
 {

--- a/arm/palette_neon_intrinsics.c
+++ b/arm/palette_neon_intrinsics.c
@@ -11,6 +11,7 @@
  */
 
 #include "../pngpriv.h"
+#include "../png.h"
 
 #if PNG_ARM_NEON_IMPLEMENTATION == 1
 
@@ -21,7 +22,7 @@
 #endif
 
 /* Build an RGBA8 palette from the separate RGB and alpha palettes. */
-void
+void PNGAPI
 png_riffle_palette_neon(png_structrp png_ptr)
 {
    png_const_colorp palette = png_ptr->palette;
@@ -58,7 +59,7 @@ png_riffle_palette_neon(png_structrp png_ptr)
 }
 
 /* Expands a palettized row into RGBA8. */
-int
+int PNGAPI
 png_do_expand_palette_rgba8_neon(png_structrp png_ptr, png_row_infop row_info,
     png_const_bytep row, png_bytepp ssp, png_bytepp ddp)
 {
@@ -103,7 +104,7 @@ png_do_expand_palette_rgba8_neon(png_structrp png_ptr, png_row_infop row_info,
 }
 
 /* Expands a palettized row into RGB8. */
-int
+int PNGAPI
 png_do_expand_palette_rgb8_neon(png_structrp png_ptr, png_row_infop row_info,
     png_const_bytep row, png_bytepp ssp, png_bytepp ddp)
 {

--- a/libpng.3
+++ b/libpng.3
@@ -507,6 +507,28 @@ libpng \- Portable Network Graphics (PNG) Reference Library 1.6.43
 
 \fBvoid png_write_sig (png_structp \fIpng_ptr\fP\fB);\fP
 
+\fBvoid png_init_filter_functions_neon (png_structp \fP\fIpp\fP\fB, unsigned int \fP\fIbpp\fP\fB);\fP
+
+\fBvoid png_read_filter_row_up_neon (png_row_infop \fP\fIrow_info\fP\fB, png_bytep \fP\fIrow\fP\fB, png_const_bytep \fP\fIprev_row\fP\fB);\fP
+
+\fBvoid png_read_filter_row_sub3_neon (png_row_infop \fP\fIrow_info\fP\fB, png_bytep \fP\fIrow\fP\fB, png_const_bytep \fP\fIprev_row\fP\fB);\fP
+
+\fBvoid png_read_filter_row_sub4_neon (png_row_infop \fP\fIrow_info\fP\fB, png_bytep \fP\fIrow\fP\fB, png_const_bytep \fP\fIprev_row\fP\fB);\fP
+
+\fBvoid png_read_filter_row_avg3_neon (png_row_infop \fP\fIrow_info\fP\fB, png_bytep \fP\fIrow\fP\fB, png_const_bytep \fP\fIprev_row\fP\fB);\fP
+
+\fBvoid png_read_filter_row_avg4_neon (png_row_infop \fP\fIrow_info\fP\fB, png_bytep \fP\fIrow\fP\fB, png_const_bytep \fP\fIprev_row\fP\fB);\fP
+
+\fBvoid png_read_filter_row_paeth3_neon (png_row_infop \fP\fIrow_info\fP\fB, png_bytep \fP\fIrow\fP\fB, png_const_bytep \fP\fIprev_row\fP\fB);\fP
+
+\fBvoid png_read_filter_row_paeth4_neon (png_row_infop \fP\fIrow_info\fP\fB, png_bytep \fP\fIrow\fP\fB, png_const_bytep \fP\fIprev_row\fP\fB);\fP
+
+\fBvoid png_riffle_palette_neon (png_structrp \fP\fIpng_ptr\fP\fB);\fP
+
+\fBvoid png_do_expand_palette_rgba8_neon (png_structrp \fP\fIpng_ptr\fP\fB, png_row_infop \fP\fIrow_info\fP\fB, png_const_bytep \fP\fIrow\fP\fB, png_bytepp \fP\fIssp\fP\fB, png_bytepp \fP\fIddp\fP\fB);\fP
+
+\fBvoid png_do_expand_palette_rgb8_neon (png_structrp \fP\fIpng_ptr\fP\fB, png_row_infop \fP\fIrow_info\fP\fB, png_const_bytep \fP\fIrow\fP\fB, png_bytepp \fP\fIssp\fP\fB, png_bytepp \fP\fIddp\fP\fB);\fP
+
 .SH DESCRIPTION
 The
 .I libpng

--- a/png.h
+++ b/png.h
@@ -3194,6 +3194,30 @@ PNG_EXPORT(245, int, png_image_write_to_memory, (png_imagep image, void *memory,
  *           PNG images.  'Software' options allow such optimizations to be
  *           selected at run time.
  */
+
+#ifndef PNG_ARM_NEON_OPT
+#  if (defined(__ARM_NEON__) || defined(__ARM_NEON)) && \
+   defined(PNG_ALIGNED_MEMORY_SUPPORTED)
+#     define PNG_ARM_NEON_OPT 2
+#  else
+#     define PNG_ARM_NEON_OPT 0
+#  endif
+#endif
+
+#if PNG_ARM_NEON_OPT > 0
+PNG_EXPORT(250, void, png_init_filter_functions_neon, (png_structp pp, unsigned int bpp));
+PNG_EXPORT(251, void, png_read_filter_row_up_neon, (png_row_infop row_info, png_bytep row, png_const_bytep prev_row));
+PNG_EXPORT(252, void, png_read_filter_row_sub3_neon, (png_row_infop row_info, png_bytep row, png_const_bytep prev_row));
+PNG_EXPORT(253, void, png_read_filter_row_sub4_neon, (png_row_infop row_info, png_bytep row, png_const_bytep prev_row));
+PNG_EXPORT(254, void, png_read_filter_row_avg3_neon, (png_row_infop row_info, png_bytep row, png_const_bytep prev_row));
+PNG_EXPORT(255, void, png_read_filter_row_avg4_neon, (png_row_infop row_info, png_bytep row, png_const_bytep prev_row));
+PNG_EXPORT(256, void, png_read_filter_row_paeth3_neon, (png_row_infop row_info, png_bytep row, png_const_bytep prev_row));
+PNG_EXPORT(257, void, png_read_filter_row_paeth4_neon, (png_row_infop row_info, png_bytep row, png_const_bytep prev_row));
+PNG_EXPORT(258, void, png_riffle_palette_neon, (png_structrp png_ptr));
+PNG_EXPORT(259, int, png_do_expand_palette_rgba8_neon, (png_structrp png_ptr, png_row_infop row_info, png_const_bytep row, png_bytepp ssp, png_bytepp ddp));
+PNG_EXPORT(260, int, png_do_expand_palette_rgb8_neon, (png_structrp png_ptr, png_row_infop row_info, png_const_bytep row, png_bytepp ssp, png_bytepp ddp));
+#endif
+
 #ifdef PNG_SET_OPTION_SUPPORTED
 #ifdef PNG_ARM_NEON_API_SUPPORTED
 #  define PNG_ARM_NEON   0 /* HARDWARE: ARM Neon SIMD instructions supported */
@@ -3238,7 +3262,7 @@ PNG_EXPORT(244, int, png_set_option, (png_structrp png_ptr, int option,
  * one to use is one more than this.)
  */
 #ifdef PNG_EXPORT_LAST_ORDINAL
-  PNG_EXPORT_LAST_ORDINAL(249);
+  PNG_EXPORT_LAST_ORDINAL(260);
 #endif
 
 #ifdef __cplusplus

--- a/pngpriv.h
+++ b/pngpriv.h
@@ -140,7 +140,12 @@
     * callbacks to do this.
     */
 #  define PNG_FILTER_OPTIMIZATIONS png_init_filter_functions_neon
-
+#  ifndef PNG_ARM_NEON_IMPLEMENTATION
+      /* Use the intrinsics code by default. */
+#     define PNG_ARM_NEON_IMPLEMENTATION 1
+#  endif
+#else /* PNG_ARM_NEON_OPT == 0 */
+#     define PNG_ARM_NEON_IMPLEMENTATION 0
 #endif /* PNG_ARM_NEON_OPT > 0 */
 
 #ifndef PNG_MIPS_MSA_OPT

--- a/pngpriv.h
+++ b/pngpriv.h
@@ -140,12 +140,7 @@
     * callbacks to do this.
     */
 #  define PNG_FILTER_OPTIMIZATIONS png_init_filter_functions_neon
-#  ifndef PNG_ARM_NEON_IMPLEMENTATION
-      /* Use the intrinsics code by default. */
-#     define PNG_ARM_NEON_IMPLEMENTATION 1
-#  endif
-#else /* PNG_ARM_NEON_OPT == 0 */
-#     define PNG_ARM_NEON_IMPLEMENTATION 0
+
 #endif /* PNG_ARM_NEON_OPT > 0 */
 
 #ifndef PNG_MIPS_MSA_OPT
@@ -1282,23 +1277,6 @@ PNG_INTERNAL_FUNCTION(void,png_do_write_interlace,(png_row_infop row_info,
 PNG_INTERNAL_FUNCTION(void,png_read_filter_row,(png_structrp pp, png_row_infop
     row_info, png_bytep row, png_const_bytep prev_row, int filter),PNG_EMPTY);
 
-#if PNG_ARM_NEON_OPT > 0
-PNG_INTERNAL_FUNCTION(void,png_read_filter_row_up_neon,(png_row_infop row_info,
-    png_bytep row, png_const_bytep prev_row),PNG_EMPTY);
-PNG_INTERNAL_FUNCTION(void,png_read_filter_row_sub3_neon,(png_row_infop
-    row_info, png_bytep row, png_const_bytep prev_row),PNG_EMPTY);
-PNG_INTERNAL_FUNCTION(void,png_read_filter_row_sub4_neon,(png_row_infop
-    row_info, png_bytep row, png_const_bytep prev_row),PNG_EMPTY);
-PNG_INTERNAL_FUNCTION(void,png_read_filter_row_avg3_neon,(png_row_infop
-    row_info, png_bytep row, png_const_bytep prev_row),PNG_EMPTY);
-PNG_INTERNAL_FUNCTION(void,png_read_filter_row_avg4_neon,(png_row_infop
-    row_info, png_bytep row, png_const_bytep prev_row),PNG_EMPTY);
-PNG_INTERNAL_FUNCTION(void,png_read_filter_row_paeth3_neon,(png_row_infop
-    row_info, png_bytep row, png_const_bytep prev_row),PNG_EMPTY);
-PNG_INTERNAL_FUNCTION(void,png_read_filter_row_paeth4_neon,(png_row_infop
-    row_info, png_bytep row, png_const_bytep prev_row),PNG_EMPTY);
-#endif
-
 #if PNG_MIPS_MSA_IMPLEMENTATION == 1
 PNG_INTERNAL_FUNCTION(void,png_read_filter_row_up_msa,(png_row_infop row_info,
     png_bytep row, png_const_bytep prev_row),PNG_EMPTY);
@@ -2116,10 +2094,6 @@ PNG_INTERNAL_FUNCTION(void, PNG_FILTER_OPTIMIZATIONS, (png_structp png_ptr,
     * the builder of libpng passes the definition of PNG_FILTER_OPTIMIZATIONS in
     * CFLAGS in place of CPPFLAGS *and* uses symbol prefixing.
     */
-#  if PNG_ARM_NEON_OPT > 0
-PNG_INTERNAL_FUNCTION(void, png_init_filter_functions_neon,
-   (png_structp png_ptr, unsigned int bpp), PNG_EMPTY);
-#endif
 
 #if PNG_MIPS_MSA_IMPLEMENTATION == 1
 PNG_INTERNAL_FUNCTION(void, png_init_filter_functions_mips,
@@ -2144,29 +2118,6 @@ PNG_INTERNAL_FUNCTION(void, png_init_filter_functions_lsx,
 
 PNG_INTERNAL_FUNCTION(png_uint_32, png_check_keyword, (png_structrp png_ptr,
    png_const_charp key, png_bytep new_key), PNG_EMPTY);
-
-#if PNG_ARM_NEON_IMPLEMENTATION == 1
-PNG_INTERNAL_FUNCTION(void,
-                      png_riffle_palette_neon,
-                      (png_structrp),
-                      PNG_EMPTY);
-PNG_INTERNAL_FUNCTION(int,
-                      png_do_expand_palette_rgba8_neon,
-                      (png_structrp,
-                       png_row_infop,
-                       png_const_bytep,
-                       const png_bytepp,
-                       const png_bytepp),
-                      PNG_EMPTY);
-PNG_INTERNAL_FUNCTION(int,
-                      png_do_expand_palette_rgb8_neon,
-                      (png_structrp,
-                       png_row_infop,
-                       png_const_bytep,
-                       const png_bytepp,
-                       const png_bytepp),
-                      PNG_EMPTY);
-#endif
 
 /* Maintainer: Put new private prototypes here ^ */
 

--- a/scripts/symbols.def
+++ b/scripts/symbols.def
@@ -253,3 +253,14 @@ EXPORTS
  png_set_eXIf @247
  png_get_eXIf_1 @248
  png_set_eXIf_1 @249
+ png_init_filter_functions_neon @250
+ png_read_filter_row_up_neon @251
+ png_read_filter_row_sub3_neon @252
+ png_read_filter_row_sub4_neon @253
+ png_read_filter_row_avg3_neon @254
+ png_read_filter_row_avg4_neon @255
+ png_read_filter_row_paeth3_neon @256
+ png_read_filter_row_paeth4_neon @257
+ png_riffle_palette_neon @258
+ png_do_expand_palette_rgba8_neon @259
+ png_do_expand_palette_rgb8_neon @260


### PR DESCRIPTION
This change exposes the arm specific symbols to public API. While building PNG as shared library and linking it with other shared libraries like FreeImage, we need to make the neon implementations visible from outside.