### PR TITLE
bug: pngimage.c: Disable the check on interlace_method if WRITE_INTERLACE is not supported.

### DIFF
--- a/contrib/libtests/pngimage.c
+++ b/contrib/libtests/pngimage.c
@@ -1016,7 +1016,12 @@ compare_read(struct display *dp, int applied_transforms)
    C(height);
    C(bit_depth);
    C(color_type);
-   C(interlace_method);
+#  ifdef PNG_WRITE_INTERLACING_SUPPORTED
+      /* If write interlace has been disabled the PNG is still written
+       * correctly but as a simple, not interlacedd, PNG.
+       */
+      C(interlace_method);
+#  endif
    C(compression_method);
    C(filter_method);
 


### PR DESCRIPTION
Inside libpng if interlacing a PNG is disabled libpng silently removes
it.  This updates pngimage.c to not check the interlace in the resultant
image, other behavior is still checked.

Signed-off-by: John Bowler <jbowler@acm.org>
