### PR TITLE
[libpng18] [code cleanup] Remove 10700 checkes where possible.

### DIFF
--- a/contrib/libtests/pngimage.c
+++ b/contrib/libtests/pngimage.c
@@ -46,7 +46,6 @@
 #  define SKIP 0
 #endif
 
-#if PNG_LIBPNG_VER != 10700
    /* READ_PNG and WRITE_PNG were not defined, so: */
 #  ifdef PNG_INFO_IMAGE_SUPPORTED
 #     ifdef PNG_SEQUENTIAL_READ_SUPPORTED
@@ -56,7 +55,6 @@
 #        define PNG_WRITE_PNG_SUPPORTED
 #     endif /* WRITE */
 #  endif /* INFO_IMAGE */
-#endif
 
 #ifdef PNG_READ_PNG_SUPPORTED
 /* If a transform is valid on both read and write this implies that if the

--- a/contrib/libtests/pngstest.c
+++ b/contrib/libtests/pngstest.c
@@ -360,10 +360,8 @@ print_opts(png_uint_32 opts)
       printf(" --sRGB-16bit");
    if (opts & NO_RESEED)
       printf(" --noreseed");
-#if PNG_LIBPNG_VER != 10700 /* else on by default */
    if (opts & GBG_ERROR)
       printf(" --fault-gbg-warning");
-#endif
 }
 
 #define FORMAT_NO_CHANGE 0x80000000 /* additional flag */

--- a/contrib/libtests/pngunknown.c
+++ b/contrib/libtests/pngunknown.c
@@ -98,7 +98,6 @@ typedef png_byte *png_const_bytep;
 #  define png_const_structp png_structp
 #endif
 
-#if PNG_LIBPNG_VER != 10700
    /* Copied from libpng 1.7.0 png.h */
 #define PNG_u2(b1, b2) (((unsigned int)(b1) << 8) + (b2))
 
@@ -142,8 +141,6 @@ typedef png_byte *png_const_bytep;
 #define PNG_CHUNK_PRIVATE(c)      (1 & ((c) >> 21))
 #define PNG_CHUNK_RESERVED(c)     (1 & ((c) >> 13))
 #define PNG_CHUNK_SAFE_TO_COPY(c) (1 & ((c) >>  5))
-
-#endif
 
 #ifdef __cplusplus
 #  define this not_the_cpp_this

--- a/contrib/tools/pngcp.c
+++ b/contrib/tools/pngcp.c
@@ -53,7 +53,6 @@
 #  include "../../png.h"
 #endif
 
-#if PNG_LIBPNG_VER != 10700
    /* READ_PNG and WRITE_PNG were not defined, so: */
 #  ifdef PNG_INFO_IMAGE_SUPPORTED
 #     ifdef PNG_SEQUENTIAL_READ_SUPPORTED
@@ -63,7 +62,6 @@
 #        define PNG_WRITE_PNG_SUPPORTED
 #     endif /* WRITE */
 #  endif /* INFO_IMAGE */
-#endif
 
 #if (defined(PNG_READ_PNG_SUPPORTED)) && (defined(PNG_WRITE_PNG_SUPPORTED))
 #include <stdarg.h>
@@ -400,7 +398,7 @@ struct display
    png_alloc_size_t read_size;
    png_structp      read_pp;
    png_infop        ip;
-#  if PNG_LIBPNG_VER != 10700 && defined PNG_TEXT_SUPPORTED
+#  if defined PNG_TEXT_SUPPORTED
       png_textp     text_ptr; /* stash of text chunks */
       int           num_text;
       int           text_stashed;
@@ -489,7 +487,7 @@ display_init(struct display *dp)
    dp->ip = NULL;
    dp->write_pp = NULL;
    dp->min_windowBits = -1; /* this is an OPTIND, so -1 won't match anything */
-#  if PNG_LIBPNG_VER != 10700 && defined PNG_TEXT_SUPPORTED
+#  if defined PNG_TEXT_SUPPORTED
       dp->text_ptr = NULL;
       dp->num_text = 0;
       dp->text_stashed = 0;
@@ -531,7 +529,7 @@ display_clean(struct display *dp)
    display_clean_write(dp, 1/*freeinfo*/);
    dp->output_file = NULL;
 
-#  if PNG_LIBPNG_VER != 10700 && defined PNG_TEXT_SUPPORTED
+#  if defined PNG_TEXT_SUPPORTED
       /* This is actually created and used by the write code, but only
        * once; it has to be retained for subsequent writes of the same file.
        */
@@ -635,7 +633,7 @@ display_log(struct display *dp, error_level level, const char *fmt, ...)
    }
 }
 
-#if PNG_LIBPNG_VER != 10700 && defined PNG_TEXT_SUPPORTED
+#if defined PNG_TEXT_SUPPORTED
 static void
 text_stash(struct display *dp)
 {
@@ -687,10 +685,7 @@ text_restore(struct display *dp)
 
 #define text_restore(dp) if (dp->text_stashed) text_restore(dp)
 
-#else
-#define text_stash(dp) ((void)0)
-#define text_restore(dp) ((void)0)
-#endif
+#endif /* pre 1.7 */
 
 /* OPTIONS:
  *

--- a/contrib/tools/pngfix.c
+++ b/contrib/tools/pngfix.c
@@ -84,7 +84,6 @@
 #  define aligncastconst(type, value) ((const void*)(value))
 #endif /* __cplusplus */
 
-#if PNG_LIBPNG_VER != 10700
 /* Chunk tags (copied from pngpriv.h) */
 #define PNG_32b(b,s) ((png_uint_32)(b) << (s))
 #define PNG_U32(b1,b2,b3,b4) \
@@ -117,7 +116,6 @@
 #define png_tIME PNG_U32(116,  73,  77,  69)
 #define png_tRNS PNG_U32(116,  82,  78,  83)
 #define png_zTXt PNG_U32(122,  84,  88, 116)
-#endif
 
 /* The 8-byte signature as a pair of 32-bit quantities */
 #define sig1 PNG_U32(137,  80,  78,  71)


### PR DESCRIPTION
This removes certain of the 10700 checks which can safely be removed as
they depend on the major require in libpng-1.7 which is not happening
in libpng-1.8.

The checks in pngvalid.c remain because it may (should) be possible to
fix or partially the underlying libpng bugs in 1.8.  The checks document
what those bugs are and ideally the 10700 branch of the #if's can be
used after a fix.

Signed-off-by: John Bowler <jbowler@acm.org>
