### PR TITLE
code cleanup: This change removes the blank line from the beginning of libpng source files.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,3 @@
-
 # CMakeLists.txt - CMake lists for libpng
 #
 # Copyright (c) 2018-2024 Cosmin Truta.

--- a/arm/arm_init.c
+++ b/arm/arm_init.c
@@ -1,4 +1,3 @@
-
 /* arm_init.c - NEON optimised filter functions
  *
  * Copyright (c) 2018-2022 Cosmin Truta

--- a/arm/filter_neon.S
+++ b/arm/filter_neon.S
@@ -1,4 +1,3 @@
-
 /* filter_neon.S - placeholder file
  *
  * Copyright (c) 2024 Cosmin Truta

--- a/contrib/examples/README.txt
+++ b/contrib/examples/README.txt
@@ -1,4 +1,3 @@
-
 This directory (contrib/examples) contains examples of libpng usage.
 
 NO COPYRIGHT RIGHTS ARE CLAIMED TO ANY OF THE FILES IN THIS DIRECTORY.

--- a/contrib/libtests/pngimage.c
+++ b/contrib/libtests/pngimage.c
@@ -1,4 +1,3 @@
-
 /* pngimage.c
  *
  * Copyright (c) 2021-2024 Cosmin Truta

--- a/contrib/libtests/pngstest.c
+++ b/contrib/libtests/pngstest.c
@@ -1,4 +1,3 @@
-
 /* pngstest.c
  *
  * Copyright (c) 2021-2024 Cosmin Truta

--- a/contrib/libtests/pngunknown.c
+++ b/contrib/libtests/pngunknown.c
@@ -1,4 +1,3 @@
-
 /* pngunknown.c - test the read side unknown chunk handling
  *
  * Copyright (c) 2021-2024 Cosmin Truta

--- a/contrib/libtests/pngvalid.c
+++ b/contrib/libtests/pngvalid.c
@@ -1,4 +1,3 @@
-
 /* pngvalid.c - validate libpng by constructing then reading png files.
  *
  * Copyright (c) 2021-2024 Cosmin Truta

--- a/contrib/libtests/readpng.c
+++ b/contrib/libtests/readpng.c
@@ -1,4 +1,3 @@
-
 /* readpng.c
  *
  * Copyright (c) 2013 John Cunningham Bowler

--- a/contrib/libtests/tarith.c
+++ b/contrib/libtests/tarith.c
@@ -1,4 +1,3 @@
-
 /* tarith.c
  *
  * Copyright (c) 2021 Cosmin Truta

--- a/contrib/libtests/timepng.c
+++ b/contrib/libtests/timepng.c
@@ -1,4 +1,3 @@
-
 /* timepng.c
  *
  * Copyright (c) 2013,2016 John Cunningham Bowler

--- a/contrib/mips-mmi/linux.c
+++ b/contrib/mips-mmi/linux.c
@@ -1,4 +1,3 @@
-
 /* contrib/mips-mmi/linux.c
  *
  * Copyright (c) 2024 Cosmin Truta

--- a/contrib/mips-msa/linux.c
+++ b/contrib/mips-msa/linux.c
@@ -1,4 +1,3 @@
-
 /* contrib/mips-msa/linux.c
  *
  * Copyright (c) 2020-2023 Cosmin Truta

--- a/contrib/pngminim/README
+++ b/contrib/pngminim/README
@@ -1,4 +1,3 @@
-
 This demonstrates the use of PNG_USER_CONFIG, pngusr.h and pngusr.dfa
 to build minimal decoder, encoder, and progressive reader applications.
 

--- a/contrib/pngminus/CHANGES.txt
+++ b/contrib/pngminus/CHANGES.txt
@@ -1,4 +1,3 @@
-
 pnm2png / png2pnm --- conversion from PBM/PGM/PPM-file to PNG-file
 copyright (C) 1999-2019 by Willem van Schaik <willem at schaik dot com>
 

--- a/contrib/pngminus/LICENSE.txt
+++ b/contrib/pngminus/LICENSE.txt
@@ -1,4 +1,3 @@
-
 pnm2png / png2pnm --- conversion from PBM/PGM/PPM-file to PNG-file
 
 copyright (C) 1999-2019 by Willem van Schaik <willem at schaik dot com>

--- a/contrib/pngsuite/README
+++ b/contrib/pngsuite/README
@@ -1,4 +1,3 @@
-
 pngsuite
 --------
 Copyright (c) Willem van Schaik, 1999, 2011, 2012

--- a/contrib/pngsuite/interlaced/README
+++ b/contrib/pngsuite/interlaced/README
@@ -1,2 +1,1 @@
-
 These images fail the "pngimage-quick" and "pngimage-full" tests.

--- a/example.c
+++ b/example.c
@@ -1,4 +1,3 @@
-
 #if 0 /* in case someone actually tries to compile this */
 
 /* example.c - an example of using libpng

--- a/manuals/libpng-install.txt
+++ b/manuals/libpng-install.txt
@@ -1,4 +1,3 @@
-
     Installing libpng
 
 Contents

--- a/mips/mips_init.c
+++ b/mips/mips_init.c
@@ -1,4 +1,3 @@
-
 /* mips_init.c - MSA optimised filter functions
  *
  * Copyright (c) 2018 Cosmin Truta

--- a/png.c
+++ b/png.c
@@ -1,4 +1,3 @@
-
 /* png.c - location for general purpose libpng functions
  *
  * Copyright (c) 2018-2024 Cosmin Truta

--- a/png.h
+++ b/png.h
@@ -1,4 +1,3 @@
-
 /* png.h - header file for PNG reference library
  *
  * libpng version 1.8.0.git

--- a/pngconf.h
+++ b/pngconf.h
@@ -1,4 +1,3 @@
-
 /* pngconf.h - machine-configurable file for libpng
  *
  * libpng version 1.8.0.git

--- a/pngdebug.h
+++ b/pngdebug.h
@@ -1,4 +1,3 @@
-
 /* pngdebug.h - Debugging macros for libpng, also used in pngtest.c
  *
  * Copyright (c) 2018 Cosmin Truta

--- a/pngerror.c
+++ b/pngerror.c
@@ -1,4 +1,3 @@
-
 /* pngerror.c - stub functions for i/o and memory allocation
  *
  * Copyright (c) 2018-2024 Cosmin Truta

--- a/pngget.c
+++ b/pngget.c
@@ -1,4 +1,3 @@
-
 /* pngget.c - retrieval of values from info struct
  *
  * Copyright (c) 2018-2024 Cosmin Truta

--- a/pnginfo.h
+++ b/pnginfo.h
@@ -1,4 +1,3 @@
-
 /* pnginfo.h - header file for PNG reference library
  *
  * Copyright (c) 2018 Cosmin Truta

--- a/pngmem.c
+++ b/pngmem.c
@@ -1,4 +1,3 @@
-
 /* pngmem.c - stub functions for memory allocation
  *
  * Copyright (c) 2018 Cosmin Truta

--- a/pngpread.c
+++ b/pngpread.c
@@ -1,4 +1,3 @@
-
 /* pngpread.c - read a png file in push mode
  *
  * Copyright (c) 2018-2024 Cosmin Truta

--- a/pngpriv.h
+++ b/pngpriv.h
@@ -1,4 +1,3 @@
-
 /* pngpriv.h - private declarations for use inside libpng
  *
  * Copyright (c) 2018-2024 Cosmin Truta

--- a/pngread.c
+++ b/pngread.c
@@ -1,4 +1,3 @@
-
 /* pngread.c - read a PNG file
  *
  * Copyright (c) 2018-2024 Cosmin Truta

--- a/pngrio.c
+++ b/pngrio.c
@@ -1,4 +1,3 @@
-
 /* pngrio.c - functions for data input
  *
  * Copyright (c) 2018 Cosmin Truta

--- a/pngrtran.c
+++ b/pngrtran.c
@@ -1,4 +1,3 @@
-
 /* pngrtran.c - transforms the data in a row for PNG readers
  *
  * Copyright (c) 2018-2024 Cosmin Truta

--- a/pngrutil.c
+++ b/pngrutil.c
@@ -1,4 +1,3 @@
-
 /* pngrutil.c - utilities to read a PNG file
  *
  * Copyright (c) 2018-2024 Cosmin Truta

--- a/pngset.c
+++ b/pngset.c
@@ -1,4 +1,3 @@
-
 /* pngset.c - storage of image information into info struct
  *
  * Copyright (c) 2018-2024 Cosmin Truta

--- a/pngsimd.c
+++ b/pngsimd.c
@@ -1,4 +1,3 @@
-
 /* pngsimd.c - hardware (cpu/arch) specific code
  *
  * Copyright (c) 2018-2024 Cosmin Truta

--- a/pngstruct.h
+++ b/pngstruct.h
@@ -1,4 +1,3 @@
-
 /* pngstruct.h - header file for PNG reference library
  *
  * Copyright (c) 2018-2024 Cosmin Truta

--- a/pngtarget.h
+++ b/pngtarget.h
@@ -1,4 +1,3 @@
-
 /* pngtarget.h - target configuration file for libpng
  *
  * libpng version 1.6.44.git

--- a/pngtest.c
+++ b/pngtest.c
@@ -1,4 +1,3 @@
-
 /* pngtest.c - a test program for libpng
  *
  * Copyright (c) 2018-2024 Cosmin Truta

--- a/pngtrans.c
+++ b/pngtrans.c
@@ -1,4 +1,3 @@
-
 /* pngtrans.c - transforms the data in a row (used by both readers and writers)
  *
  * Copyright (c) 2018-2024 Cosmin Truta

--- a/pngwio.c
+++ b/pngwio.c
@@ -1,4 +1,3 @@
-
 /* pngwio.c - functions for data output
  *
  * Copyright (c) 2018 Cosmin Truta

--- a/pngwrite.c
+++ b/pngwrite.c
@@ -1,4 +1,3 @@
-
 /* pngwrite.c - general routines to write a PNG file
  *
  * Copyright (c) 2018-2024 Cosmin Truta

--- a/pngwtran.c
+++ b/pngwtran.c
@@ -1,4 +1,3 @@
-
 /* pngwtran.c - transforms the data in a row for PNG writers
  *
  * Copyright (c) 2018 Cosmin Truta

--- a/pngwutil.c
+++ b/pngwutil.c
@@ -1,4 +1,3 @@
-
 /* pngwutil.c - utilities to write a PNG file
  *
  * Copyright (c) 2018-2024 Cosmin Truta

--- a/scripts/descrip.mms
+++ b/scripts/descrip.mms
@@ -1,4 +1,3 @@
-
 cc_defs = /inc=$(ZLIBSRC)
 c_deb =
 

--- a/scripts/intprefix.c
+++ b/scripts/intprefix.c
@@ -1,4 +1,3 @@
-
 /* intprefix.c - generate an unprefixed internal symbol list
  *
  * Copyright (c) 2013-2014 Glenn Randers-Pehrson

--- a/scripts/libpng-config-body.in
+++ b/scripts/libpng-config-body.in
@@ -1,4 +1,3 @@
-
 usage()
 {
     cat <<EOF

--- a/scripts/prefix.c
+++ b/scripts/prefix.c
@@ -1,4 +1,3 @@
-
 /* prefix.c - generate an unprefixed symbol list
  *
  * Copyright (c) 2013-2014 Glenn Randers-Pehrson

--- a/scripts/sym.c
+++ b/scripts/sym.c
@@ -1,4 +1,3 @@
-
 /* sym.c - define format of libpng.sym
  *
  * Copyright (c) 2011-2014 Glenn Randers-Pehrson

--- a/scripts/symbols.c
+++ b/scripts/symbols.c
@@ -1,4 +1,3 @@
-
 /* symbols.c - find all exported symbols
  *
  * Copyright (c) 2011-2014 Glenn Randers-Pehrson

--- a/scripts/vers.c
+++ b/scripts/vers.c
@@ -1,4 +1,3 @@
-
 /* vers.c - define format of libpng.vers
  *
  * Copyright (c) 2011-2014 Glenn Randers-Pehrson


### PR DESCRIPTION
The blank lines are apparently an artefact of an older source control
system.  They are not required and look like errors or accidents because
the format of putting a blank line at the start of files is not in
regular use by software developers.

Signed-off-by: John Bowler <jbowler@acm.org>
