### PR TITLE
bug fix: The change corrects the function png_fp_sub in the file png.c.

### DIFF
--- a/png.c
+++ b/png.c
@@ -1218,7 +1218,7 @@ png_fp_sub(png_int_32 addend0, png_int_32 addend1, int *error)
    else if (addend1 < 0)
    {
       if (0x7fffffff + addend1 >= addend0)
-         return addend0+addend1;
+         return addend0-addend1;
    }
    else
       return addend0;


### PR DESCRIPTION
The code erroneously evalulated addend0+addend1 in the case where
addend1 is less than zero.  The function is meant to subtract the second
argument from the first.
