### PR TITLE
bug fix: png_write_iCCP check on profile length

### DIFF
--- a/pngpriv.h
+++ b/pngpriv.h
@@ -1257,10 +1257,10 @@ PNG_INTERNAL_FUNCTION(void,png_write_eXIf,(png_structrp png_ptr,
 
 #ifdef PNG_WRITE_iCCP_SUPPORTED
 PNG_INTERNAL_FUNCTION(void,png_write_iCCP,(png_structrp png_ptr,
-   png_const_charp name, png_const_bytep profile), PNG_EMPTY);
-   /* The profile must have been previously validated for correctness, the
-    * length comes from the first four bytes.  Only the base, deflate,
-    * compression is supported.
+   png_const_charp name, png_const_bytep profile, png_uint_32 proflen),
+   PNG_EMPTY);
+   /* Writes a previously 'set' profile.  The profile argument is **not**
+    * compressed.
     */
 #endif
 

--- a/pngwrite.c
+++ b/pngwrite.c
@@ -196,7 +196,7 @@ png_write_info_before_PLTE(png_structrp png_ptr, png_const_inforp info_ptr)
          if ((info_ptr->valid & PNG_INFO_iCCP) != 0)
          {
             png_write_iCCP(png_ptr, info_ptr->iccp_name,
-                info_ptr->iccp_profile);
+                info_ptr->iccp_profile, info_ptr->iccp_proflen);
          }
 #  endif
 

--- a/pngwutil.c
+++ b/pngwutil.c
@@ -1150,6 +1150,9 @@ png_write_iCCP(png_structrp png_ptr, png_const_charp name,
    if (profile_len < 132)
       png_error(png_ptr, "ICC profile too short");
 
+   if (png_get_uint_32(profile) != profile_len)
+      png_error(png_ptr, "Incorrect data in iCCP");
+
    temp = (png_uint_32) (*(profile+8));
    if (temp > 3 && (profile_len & 0x03))
       png_error(png_ptr, "ICC profile length invalid (not a multiple of 4)");

--- a/pngwutil.c
+++ b/pngwutil.c
@@ -1132,10 +1132,9 @@ png_write_sRGB(png_structrp png_ptr, int srgb_intent)
 /* Write an iCCP chunk */
 void /* PRIVATE */
 png_write_iCCP(png_structrp png_ptr, png_const_charp name,
-    png_const_bytep profile)
+    png_const_bytep profile, png_uint_32 profile_len)
 {
    png_uint_32 name_len;
-   png_uint_32 profile_len;
    png_byte new_name[81]; /* 1 byte for the compression byte */
    compression_state comp;
    png_uint_32 temp;
@@ -1147,8 +1146,6 @@ png_write_iCCP(png_structrp png_ptr, png_const_charp name,
     */
    if (profile == NULL)
       png_error(png_ptr, "No profile for iCCP chunk"); /* internal error */
-
-   profile_len = png_get_uint_32(profile);
 
    if (profile_len < 132)
       png_error(png_ptr, "ICC profile too short");


### PR DESCRIPTION
Previously png_write_iCCP used the length from the first four bytes of
the profile set by png_set_iCCP rather than the actual data length
recored by png_set_iCCP.  This resulted in a read-beyond-end-of-malloc
bug if the profile data was less than 4 bytes long.

Signed-off-by: John Bowler <jbowler@acm.org>
