### PR TITLE
[libpng18] [code standardisation] Use standard C attributes

### DIFF
--- a/contrib/arm-neon/linux.c
+++ b/contrib/arm-neon/linux.c
@@ -62,8 +62,6 @@ png_have_neon(png_structp png_ptr)
 
                counter=0;
                state = Feature;
-               /* FALLTHROUGH */
-
             case Feature:
                /* Match 'FEATURE', ASCII case insensitive. */
                if ((ch & ~0x20) == ch_feature[counter])
@@ -75,8 +73,6 @@ png_have_neon(png_structp png_ptr)
 
                /* did not match 'feature' */
                state = SkipLine;
-               /* FALLTHROUGH */
-
             case SkipLine:
             skipLine:
                /* Skip everything until we see linefeed or carriage return */
@@ -110,8 +106,6 @@ png_have_neon(png_structp png_ptr)
 
                state = Neon;
                counter = 0;
-               /* FALLTHROUGH */
-
             case Neon:
                /* Look for 'neon' tag */
                if ((ch & ~0x20) == ch_neon[counter])
@@ -122,8 +116,6 @@ png_have_neon(png_structp png_ptr)
                }
 
                state = SkipTag;
-               /* FALLTHROUGH */
-
             case SkipTag:
                /* Skip non-space characters */
                if (ch == 10 || ch == 13)

--- a/contrib/libtests/pngstest.c
+++ b/contrib/libtests/pngstest.c
@@ -2897,13 +2897,10 @@ compare_two_images(Image *a, Image *b, int via_linear,
                {
                   case 4:
                      if (pua[btoa[3]] != pub[3]) break;
-                     FALLTHROUGH; /* FALLTHROUGH */
                   case 3:
                      if (pua[btoa[2]] != pub[2]) break;
-                     FALLTHROUGH; /* FALLTHROUGH */
                   case 2:
                      if (pua[btoa[1]] != pub[1]) break;
-                     FALLTHROUGH; /* FALLTHROUGH */
                   case 1:
                      if (pua[btoa[0]] != pub[0]) break;
                      if (alpha_added != 4 && pub[alpha_added] != 65535) break;
@@ -2919,13 +2916,10 @@ compare_two_images(Image *a, Image *b, int via_linear,
                {
                   case 4:
                      if (psa[btoa[3]] != psb[3]) break;
-                     FALLTHROUGH; /* FALLTHROUGH */
                   case 3:
                      if (psa[btoa[2]] != psb[2]) break;
-                     FALLTHROUGH; /* FALLTHROUGH */
                   case 2:
                      if (psa[btoa[1]] != psb[1]) break;
-                     FALLTHROUGH; /* FALLTHROUGH */
                   case 1:
                      if (psa[btoa[0]] != psb[0]) break;
                      if (alpha_added != 4 && psb[alpha_added] != 255) break;

--- a/contrib/libtests/pngstest.c
+++ b/contrib/libtests/pngstest.c
@@ -1,7 +1,7 @@
 /* pngstest.c
  *
  * Copyright (c) 2021-2024 Cosmin Truta
- * Copyright (c) 2013-2017 John Cunningham Bowler
+ * Copyright (c) 2013-2017,2024 John Cunningham Bowler
  *
  * This code is released under the libpng license.
  * For conditions of distribution and use, see the disclaimer
@@ -45,6 +45,18 @@
 
 #ifdef PNG_SIMPLIFIED_READ_SUPPORTED /* Else nothing can be done */
 #include "../tools/sRGB.h"
+
+/* This is a sanity check on PNG_HAS_ATTRIBUTE.
+ */
+#if PNG_HAS_ATTRIBUTE(__unknown__::attribute)
+#  error PNG_HAS_ATTRIBUTE is not working correctly
+#endif
+
+#if PNG_HAS_ATTRIBUTE(fallthrough)
+#  define FALLTHROUGH PNG_ATTRIBUTE(fallthrough)
+#else
+#  define FALLTRHOUGH /* FALLTHROUGH */
+#endif
 
 /* KNOWN ISSUES
  *
@@ -2885,13 +2897,13 @@ compare_two_images(Image *a, Image *b, int via_linear,
                {
                   case 4:
                      if (pua[btoa[3]] != pub[3]) break;
-                     /* FALLTHROUGH */
+                     FALLTHROUGH; /* FALLTHROUGH */
                   case 3:
                      if (pua[btoa[2]] != pub[2]) break;
-                     /* FALLTHROUGH */
+                     FALLTHROUGH; /* FALLTHROUGH */
                   case 2:
                      if (pua[btoa[1]] != pub[1]) break;
-                     /* FALLTHROUGH */
+                     FALLTHROUGH; /* FALLTHROUGH */
                   case 1:
                      if (pua[btoa[0]] != pub[0]) break;
                      if (alpha_added != 4 && pub[alpha_added] != 65535) break;
@@ -2907,13 +2919,13 @@ compare_two_images(Image *a, Image *b, int via_linear,
                {
                   case 4:
                      if (psa[btoa[3]] != psb[3]) break;
-                     /* FALLTHROUGH */
+                     FALLTHROUGH; /* FALLTHROUGH */
                   case 3:
                      if (psa[btoa[2]] != psb[2]) break;
-                     /* FALLTHROUGH */
+                     FALLTHROUGH; /* FALLTHROUGH */
                   case 2:
                      if (psa[btoa[1]] != psb[1]) break;
-                     /* FALLTHROUGH */
+                     FALLTHROUGH; /* FALLTHROUGH */
                   case 1:
                      if (psa[btoa[0]] != psb[0]) break;
                      if (alpha_added != 4 && psb[alpha_added] != 255) break;

--- a/contrib/libtests/pngunknown.c
+++ b/contrib/libtests/pngunknown.c
@@ -630,7 +630,6 @@ get_unknown(display *d, png_infop info_ptr, int after_IDAT)
                   ++(d->error_count);
                   break;
                }
-               FALLTHROUGH; /* (safe) */ /* FALLTHROUGH */
             case PNG_HANDLE_CHUNK_ALWAYS:
                break;
          }

--- a/contrib/libtests/pngunknown.c
+++ b/contrib/libtests/pngunknown.c
@@ -2,6 +2,7 @@
  *
  * Copyright (c) 2021-2024 Cosmin Truta
  * Copyright (c) 2015,2017 Glenn Randers-Pehrson
+ * Copyright (c) 2015-2016,2024 John Bowler
  * Written by John Cunningham Bowler
  *
  * This code is released under the libpng license.
@@ -36,6 +37,12 @@
 #  define SKIP 77
 #else
 #  define SKIP 0
+#endif
+
+#if PNG_HAS_ATTRIBUTE(fallthrough)
+#  define FALLTHROUGH PNG_ATTRIBUTE(fallthrough)
+#else
+#  define FALLTRHOUGH /* FALLTHROUGH */
 #endif
 
 
@@ -433,7 +440,7 @@ clean_display(display *d)
    }
 }
 
-PNG_FUNCTION(void, display_exit, (display *d), static PNG_NORETURN)
+PNG_FUNCTION(void, display_exit, (display *d), PNG_NORETURN static)
 {
    ++(d->error_count);
 
@@ -457,7 +464,7 @@ display_rc(const display *d, int strict)
 
 /* libpng error and warning callbacks */
 PNG_FUNCTION(void, (PNGCBAPI error), (png_structp png_ptr, const char *message),
-   static PNG_NORETURN)
+   PNG_NORETURN static)
 {
    display *d = (display*)png_get_error_ptr(png_ptr);
 
@@ -623,7 +630,7 @@ get_unknown(display *d, png_infop info_ptr, int after_IDAT)
                   ++(d->error_count);
                   break;
                }
-               /* FALLTHROUGH */ /* (safe) */
+               FALLTHROUGH; /* (safe) */ /* FALLTHROUGH */
             case PNG_HANDLE_CHUNK_ALWAYS:
                break;
          }
@@ -1104,7 +1111,7 @@ static const char *standard_tests[] =
    NULL /*end*/
 };
 
-static PNG_NORETURN void
+PNG_NORETURN static void
 usage(const char *program, const char *reason)
 {
    fprintf(stderr, "pngunknown: %s: usage:\n %s [--strict] "

--- a/contrib/libtests/pngvalid.c
+++ b/contrib/libtests/pngvalid.c
@@ -6596,16 +6596,13 @@ transform_info_imp(transform_display *dp, png_structp pp, png_infop pi)
    {
    case PNG_COLOR_TYPE_PALETTE:
       if (dp->output_bit_depth > 8) goto error;
-      FALLTHROUGH; /* FALLTHROUGH */
    case PNG_COLOR_TYPE_GRAY:
       if (dp->output_bit_depth == 1 || dp->output_bit_depth == 2 ||
          dp->output_bit_depth == 4)
          break;
-      FALLTHROUGH; /* FALLTHROUGH */
    default:
       if (dp->output_bit_depth == 8 || dp->output_bit_depth == 16)
          break;
-      /* FALLTHROUGH */
    error:
       {
          char message[128];
@@ -10008,7 +10005,6 @@ gamma_component_validate(const char *name, const validate_info *vi,
                   use_background = (alpha >= 0 && alpha < 1);
 #           endif
 #           ifdef PNG_READ_ALPHA_MODE_SUPPORTED
-                  FALLTHROUGH; /* FALLTHROUGH */
                case ALPHA_MODE_OFFSET + PNG_ALPHA_STANDARD:
                case ALPHA_MODE_OFFSET + PNG_ALPHA_BROKEN:
                case ALPHA_MODE_OFFSET + PNG_ALPHA_OPTIMIZED:

--- a/contrib/libtests/pngvalid.c
+++ b/contrib/libtests/pngvalid.c
@@ -1,7 +1,7 @@
 /* pngvalid.c - validate libpng by constructing then reading png files.
  *
  * Copyright (c) 2021-2024 Cosmin Truta
- * Copyright (c) 2014-2017 John Cunningham Bowler
+ * Copyright (c) 2014-2017,2024 John Cunningham Bowler
  *
  * This code is released under the libpng license.
  * For conditions of distribution and use, see the disclaimer
@@ -155,6 +155,13 @@ typedef png_byte *png_const_bytep;
 #     define UNUSED(param)
 #  endif
 #endif
+
+#if PNG_HAS_ATTRIBUTE(fallthrough)
+#  define FALLTHROUGH PNG_ATTRIBUTE(fallthrough)
+#else
+#  define FALLTRHOUGH /* FALLTHROUGH */
+#endif
+
 
 /***************************** EXCEPTION HANDLING *****************************/
 #ifdef PNG_FREESTANDING_TESTS
@@ -6589,12 +6596,12 @@ transform_info_imp(transform_display *dp, png_structp pp, png_infop pi)
    {
    case PNG_COLOR_TYPE_PALETTE:
       if (dp->output_bit_depth > 8) goto error;
-      /* FALLTHROUGH */
+      FALLTHROUGH; /* FALLTHROUGH */
    case PNG_COLOR_TYPE_GRAY:
       if (dp->output_bit_depth == 1 || dp->output_bit_depth == 2 ||
          dp->output_bit_depth == 4)
          break;
-      /* FALLTHROUGH */
+      FALLTHROUGH; /* FALLTHROUGH */
    default:
       if (dp->output_bit_depth == 8 || dp->output_bit_depth == 16)
          break;
@@ -10001,7 +10008,7 @@ gamma_component_validate(const char *name, const validate_info *vi,
                   use_background = (alpha >= 0 && alpha < 1);
 #           endif
 #           ifdef PNG_READ_ALPHA_MODE_SUPPORTED
-               /* FALLTHROUGH */
+                  FALLTHROUGH; /* FALLTHROUGH */
                case ALPHA_MODE_OFFSET + PNG_ALPHA_STANDARD:
                case ALPHA_MODE_OFFSET + PNG_ALPHA_BROKEN:
                case ALPHA_MODE_OFFSET + PNG_ALPHA_OPTIMIZED:

--- a/contrib/tools/pngfix.c
+++ b/contrib/tools/pngfix.c
@@ -31,6 +31,12 @@
 #  include "../../png.h"
 #endif
 
+#if PNG_HAS_ATTRIBUTE(fallthrough)
+#  define FALLTHROUGH PNG_ATTRIBUTE(fallthrough)
+#else
+#  define FALLTRHOUGH /* FALLTHROUGH */
+#endif
+
 #ifdef PNG_SETJMP_SUPPORTED
 #include <setjmp.h>
 
@@ -2399,7 +2405,7 @@ zlib_advance(struct zlib *zlib, png_uint_32 nbytes)
                   endrc = ZLIB_TOO_FAR_BACK;
                   break;
                }
-               /* FALLTHROUGH */
+               FALLTHROUGH; /* FALLTHROUGH */
 
             default:
                zlib_message(zlib, 0/*stream error*/);
@@ -2553,7 +2559,7 @@ zlib_run(struct zlib *zlib)
                   list->lengths[i] -= zlib->extra_bytes;
                   list->count = i+1;
                   zlib->idat->idat_list_tail = list;
-                  /* FALLTHROUGH */
+                  FALLTHROUGH; /* FALLTHROUGH */
 
                default:
                   return rc;
@@ -2656,7 +2662,7 @@ zlib_check(struct file *file, png_uint_32 offset)
             /* Truncated stream; unrecoverable, gets converted to ZLIB_FATAL */
             zlib.z.msg = PNGZ_MSG_CAST("[truncated]");
             zlib_message(&zlib, 0/*expected*/);
-            /* FALLTHROUGH */
+            FALLTHROUGH; /* FALLTHROUGH */
 
          default:
             /* Unrecoverable error; skip the chunk; a zlib_message has already
@@ -3324,7 +3330,7 @@ read_callback(png_structp png_ptr, png_bytep buffer, size_t count)
                if (file->state != STATE_IDAT && length > 0)
                   setpos(chunk);
             }
-            /* FALLTHROUGH */
+            FALLTHROUGH; /* FALLTHROUGH */
 
          default:
             assert(chunk != NULL);

--- a/contrib/tools/pngfix.c
+++ b/contrib/tools/pngfix.c
@@ -2405,8 +2405,6 @@ zlib_advance(struct zlib *zlib, png_uint_32 nbytes)
                   endrc = ZLIB_TOO_FAR_BACK;
                   break;
                }
-               FALLTHROUGH; /* FALLTHROUGH */
-
             default:
                zlib_message(zlib, 0/*stream error*/);
                endrc = ZLIB_FATAL;
@@ -2559,8 +2557,6 @@ zlib_run(struct zlib *zlib)
                   list->lengths[i] -= zlib->extra_bytes;
                   list->count = i+1;
                   zlib->idat->idat_list_tail = list;
-                  FALLTHROUGH; /* FALLTHROUGH */
-
                default:
                   return rc;
             }
@@ -2662,8 +2658,6 @@ zlib_check(struct file *file, png_uint_32 offset)
             /* Truncated stream; unrecoverable, gets converted to ZLIB_FATAL */
             zlib.z.msg = PNGZ_MSG_CAST("[truncated]");
             zlib_message(&zlib, 0/*expected*/);
-            FALLTHROUGH; /* FALLTHROUGH */
-
          default:
             /* Unrecoverable error; skip the chunk; a zlib_message has already
              * been output.
@@ -3330,8 +3324,6 @@ read_callback(png_structp png_ptr, png_bytep buffer, size_t count)
                if (file->state != STATE_IDAT && length > 0)
                   setpos(chunk);
             }
-            FALLTHROUGH; /* FALLTHROUGH */
-
          default:
             assert(chunk != NULL);
 

--- a/pngerror.c
+++ b/pngerror.c
@@ -19,9 +19,8 @@
 
 #if defined(PNG_READ_SUPPORTED) || defined(PNG_WRITE_SUPPORTED)
 
-static PNG_FUNCTION(void /* PRIVATE */,
-png_default_error,(png_const_structrp png_ptr, png_const_charp error_message),
-    PNG_NORETURN);
+PNG_FUNCTION(void, png_default_error,(png_const_structrp png_ptr,
+    png_const_charp error_message),PNG_NORETURN static);
 
 #ifdef PNG_WARNINGS_SUPPORTED
 static void /* PRIVATE */
@@ -163,7 +162,7 @@ png_format_number(png_const_charp start, png_charp end, int format,
          case PNG_NUMBER_FORMAT_02u:
             /* Expects at least 2 digits. */
             mincount = 2;
-            /* FALLTHROUGH */
+            PNG_FALLTHROUGH; /* FALLTHROUGH */
 
          case PNG_NUMBER_FORMAT_u:
             *--end = digits[number % 10];
@@ -173,7 +172,7 @@ png_format_number(png_const_charp start, png_charp end, int format,
          case PNG_NUMBER_FORMAT_02x:
             /* This format expects at least two digits */
             mincount = 2;
-            /* FALLTHROUGH */
+            PNG_FALLTHROUGH; /* FALLTHROUGH */
 
          case PNG_NUMBER_FORMAT_x:
             *--end = digits[number & 0xf];
@@ -707,9 +706,9 @@ png_free_jmpbuf(png_structrp png_ptr)
  * function is used by default, or if the program supplies NULL for the
  * error function pointer in png_set_error_fn().
  */
-static PNG_FUNCTION(void /* PRIVATE */,
+PNG_FUNCTION(void /* PRIVATE */,
 png_default_error,(png_const_structrp png_ptr, png_const_charp error_message),
-    PNG_NORETURN)
+    PNG_NORETURN static)
 {
 #ifdef PNG_CONSOLE_IO_SUPPORTED
 #ifdef PNG_ERROR_NUMBERS_SUPPORTED

--- a/pngerror.c
+++ b/pngerror.c
@@ -162,8 +162,6 @@ png_format_number(png_const_charp start, png_charp end, int format,
          case PNG_NUMBER_FORMAT_02u:
             /* Expects at least 2 digits. */
             mincount = 2;
-            PNG_FALLTHROUGH; /* FALLTHROUGH */
-
          case PNG_NUMBER_FORMAT_u:
             *--end = digits[number % 10];
             number /= 10;
@@ -172,8 +170,6 @@ png_format_number(png_const_charp start, png_charp end, int format,
          case PNG_NUMBER_FORMAT_02x:
             /* This format expects at least two digits */
             mincount = 2;
-            PNG_FALLTHROUGH; /* FALLTHROUGH */
-
          case PNG_NUMBER_FORMAT_x:
             *--end = digits[number & 0xf];
             number >>= 4;

--- a/pngpriv.h
+++ b/pngpriv.h
@@ -46,22 +46,6 @@
 
 #define PNGLIB_BUILD /*libpng is being built, not used*/
 
-/* If HAVE_CONFIG_H is defined during the build then the build system must
- * provide an appropriate "config.h" file on the include path.  The header file
- * must provide definitions as required below (search for "HAVE_CONFIG_H");
- * see configure.ac for more details of the requirements.  The macro
- * "PNG_NO_CONFIG_H" is provided for maintainers to test for dependencies on
- * 'configure'; define this macro to prevent the configure build including the
- * configure generated config.h.  Libpng is expected to compile without *any*
- * special build system support on a reasonably ANSI-C compliant system.
- */
-#if defined(HAVE_CONFIG_H) && !defined(PNG_NO_CONFIG_H)
-#  include <config.h>
-
-   /* Pick up the definition of 'restrict' from config.h if it was read: */
-#  define PNG_RESTRICT restrict
-#endif
-
 /* To support symbol prefixing it is necessary to know *before* including png.h
  * whether the fixed point (and maybe other) APIs are exported, because if they
  * are not internal definitions may be required.  This is handled below just
@@ -165,13 +149,12 @@
 
 #ifndef PNG_INTERNAL_FUNCTION
 #  define PNG_INTERNAL_FUNCTION(type, name, args, attributes)\
-      PNG_LINKAGE_FUNCTION PNG_FUNCTION(type, name, args, PNG_EMPTY attributes)
+      PNG_FUNCTION(type, name, args, attributes PNG_LINKAGE_FUNCTION)
 #endif
 
 #ifndef PNG_INTERNAL_CALLBACK
 #  define PNG_INTERNAL_CALLBACK(type, name, args, attributes)\
-      PNG_LINKAGE_CALLBACK PNG_FUNCTION(type, (PNGCBAPI name), args,\
-         PNG_EMPTY attributes)
+      PNG_FUNCTION(type, (PNGCBAPI name), args, attributes PNG_LINKAGE_CALLBACK)
 #endif
 
 /* If floating or fixed point APIs are disabled they may still be compiled
@@ -247,14 +230,41 @@
 #  define PNG_MAX_MALLOC_64K
 #endif
 
+#ifndef PNG_MAYBE_UNUSED
+   /* Unused formal parameter warnings can be silenced by using this macro
+    * to qualify the declaration, but see PNG_UNUSED below.
+    * macro.  Note this is used in the #if code path where the parameter
+    * is not used.
+    */
+#  if PNG_HAS_ATTRIBUTE(maybe_unused)
+#     define PNG_MAYBE_UNUSED PNG_ATTRIBUTE(maybe_unused)
+#  else
+#     define PNG_MAYBE_UNUSED /*maybe unused*/
+#  endif
+#endif
+
 #ifndef PNG_UNUSED
-/* Unused formal parameter warnings are silenced using the following macro
- * which is expected to have no bad effects on performance (optimizing
- * compilers will probably remove it entirely).  Note that if you replace
- * it with something other than whitespace, you must include the terminating
- * semicolon.
- */
+   /* As a better alternative to the above use this macro in (at the end of)
+    * the #if code tree where the parameter is not used.  Note that this macro
+    * includes a ";" if it is defined and the parameter must be a single token.
+    */
 #  define PNG_UNUSED(param) (void)param;
+#endif
+
+#ifndef PNG_FALLTHROUGH
+   /* This notation is used immediately above a switch case label to indicate
+    * that the preceding code "falls through" to the next label.  Some
+    * authorities regard this as a bad thing to do but libpng does it a lot.
+    *
+    * NOTE: this must be used in the form:
+    *
+    *    PNG_FALLTHROUGH;
+    */
+#  if PNG_HAS_ATTRIBUTE(fallthrough)
+#     define PNG_FALLTHROUGH PNG_ATTRIBUTE(fallthrough)
+#  else
+#     define PNG_FALLTHROUGH /* FALLTHROUGH */
+#  endif
 #endif
 
 /* Just a little check that someone hasn't tried to define something

--- a/pngread.c
+++ b/pngread.c
@@ -1918,7 +1918,7 @@ png_create_colormap_entry(png_image_read_control *display,
          {
             case 4:
                entry[afirst ? 0 : 3] = (png_uint_16)alpha;
-               /* FALLTHROUGH */
+               PNG_FALLTHROUGH; /* FALLTHROUGH */
 
             case 3:
                if (alpha < 65535)
@@ -1940,7 +1940,7 @@ png_create_colormap_entry(png_image_read_control *display,
 
             case 2:
                entry[1 ^ afirst] = (png_uint_16)alpha;
-               /* FALLTHROUGH */
+               PNG_FALLTHROUGH; /* FALLTHROUGH */
 
             case 1:
                if (alpha < 65535)
@@ -1969,7 +1969,7 @@ png_create_colormap_entry(png_image_read_control *display,
          {
             case 4:
                entry[afirst ? 0 : 3] = (png_byte)alpha;
-               /* FALLTHROUGH */
+               PNG_FALLTHROUGH; /* FALLTHROUGH */
             case 3:
                entry[afirst + (2 ^ bgr)] = (png_byte)blue;
                entry[afirst + 1] = (png_byte)green;
@@ -1978,7 +1978,7 @@ png_create_colormap_entry(png_image_read_control *display,
 
             case 2:
                entry[1 ^ afirst] = (png_byte)alpha;
-               /* FALLTHROUGH */
+               PNG_FALLTHROUGH; /* FALLTHROUGH */
             case 1:
                entry[afirst] = (png_byte)green;
                break;
@@ -2898,7 +2898,7 @@ png_image_read_colormap(png_voidp argument)
       case P_sRGB:
          /* Change to 8-bit sRGB */
          png_set_alpha_mode_fixed(png_ptr, PNG_ALPHA_PNG, PNG_GAMMA_sRGB);
-         /* FALLTHROUGH */
+         PNG_FALLTHROUGH; /* FALLTHROUGH */
 
       case P_FILE:
          if (png_ptr->bit_depth > 8)

--- a/pngread.c
+++ b/pngread.c
@@ -1918,8 +1918,6 @@ png_create_colormap_entry(png_image_read_control *display,
          {
             case 4:
                entry[afirst ? 0 : 3] = (png_uint_16)alpha;
-               PNG_FALLTHROUGH; /* FALLTHROUGH */
-
             case 3:
                if (alpha < 65535)
                {
@@ -1940,8 +1938,6 @@ png_create_colormap_entry(png_image_read_control *display,
 
             case 2:
                entry[1 ^ afirst] = (png_uint_16)alpha;
-               PNG_FALLTHROUGH; /* FALLTHROUGH */
-
             case 1:
                if (alpha < 65535)
                {
@@ -1969,7 +1965,6 @@ png_create_colormap_entry(png_image_read_control *display,
          {
             case 4:
                entry[afirst ? 0 : 3] = (png_byte)alpha;
-               PNG_FALLTHROUGH; /* FALLTHROUGH */
             case 3:
                entry[afirst + (2 ^ bgr)] = (png_byte)blue;
                entry[afirst + 1] = (png_byte)green;
@@ -1978,7 +1973,6 @@ png_create_colormap_entry(png_image_read_control *display,
 
             case 2:
                entry[1 ^ afirst] = (png_byte)alpha;
-               PNG_FALLTHROUGH; /* FALLTHROUGH */
             case 1:
                entry[afirst] = (png_byte)green;
                break;
@@ -2898,8 +2892,6 @@ png_image_read_colormap(png_voidp argument)
       case P_sRGB:
          /* Change to 8-bit sRGB */
          png_set_alpha_mode_fixed(png_ptr, PNG_ALPHA_PNG, PNG_GAMMA_sRGB);
-         PNG_FALLTHROUGH; /* FALLTHROUGH */
-
       case P_FILE:
          if (png_ptr->bit_depth > 8)
             png_set_scale_16(png_ptr);

--- a/pngrtran.c
+++ b/pngrtran.c
@@ -48,9 +48,7 @@ png_set_crc_action(png_structrp png_ptr, int crit_action, int ancil_action)
       case PNG_CRC_WARN_DISCARD:    /* Not a valid action for critical data */
          png_warning(png_ptr,
              "Can't discard critical data on CRC error");
-         PNG_FALLTHROUGH; /* FALLTHROUGH */
       case PNG_CRC_ERROR_QUIT:                                /* Error/quit */
-
       case PNG_CRC_DEFAULT:
       default:
          png_ptr->flags &= ~PNG_FLAG_CRC_CRITICAL_MASK;
@@ -1251,8 +1249,6 @@ png_init_rgb_transformations(png_structrp png_ptr)
             default:
 
             case 8:
-               PNG_FALLTHROUGH; /*  (Already 8 bits) */ /* FALLTHROUGH */
-
             case 16:
                /* Already a full 16 bits */
                break;

--- a/pngrtran.c
+++ b/pngrtran.c
@@ -48,7 +48,7 @@ png_set_crc_action(png_structrp png_ptr, int crit_action, int ancil_action)
       case PNG_CRC_WARN_DISCARD:    /* Not a valid action for critical data */
          png_warning(png_ptr,
              "Can't discard critical data on CRC error");
-         /* FALLTHROUGH */
+         PNG_FALLTHROUGH; /* FALLTHROUGH */
       case PNG_CRC_ERROR_QUIT:                                /* Error/quit */
 
       case PNG_CRC_DEFAULT:
@@ -1251,7 +1251,7 @@ png_init_rgb_transformations(png_structrp png_ptr)
             default:
 
             case 8:
-               /* FALLTHROUGH */ /*  (Already 8 bits) */
+               PNG_FALLTHROUGH; /*  (Already 8 bits) */ /* FALLTHROUGH */
 
             case 16:
                /* Already a full 16 bits */

--- a/pngrutil.c
+++ b/pngrutil.c
@@ -3104,7 +3104,7 @@ png_handle_unknown(png_structrp png_ptr, png_inforp info_ptr,
          case 2:
             png_ptr->user_chunk_cache_max = 1;
             png_chunk_benign_error(png_ptr, "no space in chunk cache");
-            /* FALLTHROUGH */
+            PNG_FALLTHROUGH; /* FALLTHROUGH */
          case 1:
             /* NOTE: prior to 1.6.0 this case resulted in an unknown critical
              * chunk being skipped, now there will be a hard error below.
@@ -3113,7 +3113,7 @@ png_handle_unknown(png_structrp png_ptr, png_inforp info_ptr,
 
          default: /* not at limit */
             --(png_ptr->user_chunk_cache_max);
-            /* FALLTHROUGH */
+            PNG_FALLTHROUGH; /* FALLTHROUGH */
          case 0: /* no limit */
 #  endif /* USER_LIMITS */
             /* Here when the limit isn't reached or when limits are compiled

--- a/pngrutil.c
+++ b/pngrutil.c
@@ -3104,7 +3104,6 @@ png_handle_unknown(png_structrp png_ptr, png_inforp info_ptr,
          case 2:
             png_ptr->user_chunk_cache_max = 1;
             png_chunk_benign_error(png_ptr, "no space in chunk cache");
-            PNG_FALLTHROUGH; /* FALLTHROUGH */
          case 1:
             /* NOTE: prior to 1.6.0 this case resulted in an unknown critical
              * chunk being skipped, now there will be a hard error below.
@@ -3113,7 +3112,6 @@ png_handle_unknown(png_structrp png_ptr, png_inforp info_ptr,
 
          default: /* not at limit */
             --(png_ptr->user_chunk_cache_max);
-            PNG_FALLTHROUGH; /* FALLTHROUGH */
          case 0: /* no limit */
 #  endif /* USER_LIMITS */
             /* Here when the limit isn't reached or when limits are compiled

--- a/pngwrite.c
+++ b/pngwrite.c
@@ -1043,7 +1043,6 @@ png_set_filter(png_structrp png_ptr, int method, int filters)
          case 6:
          case 7: png_app_error(png_ptr, "Unknown row filter for method 0");
 #endif /* WRITE_FILTER */
-            PNG_FALLTHROUGH; /* FALLTHROUGH */
          case PNG_FILTER_VALUE_NONE:
             png_ptr->do_filter = PNG_FILTER_NONE; break;
 
@@ -1887,7 +1886,6 @@ png_image_set_PLTE(png_image_write_control *display)
                tRNS[i] = entry[afirst ? 0 : 3];
                if (tRNS[i] < 255)
                   num_trans = i+1;
-               PNG_FALLTHROUGH; /* FALLTHROUGH */
             case 3:
                palette[i].blue = entry[afirst + (2 ^ bgr)];
                palette[i].green = entry[afirst + 1];
@@ -1898,7 +1896,6 @@ png_image_set_PLTE(png_image_write_control *display)
                tRNS[i] = entry[1 ^ afirst];
                if (tRNS[i] < 255)
                   num_trans = i+1;
-               PNG_FALLTHROUGH; /* FALLTHROUGH */
             case 1:
                palette[i].blue = palette[i].red = palette[i].green =
                   entry[afirst];

--- a/pngwrite.c
+++ b/pngwrite.c
@@ -1043,7 +1043,7 @@ png_set_filter(png_structrp png_ptr, int method, int filters)
          case 6:
          case 7: png_app_error(png_ptr, "Unknown row filter for method 0");
 #endif /* WRITE_FILTER */
-            /* FALLTHROUGH */
+            PNG_FALLTHROUGH; /* FALLTHROUGH */
          case PNG_FILTER_VALUE_NONE:
             png_ptr->do_filter = PNG_FILTER_NONE; break;
 
@@ -1887,7 +1887,7 @@ png_image_set_PLTE(png_image_write_control *display)
                tRNS[i] = entry[afirst ? 0 : 3];
                if (tRNS[i] < 255)
                   num_trans = i+1;
-               /* FALLTHROUGH */
+               PNG_FALLTHROUGH; /* FALLTHROUGH */
             case 3:
                palette[i].blue = entry[afirst + (2 ^ bgr)];
                palette[i].green = entry[afirst + 1];
@@ -1898,7 +1898,7 @@ png_image_set_PLTE(png_image_write_control *display)
                tRNS[i] = entry[1 ^ afirst];
                if (tRNS[i] < 255)
                   num_trans = i+1;
-               /* FALLTHROUGH */
+               PNG_FALLTHROUGH; /* FALLTHROUGH */
             case 1:
                palette[i].blue = palette[i].red = palette[i].green =
                   entry[afirst];


### PR DESCRIPTION
ISO have recently standardized a way of defining attributes based on the
ISO-C++ syntax standardised in 2011.  This allows removal of the
existing compiler-specific hacks as well as compatibility with C++.  The
latter is important for attributes used in the header files which
declare the libpng API (png.h and descendants.)

This also extends the attribute handling to any compliant C compiler,
not just the three with compiler specific support in the prior code.

The fix also enables removal of the highly idiosyncratic use of specific
comments to indicate "fall through" in case statements; the concept is
now supported by the [[fallthrough]] attribute.

The changes include checks to ensure that the attribute syntax is
supported by the compiler and that the specific attributes are also
supported.

The changes are detailed in these commits:

commit 51b6189d3c21711bbd95538883c0aca3bb61dc67
commit 8942be90442e7a59260b01e49cdb4a3bc50c80b8

Signed-off-by: John Bowler <jbowler@acm.org>
