### PR TITLE
[libpng18] BUILD BREAK: quick fix for -Wcast-align in arm/palette_neon_intrinsics.c

### DIFF
--- a/arm/palette_neon_intrinsics.c
+++ b/arm/palette_neon_intrinsics.c
@@ -64,7 +64,7 @@ png_do_expand_palette_rgba8_neon(png_structrp png_ptr, png_row_infop row_info,
 {
    png_uint_32 row_width = row_info->width;
    const png_uint_32 *riffled_palette =
-      (const png_uint_32 *)png_ptr->riffled_palette;
+      png_aligncastconst(png_const_uint_32p, png_ptr->riffled_palette);
    const png_uint_32 pixels_per_chunk = 4;
    png_uint_32 i;
 


### PR DESCRIPTION
QD fix: use png_aligncastconst for the upcast in NEON palette
    
Fix (work round) for #605

This changes the arm/palette_neon_intrinsics.c code from using a bare
cast to using the portable macro png_aligncastconst.  This removes the
-Wcast-align warning.
    
The cast is safe because the pointer was allocated by malloc(1024) and
malloc is required to return a pointer with sufficient alignment for
anything the allocation can accomodate.
    
Nevertheless this is a quick and dirty fix; the use of png_bytep in the
png_struct declaration of the pointer is entirely machine specific,
other architectures may need different types and consequently the only
type which is portable to other companies CPUs is (void*).
    
Signed-off-by: John Bowler <jbowler@acm.org>
