### PR TITLE
dev: Make the use of stdio FILE robust.

### DIFF
--- a/png.h
+++ b/png.h
@@ -1541,9 +1541,17 @@ PNG_REMOVED(209, void, png_set_filter_heuristics_fixed,
  */
 
 #ifdef PNG_STDIO_SUPPORTED
-/* Initialize the input/output for the PNG file to the default functions. */
-PNG_EXPORT(74, void, png_init_io, (png_structrp png_ptr, png_FILE_p fp));
-#endif
+#  if defined(PNG_SEQUENTIAL_READ_SUPPORTED) || defined(PNG_WRITE_SUPPORTED)
+/* Initialize the input/output for the PNG file to use stdio. */
+PNG_EXPORT(74, void, png_init_io, (png_structrp png_ptr, FILE *fp,
+      size_t (*fread)(void *ptr, size_t size, size_t nmemb, FILE*),
+      size_t (*fwrite)(const void *ptr, size_t size, size_t nmemb, FILE*),
+      int (*fflush)(FILE*)));
+
+#define png_init_io(png_ptr, fp)\
+   ((png_init_io)(png_ptr, fp, fread, fwrite, fflush))
+#endif /* SEQUENTIAL_READ || WRITE */
+#endif /* STDIO */
 
 /* Replace the (error and abort), and warning functions with user
  * supplied functions.  If no messages are to be printed you must still
@@ -2977,7 +2985,10 @@ PNG_EXPORT(234, int, png_image_begin_read_from_file, (png_imagep image,
     */
 
 PNG_EXPORT(235, int, png_image_begin_read_from_stdio, (png_imagep image,
-   FILE* file));
+   FILE* file, size_t (*fread)(void *ptr, size_t size, size_t nmemb, FILE*)));
+#define png_image_begin_read_from_stdio(image, file)\
+   ((png_image_begin_read_from_stdio)(image, file, fread))
+
    /* The PNG header is read from the stdio FILE object. */
 #endif /* STDIO */
 
@@ -3051,8 +3062,14 @@ PNG_EXPORT(239, int, png_image_write_to_file, (png_imagep image,
 
 PNG_EXPORT(240, int, png_image_write_to_stdio, (png_imagep image, FILE *file,
    int convert_to_8_bit, const void *buffer, png_int_32 row_stride,
-   const void *colormap));
+   const void *colormap,
+   size_t (*fwrite)(const void *ptr, size_t size, size_t nmemb, FILE*),
+   int (*fflush)(FILE*)));
    /* Write the image to the given (FILE*). */
+
+#define png_image_write_to_stdio(png_ptr, fp, cmap, cvt_to_8, buffer, stride)\
+   ((png_image_write_to_stdio)(png_ptr, fp, cmap, cvt_to_8, buffer, stride,\
+      fwrite, fflush))
 #endif /* SIMPLIFIED_WRITE_STDIO */
 
 /* With all write APIs if image is in one of the linear formats with 16-bit

--- a/pngpriv.h
+++ b/pngpriv.h
@@ -849,23 +849,27 @@ PNG_INTERNAL_FUNCTION(void,png_zfree,(voidpf png_ptr, voidpf ptr),PNG_EMPTY);
  * PNGCBAPI at 1.5.0
  */
 
-PNG_INTERNAL_FUNCTION(void PNGCBAPI,png_default_read_data,(png_structp png_ptr,
-    png_bytep data, size_t length),PNG_EMPTY);
-
 #ifdef PNG_PROGRESSIVE_READ_SUPPORTED
 PNG_INTERNAL_FUNCTION(void PNGCBAPI,png_push_fill_buffer,(png_structp png_ptr,
     png_bytep buffer, size_t length),PNG_EMPTY);
-#endif
+#endif /* PROGRESSIVE_READ */
 
-PNG_INTERNAL_FUNCTION(void PNGCBAPI,png_default_write_data,(png_structp png_ptr,
+#ifdef PNG_STDIO_SUPPORTED
+#  ifdef PNG_SEQUENTIAL_READ_SUPPORTED
+PNG_INTERNAL_FUNCTION(void PNGCBAPI,png_stdio_read,(png_structp png_ptr,
     png_bytep data, size_t length),PNG_EMPTY);
+#  endif /* SEQUENTIAL_READ */
+
+#ifdef PNG_WRITE_SUPPORTED
+PNG_INTERNAL_FUNCTION(void PNGCBAPI,png_stdio_write,(png_structp png_ptr,
+    png_bytep data, size_t length),PNG_EMPTY);
+#endif /* WRITE */
 
 #ifdef PNG_WRITE_FLUSH_SUPPORTED
-#  ifdef PNG_STDIO_SUPPORTED
-PNG_INTERNAL_FUNCTION(void PNGCBAPI,png_default_flush,(png_structp png_ptr),
+PNG_INTERNAL_FUNCTION(void PNGCBAPI,png_stdio_flush,(png_structp png_ptr),
    PNG_EMPTY);
-#  endif
-#endif
+#endif /* WRITE_FLUSH */
+#endif /* STDIO */
 
 /* Reset the CRC variable */
 PNG_INTERNAL_FUNCTION(void,png_reset_crc,(png_structrp png_ptr),PNG_EMPTY);
@@ -1815,8 +1819,11 @@ typedef struct png_control
    png_const_bytep memory;          /* Memory buffer. */
    size_t          size;            /* Size of the memory buffer. */
 
+#  ifdef PNG_STDIO_SUPPORTED
+      FILE     *io_file;            /* FILE* opened by us, not user/app */
+#  endif
+
    unsigned int for_write       :1; /* Otherwise it is a read structure */
-   unsigned int owned_file      :1; /* We own the file in io_ptr */
 } png_control;
 
 /* Return the pointer to the jmp_buf from a png_control: necessary because C

--- a/pngstruct.h
+++ b/pngstruct.h
@@ -155,6 +155,18 @@ struct png_struct_def
    png_rw_ptr write_data_fn;  /* function for writing output data */
    png_rw_ptr read_data_fn;   /* function for reading input data */
    png_voidp io_ptr;          /* ptr to application struct for I/O functions */
+#ifdef PNG_STDIO_SUPPORTED
+   FILE *stdio_ptr;
+#  ifdef PNG_SEQUENTIAL_READ_SUPPORTED
+      size_t (*fread)(void *ptr, size_t size, size_t nmemb, FILE*);
+#  endif /* SEQUENTIAL_READ */
+#  ifdef PNG_WRITE_SUPPORTED
+      size_t (*fwrite)(const void *ptr, size_t size, size_t nmemb, FILE*);
+#     ifdef PNG_WRITE_FLUSH_SUPPORTED
+         int (*fflush)(FILE*);
+#     endif /* WRITE_FLUSH */
+#  endif /* WRITE */
+#endif /* STDIO */
 
 #ifdef PNG_READ_USER_TRANSFORM_SUPPORTED
    png_user_transform_ptr read_user_transform_fn; /* user read transform */


### PR DESCRIPTION
ABI changes:
    The three API functions png_init_io, png_begin_read_from_stdio and
    png_image_write_to_stdio now require the host fread, fwrite and
    fflush functions where appropriate in addition to the host FILE.

    Internally libpng uses the provided functions for all operations on
    the FILE; it does not use the implementations available when libpng
    was built.

API changes:
    The original APIs of the above three functions are now implemented
    as function-like macros which automatically pass the correct ISO-C
    functions.  This ensures that there are no net API changes and that
    the correct arguments are passed.

Build changes:
    The read stdio functionality is now dependent on SEQUENTIAL_READ
    rather than READ.  This is done for clarity; the progressive read
    mechanism does not use FILE.

Internal changes:
    png_struct::io_ptr has been supplemented with png_struct::stdio_ptr
    used when stdio is used directly by libpng for IO as opposed to
    caller-provided callbacks.

    Error checking has been added to detect mismatched use of the stdio
    (png_init_io etc) API with the callback (png_set_read_fn,
    png_set_write_fn APIs.)  Changing from one API to the other
    mid-stream should work but has not been tested and is not currently
    a documented option.

The changes address an issue which is frequently encountered on
Microsoft Windows systems because Windows NT DLLs each have their own
ISO-C hosted environment.  This means that a FILE from one DLL cannot be
used safely from a different DLL unless all access to the object is done
using functionality from the creating DLL.  The problem is more general;
passing objects across DLL or other boundaries is frequently supported
but direct access to those objects' internal structure in the receiving
environment is not safe.  Other such uses were address early on in the
development of libpng, this addresses the main, almost certainly, sole
remaining issue.

The idea of adding additional function pointers png_init_io was
suggested by github.com user pp383 in pull request #208.

Signed-off-by: John Bowler <jbowler@acm.org>
