### PR TITLE
fix: Update the cICP implementation yet more

### DIFF
--- a/pngread.c
+++ b/pngread.c
@@ -1,6 +1,6 @@
 /* pngread.c - read a PNG file
  *
- * Copyright (c) 2018-2024 Cosmin Truta
+ * Copyright (c) 2018-2025 Cosmin Truta
  * Copyright (c) 1998-2002,2004,2006-2018 Glenn Randers-Pehrson
  * Copyright (c) 1996-1997 Andreas Dilger
  * Copyright (c) 1995-1996 Guy Eric Schalnat, Group 42, Inc.
@@ -182,6 +182,7 @@ png_read_info(png_structrp png_ptr, png_inforp info_ptr)
       else if (chunk_name == png_cHRM)
          png_handle_cHRM(png_ptr, info_ptr, length);
 #endif
+
 #ifdef PNG_READ_cICP_SUPPORTED
       else if (chunk_name == png_cICP)
          png_handle_cICP(png_ptr, info_ptr, length);
@@ -862,6 +863,11 @@ png_read_end(png_structrp png_ptr, png_inforp info_ptr)
 #ifdef PNG_READ_cHRM_SUPPORTED
       else if (chunk_name == png_cHRM)
          png_handle_cHRM(png_ptr, info_ptr, length);
+#endif
+
+#ifdef PNG_READ_cICP_SUPPORTED
+      else if (chunk_name == png_cICP)
+         png_handle_cICP(png_ptr, info_ptr, length);
 #endif
 
 #ifdef PNG_READ_eXIf_SUPPORTED

--- a/pngset.c
+++ b/pngset.c
@@ -1,6 +1,6 @@
 /* pngset.c - storage of image information into info struct
  *
- * Copyright (c) 2018-2024 Cosmin Truta
+ * Copyright (c) 2018-2025 Cosmin Truta
  * Copyright (c) 1998-2018 Glenn Randers-Pehrson
  * Copyright (c) 1996-1997 Andreas Dilger
  * Copyright (c) 1995-1996 Guy Eric Schalnat, Group 42, Inc.
@@ -1411,6 +1411,7 @@ png_set_keep_unknown_chunks(png_structrp png_ptr, int keep,
       static const png_byte chunks_to_ignore[] = {
          98,  75,  71,  68, '\0',  /* bKGD */
          99,  72,  82,  77, '\0',  /* cHRM */
+         99,  73,  67,  80, '\0',  /* cICP */
         101,  88,  73, 102, '\0',  /* eXIf */
         103,  65,  77,  65, '\0',  /* gAMA */
         104,  73,  83,  84, '\0',  /* hIST */

--- a/pngtest.c
+++ b/pngtest.c
@@ -1,6 +1,6 @@
 /* pngtest.c - a test program for libpng
  *
- * Copyright (c) 2018-2024 Cosmin Truta
+ * Copyright (c) 2018-2025 Cosmin Truta
  * Copyright (c) 1998-2002,2004,2006-2018 Glenn Randers-Pehrson
  * Copyright (c) 1996-1997 Andreas Dilger
  * Copyright (c) 1995-1996 Guy Eric Schalnat, Group 42, Inc.
@@ -1168,6 +1168,21 @@ test_one_file(const char *inname, const char *outname)
 #endif
 #endif /* Floating point */
 #endif /* Fixed point */
+#ifdef PNG_cICP_SUPPORTED
+   {
+      png_byte colour_primaries;
+      png_byte transfer_function;
+      png_byte matrix_coefficients;
+      png_byte video_full_range_flag;
+
+      if (png_get_cICP(read_ptr, read_info_ptr,
+                       &colour_primaries, &transfer_function,
+                       &matrix_coefficients, &video_full_range_flag) != 0)
+         png_set_cICP(write_ptr, write_info_ptr,
+                      colour_primaries, transfer_function,
+                      matrix_coefficients, video_full_range_flag);
+   }
+#endif
 #ifdef PNG_iCCP_SUPPORTED
    {
       png_charp name;
@@ -1204,21 +1219,6 @@ test_one_file(const char *inname, const char *outname)
 
       if (png_get_bKGD(read_ptr, read_info_ptr, &background) != 0)
          png_set_bKGD(write_ptr, write_info_ptr, background);
-   }
-#endif
-#ifdef PNG_cICP_SUPPORTED
-   {
-      png_byte colour_primaries;
-      png_byte transfer_function;
-      png_byte matrix_coefficients;
-      png_byte video_full_range_flag;
-
-      if (png_get_cICP(read_ptr, read_info_ptr,
-                       &colour_primaries, &transfer_function,
-                       &matrix_coefficients, &video_full_range_flag) != 0)
-         png_set_cICP(write_ptr, write_info_ptr,
-                      colour_primaries, transfer_function,
-                      matrix_coefficients, video_full_range_flag);
    }
 #endif
 #ifdef PNG_READ_eXIf_SUPPORTED


### PR DESCRIPTION
For the sake of completeness:
 * Add the cICP entry to the list of known chunks to ignore inside `png_set_keep_unknown_chunks`.
 * Handle cICP in `png_read_end`, alongside cHRM, gAMA, iCCP, sRGB.
 * In pngtest.c, move the cICP test code near cHRM, gaMA, iCCP, sRGB.