### PR TITLE
[libpng18] [build system] Require ISO-C when building libpng

### DIFF
--- a/pngpriv.h
+++ b/pngpriv.h
@@ -22,6 +22,16 @@
 #ifndef PNGPRIV_H
 #define PNGPRIV_H
 
+/* Compiler functionality.  For building libpng (though not necessarily for
+ * using libpng) a C compiler conformant to at least the original ANSI-C
+ * standard (C89, ISO-C90) is required.
+ */
+#if __STDC__ != 1
+#  error A compiler compliant with ISO-C90 is required to build libpng
+#endif
+
+/* TODO: check __STDC_VERSION__ (defined in ISO-C95) */
+
 /* Feature Test Macros.  The following are defined here to ensure that correctly
  * implemented libraries reveal the APIs libpng needs to build and hide those
  * that are not needed and potentially damaging to the compilation.


### PR DESCRIPTION
Previously the build systems would accept any old compiler and those
compilers would define any old symbol or macro name.  ISO (well, ANSI)
defined a strict set of symbols/macros which may be defined by the
implementation leaving the remainder for application programs.

Adding a requirement for an ISO-C compiler (any version) ensures that a
check for name clashes on one compiler (with a sufficient level of
diagnostics) works for every ISO-C compiler.  In other words if it
builds on one it builds on all.

The check is in pngpriv.h; the same restrictions do not apply to code
that calls the public interface of libpng, only to the compiler used to
build ligpng.

Signed-off-by: John Bowler <jbowler@acm.org>
