### PR TITLE
code cleanup: chunk lengths and allocation limits

### DIFF
--- a/png.c
+++ b/png.c
@@ -278,11 +278,21 @@ png_create_png_struct,(png_const_charp user_png_ver, png_voidp error_ptr,
       create_struct.user_chunk_cache_max = PNG_USER_CHUNK_CACHE_MAX;
 #     endif
 
-#     ifdef PNG_USER_CHUNK_MALLOC_MAX
       /* Added at libpng-1.2.43 and 1.4.1, required only for read but exists
        * in png_struct regardless.
+       *
+       * 1.6.47: ensure that the field is always set to a non-zero value so that
+       * it does not have to be checked when used.
        */
+#     if PNG_USER_CHUNK_MALLOC_MAX > 0 /* default to compile-time limit */
       create_struct.user_chunk_malloc_max = PNG_USER_CHUNK_MALLOC_MAX;
+
+      /* No compile time limit so initialize to the system limit: */
+#     elif (defined PNG_MAX_MALLOC_64K/* legacy system limit */
+      create_struct.user_chunk_malloc_max = 65536U;
+
+#     else                            /* modern system limit SIZE_MAX (C99) */
+      create_struct.user_chunk_malloc_max = PNG_SIZE_MAX;
 #     endif
 #  endif
 

--- a/png.c
+++ b/png.c
@@ -280,9 +280,6 @@ png_create_png_struct,(png_const_charp user_png_ver, png_voidp error_ptr,
 
       /* Added at libpng-1.2.43 and 1.4.1, required only for read but exists
        * in png_struct regardless.
-       *
-       * 1.6.47: ensure that the field is always set to a non-zero value so that
-       * it does not have to be checked when used.
        */
 #     if PNG_USER_CHUNK_MALLOC_MAX > 0 /* default to compile-time limit */
       create_struct.user_chunk_malloc_max = PNG_USER_CHUNK_MALLOC_MAX;

--- a/pngmem.c
+++ b/pngmem.c
@@ -72,30 +72,29 @@ png_malloc_base,(png_const_structrp png_ptr, png_alloc_size_t size),
     * to implement a user memory handler.  This checks to be sure it isn't
     * called with big numbers.
     */
-#ifndef PNG_USER_MEM_SUPPORTED
-   PNG_UNUSED(png_ptr)
-#endif
+#  ifdef PNG_MAX_MALLOC_64K
+      /* This is support for legacy systems which had segmented addressing
+       * limiting the maximum allocation size to 65536.  It takes precedence
+       * over PNG_SIZE_MAX which is set to 65535 on true 16-bit systems.
+       *
+       * TODO: libpng-1.8: finally remove both cases.
+       */
+      if (size > 65536U) return NULL;
+#  endif
 
-   /* Some compilers complain that this is always true.  However, it
-    * can be false when integer overflow happens.
+   /* This is checked too because the system malloc call below takes a (size_t).
     */
-   if (size > 0 && size <= PNG_SIZE_MAX
-#     ifdef PNG_MAX_MALLOC_64K
-         && size <= 65536U
-#     endif
-      )
-   {
-#ifdef PNG_USER_MEM_SUPPORTED
+   if (size > PNG_SIZE_MAX) return NULL;
+
+#  ifdef PNG_USER_MEM_SUPPORTED
       if (png_ptr != NULL && png_ptr->malloc_fn != NULL)
          return png_ptr->malloc_fn(png_constcast(png_structrp,png_ptr), size);
+#  else
+      PNG_UNUSED(png_ptr)
+#  endif
 
-      else
-#endif
-         return malloc((size_t)size); /* checked for truncation above */
-   }
-
-   else
-      return NULL;
+   /* Use the system malloc */
+   return malloc((size_t)/*SAFE*/size); /* checked for truncation above */
 }
 
 #if defined(PNG_TEXT_SUPPORTED) || defined(PNG_sPLT_SUPPORTED) ||\

--- a/pngpread.c
+++ b/pngpread.c
@@ -193,17 +193,8 @@ png_push_read_chunk(png_structrp png_ptr, png_inforp info_ptr)
     */
    if ((png_ptr->mode & PNG_HAVE_CHUNK_HEADER) == 0)
    {
-      png_byte chunk_length[4];
-      png_byte chunk_tag[4];
-
       PNG_PUSH_SAVE_BUFFER_IF_LT(8)
-      png_push_fill_buffer(png_ptr, chunk_length, 4);
-      png_ptr->push_length = png_get_uint_31(png_ptr, chunk_length);
-      png_reset_crc(png_ptr);
-      png_crc_read(png_ptr, chunk_tag, 4);
-      png_ptr->chunk_name = PNG_CHUNK_FROM_STRING(chunk_tag);
-      png_check_chunk_name(png_ptr, png_ptr->chunk_name);
-      png_check_chunk_length(png_ptr, png_ptr->push_length);
+      png_ptr->push_length = png_read_chunk_header(png_ptr);
       png_ptr->mode |= PNG_HAVE_CHUNK_HEADER;
    }
 

--- a/pngset.c
+++ b/pngset.c
@@ -1733,13 +1733,13 @@ png_set_compression_buffer_size(png_structrp png_ptr, size_t size)
    if (png_ptr == NULL)
       return;
 
-   if (size == 0 || size > (uInt)-1)
+   if (size == 0 || size > PNG_UINT_31_MAX)
       png_error(png_ptr, "invalid compression buffer size");
 
 #  ifdef PNG_SEQUENTIAL_READ_SUPPORTED
    if ((png_ptr->mode & PNG_IS_READ_STRUCT) != 0)
    {
-      png_ptr->IDAT_read_size = (uInt)/*SAFE*/size; /* checked above */
+      png_ptr->IDAT_read_size = (png_uint_32)size; /* checked above */
       return;
    }
 #  endif
@@ -1831,9 +1831,10 @@ png_set_chunk_malloc_max(png_structrp png_ptr,
 {
    png_debug(1, "in png_set_chunk_malloc_max");
 
-   /* 1.6.47: make it so that user_chunk_malloc_max is never 0 to avoid checking
-    * everywhere it is used.  Setting this value to 1U will have the effect of
-    * preventing all read-time malloc operations except for reading IDAT.
+   /* pngstruct::user_chunk_malloc_max is initialized to a non-zero value in
+    * png.c.  This API supports '0' for unlimited, make sure the correct
+    * (unlimited) value is set here to avoid a need to check for 0 everywhere
+    * the parameter is used.
     */
    if (png_ptr != NULL)
    {


### PR DESCRIPTION
Internal changes only.

Move chunk length checks to fewer places:

Change png_struct::user_chunk_malloc_max to always have a non-zero value
in order to avoid the need to check for zero in multiple places.

Add png_chunk_max(png_ptr), a function like macro defined in pngpriv.h
which expresses all the previous checks on the various USER_LIMITS and
system limitations.  Replace the code which implemented such checks with
png_chunk_max.

Move the malloc limit length check in png_read_chunk_header to
png_handle_chunk and make it conditional on the chunk type.

Progressive reader: call png_read_chunk_header.

Corect the handling for the pHYs.

Signed-off-by: John Bowler <jbowler@acm.org>
