### PR TITLE
[libpng18] Remove AM_MAINTAINER_MODE from configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -35,10 +35,6 @@ AC_CONFIG_MACRO_DIR([scripts/autoconf])
 # 1.12.2 fixes a security issue in 1.11.2 and 1.12.1
 # 1.13 is required for parallel tests
 AM_INIT_AUTOMAKE([1.13 foreign dist-xz color-tests silent-rules subdir-objects])
-# The following line causes --disable-maintainer-mode to be the default to
-# configure. This is necessary because libpng distributions cannot rely on the
-# time stamps of the autotools generated files being correct
-AM_MAINTAINER_MODE
 
 dnl configure.ac and Makefile.am expect automake 1.11.2 or a compatible later
 dnl version; aclocal.m4 will generate a failure if you use a prior version of


### PR DESCRIPTION
Now the autoconf generated files are no longer in the source in libpng18
AM_MAINTAINER_MODE is not required; the generated files must have the
correct timestamp.

This change is essential in a development environment where "git pull"
may update configure.ac, Makefile.am because NOW the pull does not
update configure and Makefile.in as well.  This solves a lot of problems
but not when AM_MAINTAINER_MODE is in configure.ac where it just creates
a complete mess; configure and Makefile.in don't get updated and
mysterious (to the puller) build failures happen.

Note that 'configure --enable-maintainer-mode' is incompatible with
doing builds for different architectures in parallel; it ends up with
two configure processes overwriting stuff in ${srcdir}.

To generate a tarball run configure with "--disable-maintainer-mode".
See the discussion in paragraph 5 of section 26.2.2 of the GNU automake
manual (1.7.4).