### PR TITLE
api(Windows): Remove the ordinals attached to exported functions

### DIFF
--- a/png.h
+++ b/png.h
@@ -890,13 +890,8 @@ typedef PNG_CALLBACK(void, *png_free_ptr, (png_structp, png_voidp));
  * The PNG_EXPORT() and PNG_EXPORTA() macros used below are defined in
  * pngconf.h and in the *.dfn files in the scripts directory.
  *
- *   PNG_EXPORT(ordinal, type, name, (args));
+ *   PNG_EXPORT(type, name, (args));
  *
- *       ordinal:    ordinal that is used while building
- *                   *.def files. The ordinal value is only
- *                   relevant when preprocessing png.h with
- *                   the *.dfn files for building symbol table
- *                   entries, and are removed by pngconf.h.
  *       type:       return type of the function
  *       name:       function name
  *       args:       function arguments, with types
@@ -904,44 +899,44 @@ typedef PNG_CALLBACK(void, *png_free_ptr, (png_structp, png_voidp));
  * When we wish to append attributes to a function prototype we use
  * the PNG_EXPORTA() macro instead.
  *
- *   PNG_EXPORTA(ordinal, type, name, (args), attributes);
+ *   PNG_EXPORTA(type, name, (args), attributes);
  *
- *       ordinal, type, name, and args: same as in PNG_EXPORT().
+ *       type, name, and args: same as in PNG_EXPORT().
  *       attributes: function attributes
  */
 
 /* Returns the version number of the library */
-PNG_EXPORT(1, png_uint_32, png_access_version_number, (void));
+PNG_EXPORT(png_uint_32, png_access_version_number, (void));
 
 /* Tell lib we have already handled the first <num_bytes> magic bytes.
  * Handling more than 8 bytes from the beginning of the file is an error.
  */
-PNG_EXPORT(2, void, png_set_sig_bytes, (png_structrp png_ptr, int num_bytes));
+PNG_EXPORT(void, png_set_sig_bytes, (png_structrp png_ptr, int num_bytes));
 
 /* Check sig[start] through sig[start + num_to_check - 1] to see if it's a
  * PNG file.  Returns zero if the supplied bytes match the 8-byte PNG
  * signature, and non-zero otherwise.  Having num_to_check == 0 or
  * start > 7 will always fail (i.e. return non-zero).
  */
-PNG_EXPORT(3, int, png_sig_cmp, (png_const_bytep sig, size_t start,
+PNG_EXPORT(int, png_sig_cmp, (png_const_bytep sig, size_t start,
     size_t num_to_check));
 
 /* Allocate and initialize png_ptr struct for reading, and any other memory. */
-PNG_EXPORTA(4, png_structp, png_create_read_struct,
+PNG_EXPORTA(png_structp, png_create_read_struct,
     (png_const_charp user_png_ver, png_voidp error_ptr,
     png_error_ptr error_fn, png_error_ptr warn_fn),
     PNG_ALLOCATED);
 
 /* Allocate and initialize png_ptr struct for writing, and any other memory */
-PNG_EXPORTA(5, png_structp, png_create_write_struct,
+PNG_EXPORTA(png_structp, png_create_write_struct,
     (png_const_charp user_png_ver, png_voidp error_ptr, png_error_ptr error_fn,
     png_error_ptr warn_fn),
     PNG_ALLOCATED);
 
-PNG_EXPORT(6, size_t, png_get_compression_buffer_size,
+PNG_EXPORT(size_t, png_get_compression_buffer_size,
     (png_const_structrp png_ptr));
 
-PNG_EXPORT(7, void, png_set_compression_buffer_size, (png_structrp png_ptr,
+PNG_EXPORT(void, png_set_compression_buffer_size, (png_structrp png_ptr,
     size_t size));
 
 /* Moved from pngconf.h in 1.4.0 and modified to ensure setjmp/longjmp
@@ -955,7 +950,7 @@ PNG_EXPORT(7, void, png_set_compression_buffer_size, (png_structrp png_ptr,
  * allocated by the library - the call will return NULL on a mismatch
  * indicating an ABI mismatch.
  */
-PNG_EXPORT(8, jmp_buf*, png_set_longjmp_fn, (png_structrp png_ptr,
+PNG_EXPORT(jmp_buf*, png_set_longjmp_fn, (png_structrp png_ptr,
     png_longjmp_ptr longjmp_fn, size_t jmp_buf_size));
 #  define png_jmpbuf(png_ptr) \
       (*png_set_longjmp_fn((png_ptr), longjmp, (sizeof (jmp_buf))))
@@ -968,22 +963,22 @@ PNG_EXPORT(8, jmp_buf*, png_set_longjmp_fn, (png_structrp png_ptr,
  * will use it; otherwise it will call PNG_ABORT().  This function was
  * added in libpng-1.5.0.
  */
-PNG_EXPORTA(9, void, png_longjmp, (png_const_structrp png_ptr, int val),
+PNG_EXPORTA(void, png_longjmp, (png_const_structrp png_ptr, int val),
     PNG_NORETURN);
 
 #ifdef PNG_READ_SUPPORTED
 /* Reset the compression stream */
-PNG_EXPORTA(10, int, png_reset_zstream, (png_structrp png_ptr), PNG_DEPRECATED);
+PNG_EXPORTA(int, png_reset_zstream, (png_structrp png_ptr), PNG_DEPRECATED);
 #endif
 
 /* New functions added in libpng-1.0.2 (not enabled by default until 1.2.0) */
 #ifdef PNG_USER_MEM_SUPPORTED
-PNG_EXPORTA(11, png_structp, png_create_read_struct_2,
+PNG_EXPORTA(png_structp, png_create_read_struct_2,
     (png_const_charp user_png_ver, png_voidp error_ptr, png_error_ptr error_fn,
     png_error_ptr warn_fn,
     png_voidp mem_ptr, png_malloc_ptr malloc_fn, png_free_ptr free_fn),
     PNG_ALLOCATED);
-PNG_EXPORTA(12, png_structp, png_create_write_struct_2,
+PNG_EXPORTA(png_structp, png_create_write_struct_2,
     (png_const_charp user_png_ver, png_voidp error_ptr, png_error_ptr error_fn,
     png_error_ptr warn_fn,
     png_voidp mem_ptr, png_malloc_ptr malloc_fn, png_free_ptr free_fn),
@@ -991,43 +986,43 @@ PNG_EXPORTA(12, png_structp, png_create_write_struct_2,
 #endif
 
 /* Write the PNG file signature. */
-PNG_EXPORT(13, void, png_write_sig, (png_structrp png_ptr));
+PNG_EXPORT(void, png_write_sig, (png_structrp png_ptr));
 
 /* Write a PNG chunk - size, type, (optional) data, CRC. */
-PNG_EXPORT(14, void, png_write_chunk, (png_structrp png_ptr, png_const_bytep
+PNG_EXPORT(void, png_write_chunk, (png_structrp png_ptr, png_const_bytep
     chunk_name, png_const_bytep data, size_t length));
 
 /* Write the start of a PNG chunk - length and chunk name. */
-PNG_EXPORT(15, void, png_write_chunk_start, (png_structrp png_ptr,
+PNG_EXPORT(void, png_write_chunk_start, (png_structrp png_ptr,
     png_const_bytep chunk_name, png_uint_32 length));
 
 /* Write the data of a PNG chunk started with png_write_chunk_start(). */
-PNG_EXPORT(16, void, png_write_chunk_data, (png_structrp png_ptr,
+PNG_EXPORT(void, png_write_chunk_data, (png_structrp png_ptr,
     png_const_bytep data, size_t length));
 
 /* Finish a chunk started with png_write_chunk_start() (includes CRC). */
-PNG_EXPORT(17, void, png_write_chunk_end, (png_structrp png_ptr));
+PNG_EXPORT(void, png_write_chunk_end, (png_structrp png_ptr));
 
 /* Allocate and initialize the info structure */
-PNG_EXPORTA(18, png_infop, png_create_info_struct, (png_const_structrp png_ptr),
+PNG_EXPORTA(png_infop, png_create_info_struct, (png_const_structrp png_ptr),
     PNG_ALLOCATED);
 
 /* DEPRECATED: this function allowed init structures to be created using the
  * default allocation method (typically malloc).  Use is deprecated in 1.6.0 and
  * the API will be removed in the future.
  */
-PNG_EXPORTA(19, void, png_info_init_3, (png_infopp info_ptr,
+PNG_EXPORTA(void, png_info_init_3, (png_infopp info_ptr,
     size_t png_info_struct_size), PNG_DEPRECATED);
 
 /* Writes all the PNG information before the image. */
-PNG_EXPORT(20, void, png_write_info_before_PLTE,
+PNG_EXPORT(void, png_write_info_before_PLTE,
     (png_structrp png_ptr, png_const_inforp info_ptr));
-PNG_EXPORT(21, void, png_write_info,
+PNG_EXPORT(void, png_write_info,
     (png_structrp png_ptr, png_const_inforp info_ptr));
 
 #ifdef PNG_SEQUENTIAL_READ_SUPPORTED
 /* Read the information before the actual image data. */
-PNG_EXPORT(22, void, png_read_info,
+PNG_EXPORT(void, png_read_info,
     (png_structrp png_ptr, png_inforp info_ptr));
 #endif
 
@@ -1036,46 +1031,46 @@ PNG_EXPORT(22, void, png_read_info,
     * routine.  The original implementation used a 29 character buffer in
     * png_struct, this will be removed in future versions.
     */
-PNG_EXPORT(241, int, png_convert_to_rfc1123_buffer, (char out[29],
+PNG_EXPORT(int, png_convert_to_rfc1123_buffer, (char out[29],
     png_const_timep ptime));
 
 /* Removed from libpng 1.7 onwards; use png_convert_to_rfc1123_buffer. */
-PNG_REMOVED(23, png_const_charp, png_convert_to_rfc1123, (png_structrp png_ptr,
+PNG_REMOVED(png_const_charp, png_convert_to_rfc1123, (png_structrp png_ptr,
     png_const_timep ptime),PNG_DEPRECATED);
 #endif
 
 #ifdef PNG_CONVERT_tIME_SUPPORTED
 /* Convert from a struct tm to png_time */
-PNG_EXPORT(24, void, png_convert_from_struct_tm, (png_timep ptime,
+PNG_EXPORT(void, png_convert_from_struct_tm, (png_timep ptime,
     const struct tm * ttime));
 
 /* Convert from time_t to png_time.  Uses gmtime() */
-PNG_EXPORT(25, void, png_convert_from_time_t, (png_timep ptime, time_t ttime));
+PNG_EXPORT(void, png_convert_from_time_t, (png_timep ptime, time_t ttime));
 #endif /* CONVERT_tIME */
 
 #ifdef PNG_READ_EXPAND_SUPPORTED
 /* Expand data to 24-bit RGB, or 8-bit grayscale, with alpha if available. */
-PNG_EXPORT(26, void, png_set_expand, (png_structrp png_ptr));
-PNG_EXPORT(27, void, png_set_expand_gray_1_2_4_to_8, (png_structrp png_ptr));
-PNG_EXPORT(28, void, png_set_palette_to_rgb, (png_structrp png_ptr));
-PNG_EXPORT(29, void, png_set_tRNS_to_alpha, (png_structrp png_ptr));
+PNG_EXPORT(void, png_set_expand, (png_structrp png_ptr));
+PNG_EXPORT(void, png_set_expand_gray_1_2_4_to_8, (png_structrp png_ptr));
+PNG_EXPORT(void, png_set_palette_to_rgb, (png_structrp png_ptr));
+PNG_EXPORT(void, png_set_tRNS_to_alpha, (png_structrp png_ptr));
 #endif
 
 #ifdef PNG_READ_EXPAND_16_SUPPORTED
 /* Expand to 16-bit channels, forces conversion of palette to RGB and expansion
  * of a tRNS chunk if present.
  */
-PNG_EXPORT(221, void, png_set_expand_16, (png_structrp png_ptr));
+PNG_EXPORT(void, png_set_expand_16, (png_structrp png_ptr));
 #endif
 
 #if defined(PNG_READ_BGR_SUPPORTED) || defined(PNG_WRITE_BGR_SUPPORTED)
 /* Use blue, green, red order for pixels. */
-PNG_EXPORT(30, void, png_set_bgr, (png_structrp png_ptr));
+PNG_EXPORT(void, png_set_bgr, (png_structrp png_ptr));
 #endif
 
 #ifdef PNG_READ_GRAY_TO_RGB_SUPPORTED
 /* Expand the grayscale to 24-bit RGB if necessary. */
-PNG_EXPORT(31, void, png_set_gray_to_rgb, (png_structrp png_ptr));
+PNG_EXPORT(void, png_set_gray_to_rgb, (png_structrp png_ptr));
 #endif
 
 #ifdef PNG_READ_RGB_TO_GRAY_SUPPORTED
@@ -1085,17 +1080,17 @@ PNG_EXPORT(31, void, png_set_gray_to_rgb, (png_structrp png_ptr));
 #define PNG_ERROR_ACTION_ERROR 3
 #define PNG_RGB_TO_GRAY_DEFAULT (-1)/*for red/green coefficients*/
 
-PNG_FP_EXPORT(32, void, png_set_rgb_to_gray, (png_structrp png_ptr,
+PNG_FP_EXPORT(void, png_set_rgb_to_gray, (png_structrp png_ptr,
     int error_action, double red, double green))
-PNG_FIXED_EXPORT(33, void, png_set_rgb_to_gray_fixed, (png_structrp png_ptr,
+PNG_FIXED_EXPORT(void, png_set_rgb_to_gray_fixed, (png_structrp png_ptr,
     int error_action, png_fixed_point red, png_fixed_point green))
 
-PNG_EXPORT(34, png_byte, png_get_rgb_to_gray_status, (png_const_structrp
+PNG_EXPORT(png_byte, png_get_rgb_to_gray_status, (png_const_structrp
     png_ptr));
 #endif
 
 #ifdef PNG_BUILD_GRAYSCALE_PALETTE_SUPPORTED
-PNG_EXPORT(35, void, png_build_grayscale_palette, (int bit_depth,
+PNG_EXPORT(void, png_build_grayscale_palette, (int bit_depth,
     png_colorp palette));
 #endif
 
@@ -1141,9 +1136,9 @@ PNG_EXPORT(35, void, png_build_grayscale_palette, (int bit_depth,
 #define PNG_ALPHA_OPTIMIZED     2 /* 'PNG' for opaque pixels, else 'STANDARD' */
 #define PNG_ALPHA_BROKEN        3 /* the alpha channel is gamma encoded */
 
-PNG_FP_EXPORT(227, void, png_set_alpha_mode, (png_structrp png_ptr, int mode,
+PNG_FP_EXPORT(void, png_set_alpha_mode, (png_structrp png_ptr, int mode,
     double output_gamma))
-PNG_FIXED_EXPORT(228, void, png_set_alpha_mode_fixed, (png_structrp png_ptr,
+PNG_FIXED_EXPORT(void, png_set_alpha_mode_fixed, (png_structrp png_ptr,
     int mode, png_fixed_point output_gamma))
 #endif
 
@@ -1234,50 +1229,50 @@ PNG_FIXED_EXPORT(228, void, png_set_alpha_mode_fixed, (png_structrp png_ptr,
  */
 
 #ifdef PNG_READ_STRIP_ALPHA_SUPPORTED
-PNG_EXPORT(36, void, png_set_strip_alpha, (png_structrp png_ptr));
+PNG_EXPORT(void, png_set_strip_alpha, (png_structrp png_ptr));
 #endif
 
 #if defined(PNG_READ_SWAP_ALPHA_SUPPORTED) || \
     defined(PNG_WRITE_SWAP_ALPHA_SUPPORTED)
-PNG_EXPORT(37, void, png_set_swap_alpha, (png_structrp png_ptr));
+PNG_EXPORT(void, png_set_swap_alpha, (png_structrp png_ptr));
 #endif
 
 #if defined(PNG_READ_INVERT_ALPHA_SUPPORTED) || \
     defined(PNG_WRITE_INVERT_ALPHA_SUPPORTED)
-PNG_EXPORT(38, void, png_set_invert_alpha, (png_structrp png_ptr));
+PNG_EXPORT(void, png_set_invert_alpha, (png_structrp png_ptr));
 #endif
 
 #if defined(PNG_READ_FILLER_SUPPORTED) || defined(PNG_WRITE_FILLER_SUPPORTED)
 /* Add a filler byte to 8-bit or 16-bit Gray or 24-bit or 48-bit RGB images. */
-PNG_EXPORT(39, void, png_set_filler, (png_structrp png_ptr, png_uint_32 filler,
+PNG_EXPORT(void, png_set_filler, (png_structrp png_ptr, png_uint_32 filler,
     int flags));
 /* The values of the PNG_FILLER_ defines should NOT be changed */
 #  define PNG_FILLER_BEFORE 0
 #  define PNG_FILLER_AFTER 1
 /* Add an alpha byte to 8-bit or 16-bit Gray or 24-bit or 48-bit RGB images. */
-PNG_EXPORT(40, void, png_set_add_alpha, (png_structrp png_ptr,
+PNG_EXPORT(void, png_set_add_alpha, (png_structrp png_ptr,
     png_uint_32 filler, int flags));
 #endif /* READ_FILLER || WRITE_FILLER */
 
 #if defined(PNG_READ_SWAP_SUPPORTED) || defined(PNG_WRITE_SWAP_SUPPORTED)
 /* Swap bytes in 16-bit depth files. */
-PNG_EXPORT(41, void, png_set_swap, (png_structrp png_ptr));
+PNG_EXPORT(void, png_set_swap, (png_structrp png_ptr));
 #endif
 
 #if defined(PNG_READ_PACK_SUPPORTED) || defined(PNG_WRITE_PACK_SUPPORTED)
 /* Use 1 byte per pixel in 1, 2, or 4-bit depth files. */
-PNG_EXPORT(42, void, png_set_packing, (png_structrp png_ptr));
+PNG_EXPORT(void, png_set_packing, (png_structrp png_ptr));
 #endif
 
 #if defined(PNG_READ_PACKSWAP_SUPPORTED) || \
     defined(PNG_WRITE_PACKSWAP_SUPPORTED)
 /* Swap packing order of pixels in bytes. */
-PNG_EXPORT(43, void, png_set_packswap, (png_structrp png_ptr));
+PNG_EXPORT(void, png_set_packswap, (png_structrp png_ptr));
 #endif
 
 #if defined(PNG_READ_SHIFT_SUPPORTED) || defined(PNG_WRITE_SHIFT_SUPPORTED)
 /* Converts files to legal bit depths. */
-PNG_EXPORT(44, void, png_set_shift, (png_structrp png_ptr, png_const_color_8p
+PNG_EXPORT(void, png_set_shift, (png_structrp png_ptr, png_const_color_8p
     true_bits));
 #endif
 
@@ -1289,12 +1284,12 @@ PNG_EXPORT(44, void, png_set_shift, (png_structrp png_ptr, png_const_color_8p
  * necessary to call png_read_row or png_read_rows png_get_image_height
  * times for each pass.
 */
-PNG_EXPORT(45, int, png_set_interlace_handling, (png_structrp png_ptr));
+PNG_EXPORT(int, png_set_interlace_handling, (png_structrp png_ptr));
 #endif
 
 #if defined(PNG_READ_INVERT_SUPPORTED) || defined(PNG_WRITE_INVERT_SUPPORTED)
 /* Invert monochrome files */
-PNG_EXPORT(46, void, png_set_invert_mono, (png_structrp png_ptr));
+PNG_EXPORT(void, png_set_invert_mono, (png_structrp png_ptr));
 #endif
 
 #ifdef PNG_READ_BACKGROUND_SUPPORTED
@@ -1303,10 +1298,10 @@ PNG_EXPORT(46, void, png_set_invert_mono, (png_structrp png_ptr));
  * read.  Doing so will result in unexpected behavior and possible warnings or
  * errors if the PNG file contains a bKGD chunk.
  */
-PNG_FP_EXPORT(47, void, png_set_background, (png_structrp png_ptr,
+PNG_FP_EXPORT(void, png_set_background, (png_structrp png_ptr,
     png_const_color_16p background_color, int background_gamma_code,
     int need_expand, double background_gamma))
-PNG_FIXED_EXPORT(215, void, png_set_background_fixed, (png_structrp png_ptr,
+PNG_FIXED_EXPORT(void, png_set_background_fixed, (png_structrp png_ptr,
     png_const_color_16p background_color, int background_gamma_code,
     int need_expand, png_fixed_point background_gamma))
 #endif
@@ -1319,20 +1314,20 @@ PNG_FIXED_EXPORT(215, void, png_set_background_fixed, (png_structrp png_ptr,
 
 #ifdef PNG_READ_SCALE_16_TO_8_SUPPORTED
 /* Scale a 16-bit depth file down to 8-bit, accurately. */
-PNG_EXPORT(229, void, png_set_scale_16, (png_structrp png_ptr));
+PNG_EXPORT(void, png_set_scale_16, (png_structrp png_ptr));
 #endif
 
 #ifdef PNG_READ_STRIP_16_TO_8_SUPPORTED
 #define PNG_READ_16_TO_8_SUPPORTED /* Name prior to 1.5.4 */
 /* Strip the second byte of information from a 16-bit depth file. */
-PNG_EXPORT(48, void, png_set_strip_16, (png_structrp png_ptr));
+PNG_EXPORT(void, png_set_strip_16, (png_structrp png_ptr));
 #endif
 
 #ifdef PNG_READ_QUANTIZE_SUPPORTED
 /* Turn on quantizing, and reduce the palette to the number of colors
  * available.
  */
-PNG_EXPORT(49, void, png_set_quantize, (png_structrp png_ptr,
+PNG_EXPORT(void, png_set_quantize, (png_structrp png_ptr,
     png_colorp palette, int num_palette, int maximum_colors,
     png_const_uint_16p histogram, int full_quantize));
 #endif
@@ -1354,45 +1349,45 @@ PNG_EXPORT(49, void, png_set_quantize, (png_structrp png_ptr,
  * API (floating point or fixed.)  Notice, however, that the 'file_gamma' value
  * is the inverse of a 'screen gamma' value.
  */
-PNG_FP_EXPORT(50, void, png_set_gamma, (png_structrp png_ptr,
+PNG_FP_EXPORT(void, png_set_gamma, (png_structrp png_ptr,
     double screen_gamma, double override_file_gamma))
-PNG_FIXED_EXPORT(208, void, png_set_gamma_fixed, (png_structrp png_ptr,
+PNG_FIXED_EXPORT(void, png_set_gamma_fixed, (png_structrp png_ptr,
     png_fixed_point screen_gamma, png_fixed_point override_file_gamma))
 #endif
 
 #ifdef PNG_WRITE_FLUSH_SUPPORTED
 /* Set how many lines between output flushes - 0 for no flushing */
-PNG_EXPORT(51, void, png_set_flush, (png_structrp png_ptr, int nrows));
+PNG_EXPORT(void, png_set_flush, (png_structrp png_ptr, int nrows));
 /* Flush the current PNG output buffer */
-PNG_EXPORT(52, void, png_write_flush, (png_structrp png_ptr));
+PNG_EXPORT(void, png_write_flush, (png_structrp png_ptr));
 #endif
 
 /* Optional update palette with requested transformations */
-PNG_EXPORT(53, void, png_start_read_image, (png_structrp png_ptr));
+PNG_EXPORT(void, png_start_read_image, (png_structrp png_ptr));
 
 /* Optional call to update the users info structure */
-PNG_EXPORT(54, void, png_read_update_info, (png_structrp png_ptr,
+PNG_EXPORT(void, png_read_update_info, (png_structrp png_ptr,
     png_inforp info_ptr));
 
 #ifdef PNG_SEQUENTIAL_READ_SUPPORTED
 /* Read one or more rows of image data. */
-PNG_EXPORT(55, void, png_read_rows, (png_structrp png_ptr, png_bytepp row,
+PNG_EXPORT(void, png_read_rows, (png_structrp png_ptr, png_bytepp row,
     png_bytepp display_row, png_uint_32 num_rows));
 #endif
 
 #ifdef PNG_SEQUENTIAL_READ_SUPPORTED
 /* Read a row of data. */
-PNG_EXPORT(56, void, png_read_row, (png_structrp png_ptr, png_bytep row,
+PNG_EXPORT(void, png_read_row, (png_structrp png_ptr, png_bytep row,
     png_bytep display_row));
 #endif
 
 #ifdef PNG_SEQUENTIAL_READ_SUPPORTED
 /* Read the whole image into memory at once. */
-PNG_EXPORT(57, void, png_read_image, (png_structrp png_ptr, png_bytepp image));
+PNG_EXPORT(void, png_read_image, (png_structrp png_ptr, png_bytepp image));
 #endif
 
 /* Write a row of image data */
-PNG_EXPORT(58, void, png_write_row, (png_structrp png_ptr,
+PNG_EXPORT(void, png_write_row, (png_structrp png_ptr,
     png_const_bytep row));
 
 /* Write a few rows of image data: (*row) is not written; however, the type
@@ -1400,35 +1395,35 @@ PNG_EXPORT(58, void, png_write_row, (png_structrp png_ptr,
  * of libpng and to allow the 'display_row' array from read_rows to be passed
  * unchanged to write_rows.
  */
-PNG_EXPORT(59, void, png_write_rows, (png_structrp png_ptr, png_bytepp row,
+PNG_EXPORT(void, png_write_rows, (png_structrp png_ptr, png_bytepp row,
     png_uint_32 num_rows));
 
 /* Write the image data */
-PNG_EXPORT(60, void, png_write_image, (png_structrp png_ptr, png_bytepp image));
+PNG_EXPORT(void, png_write_image, (png_structrp png_ptr, png_bytepp image));
 
 /* Write the end of the PNG file. */
-PNG_EXPORT(61, void, png_write_end, (png_structrp png_ptr,
+PNG_EXPORT(void, png_write_end, (png_structrp png_ptr,
     png_inforp info_ptr));
 
 #ifdef PNG_SEQUENTIAL_READ_SUPPORTED
 /* Read the end of the PNG file. */
-PNG_EXPORT(62, void, png_read_end, (png_structrp png_ptr, png_inforp info_ptr));
+PNG_EXPORT(void, png_read_end, (png_structrp png_ptr, png_inforp info_ptr));
 #endif
 
 /* Free any memory associated with the png_info_struct */
-PNG_EXPORT(63, void, png_destroy_info_struct, (png_const_structrp png_ptr,
+PNG_EXPORT(void, png_destroy_info_struct, (png_const_structrp png_ptr,
     png_infopp info_ptr_ptr));
 
 /* Free any memory associated with the png_struct and the png_info_structs */
-PNG_EXPORT(64, void, png_destroy_read_struct, (png_structpp png_ptr_ptr,
+PNG_EXPORT(void, png_destroy_read_struct, (png_structpp png_ptr_ptr,
     png_infopp info_ptr_ptr, png_infopp end_info_ptr_ptr));
 
 /* Free any memory associated with the png_struct and the png_info_structs */
-PNG_EXPORT(65, void, png_destroy_write_struct, (png_structpp png_ptr_ptr,
+PNG_EXPORT(void, png_destroy_write_struct, (png_structpp png_ptr_ptr,
     png_infopp info_ptr_ptr));
 
 /* Set the libpng method of handling chunk CRC errors */
-PNG_EXPORT(66, void, png_set_crc_action, (png_structrp png_ptr, int crit_action,
+PNG_EXPORT(void, png_set_crc_action, (png_structrp png_ptr, int crit_action,
     int ancil_action));
 
 /* Values for png_set_crc_action() say how to handle CRC errors in
@@ -1459,7 +1454,7 @@ PNG_EXPORT(66, void, png_set_crc_action, (png_structrp png_ptr, int crit_action,
 /* Set the filtering method(s) used by libpng.  Currently, the only valid
  * value for "method" is 0.
  */
-PNG_EXPORT(67, void, png_set_filter, (png_structrp png_ptr, int method,
+PNG_EXPORT(void, png_set_filter, (png_structrp png_ptr, int method,
     int filters));
 #endif /* WRITE */
 
@@ -1496,50 +1491,50 @@ PNG_EXPORT(67, void, png_set_filter, (png_structrp png_ptr, int method,
  * these values may not correspond directly to the zlib compression levels.
  */
 #ifdef PNG_WRITE_CUSTOMIZE_COMPRESSION_SUPPORTED
-PNG_EXPORT(69, void, png_set_compression_level, (png_structrp png_ptr,
+PNG_EXPORT(void, png_set_compression_level, (png_structrp png_ptr,
     int level));
 
-PNG_EXPORT(70, void, png_set_compression_mem_level, (png_structrp png_ptr,
+PNG_EXPORT(void, png_set_compression_mem_level, (png_structrp png_ptr,
     int mem_level));
 
-PNG_EXPORT(71, void, png_set_compression_strategy, (png_structrp png_ptr,
+PNG_EXPORT(void, png_set_compression_strategy, (png_structrp png_ptr,
     int strategy));
 
 /* If PNG_WRITE_OPTIMIZE_CMF_SUPPORTED is defined, libpng will use a
  * smaller value of window_bits if it can do so safely.
  */
-PNG_EXPORT(72, void, png_set_compression_window_bits, (png_structrp png_ptr,
+PNG_EXPORT(void, png_set_compression_window_bits, (png_structrp png_ptr,
     int window_bits));
 
-PNG_EXPORT(73, void, png_set_compression_method, (png_structrp png_ptr,
+PNG_EXPORT(void, png_set_compression_method, (png_structrp png_ptr,
     int method));
 #endif /* WRITE_CUSTOMIZE_COMPRESSION */
 
 #ifdef PNG_WRITE_CUSTOMIZE_ZTXT_COMPRESSION_SUPPORTED
 /* Also set zlib parameters for compressing non-IDAT chunks */
-PNG_EXPORT(222, void, png_set_text_compression_level, (png_structrp png_ptr,
+PNG_EXPORT(void, png_set_text_compression_level, (png_structrp png_ptr,
     int level));
 
-PNG_EXPORT(223, void, png_set_text_compression_mem_level, (png_structrp png_ptr,
+PNG_EXPORT(void, png_set_text_compression_mem_level, (png_structrp png_ptr,
     int mem_level));
 
-PNG_EXPORT(224, void, png_set_text_compression_strategy, (png_structrp png_ptr,
+PNG_EXPORT(void, png_set_text_compression_strategy, (png_structrp png_ptr,
     int strategy));
 
 /* If PNG_WRITE_OPTIMIZE_CMF_SUPPORTED is defined, libpng will use a
  * smaller value of window_bits if it can do so safely.
  */
-PNG_EXPORT(225, void, png_set_text_compression_window_bits,
+PNG_EXPORT(void, png_set_text_compression_window_bits,
     (png_structrp png_ptr, int window_bits));
 
-PNG_EXPORT(226, void, png_set_text_compression_method, (png_structrp png_ptr,
+PNG_EXPORT(void, png_set_text_compression_method, (png_structrp png_ptr,
     int method));
 #endif /* WRITE_CUSTOMIZE_ZTXT_COMPRESSION */
 
-PNG_REMOVED(68, void, png_set_filter_heuristics, (png_structrp png_ptr,
+PNG_REMOVED(void, png_set_filter_heuristics, (png_structrp png_ptr,
     int heuristic_method, int num_weights, png_const_doublep filter_weights,
     png_const_doublep filter_costs),PNG_DEPRECATED)
-PNG_REMOVED(209, void, png_set_filter_heuristics_fixed,
+PNG_REMOVED(void, png_set_filter_heuristics_fixed,
     (png_structrp png_ptr, int heuristic_method, int num_weights,
     png_const_fixed_point_p filter_weights,
     png_const_fixed_point_p filter_costs),PNG_DEPRECATED)
@@ -1556,7 +1551,7 @@ PNG_REMOVED(209, void, png_set_filter_heuristics_fixed,
 
 #ifdef PNG_STDIO_SUPPORTED
 /* Initialize the input/output for the PNG file to the default functions. */
-PNG_EXPORT(74, void, png_init_io, (png_structrp png_ptr, png_FILE_p fp));
+PNG_EXPORT(void, png_init_io, (png_structrp png_ptr, png_FILE_p fp));
 #endif
 
 /* Replace the (error and abort), and warning functions with user
@@ -1567,11 +1562,11 @@ PNG_EXPORT(74, void, png_init_io, (png_structrp png_ptr, png_FILE_p fp));
  * default function will be used.
  */
 
-PNG_EXPORT(75, void, png_set_error_fn, (png_structrp png_ptr,
+PNG_EXPORT(void, png_set_error_fn, (png_structrp png_ptr,
     png_voidp error_ptr, png_error_ptr error_fn, png_error_ptr warning_fn));
 
 /* Return the user pointer associated with the error functions */
-PNG_EXPORT(76, png_voidp, png_get_error_ptr, (png_const_structrp png_ptr));
+PNG_EXPORT(png_voidp, png_get_error_ptr, (png_const_structrp png_ptr));
 
 /* Replace the default data output functions with a user supplied one(s).
  * If buffered output is not used, then output_flush_fn can be set to NULL.
@@ -1583,46 +1578,46 @@ PNG_EXPORT(76, png_voidp, png_get_error_ptr, (png_const_structrp png_ptr));
  * default flush function, which uses the standard *FILE structure, will
  * be used.
  */
-PNG_EXPORT(77, void, png_set_write_fn, (png_structrp png_ptr, png_voidp io_ptr,
+PNG_EXPORT(void, png_set_write_fn, (png_structrp png_ptr, png_voidp io_ptr,
     png_rw_ptr write_data_fn, png_flush_ptr output_flush_fn));
 
 /* Replace the default data input function with a user supplied one. */
-PNG_EXPORT(78, void, png_set_read_fn, (png_structrp png_ptr, png_voidp io_ptr,
+PNG_EXPORT(void, png_set_read_fn, (png_structrp png_ptr, png_voidp io_ptr,
     png_rw_ptr read_data_fn));
 
 /* Return the user pointer associated with the I/O functions */
-PNG_EXPORT(79, png_voidp, png_get_io_ptr, (png_const_structrp png_ptr));
+PNG_EXPORT(png_voidp, png_get_io_ptr, (png_const_structrp png_ptr));
 
-PNG_EXPORT(80, void, png_set_read_status_fn, (png_structrp png_ptr,
+PNG_EXPORT(void, png_set_read_status_fn, (png_structrp png_ptr,
     png_read_status_ptr read_row_fn));
 
-PNG_EXPORT(81, void, png_set_write_status_fn, (png_structrp png_ptr,
+PNG_EXPORT(void, png_set_write_status_fn, (png_structrp png_ptr,
     png_write_status_ptr write_row_fn));
 
 #ifdef PNG_USER_MEM_SUPPORTED
 /* Replace the default memory allocation functions with user supplied one(s). */
-PNG_EXPORT(82, void, png_set_mem_fn, (png_structrp png_ptr, png_voidp mem_ptr,
+PNG_EXPORT(void, png_set_mem_fn, (png_structrp png_ptr, png_voidp mem_ptr,
     png_malloc_ptr malloc_fn, png_free_ptr free_fn));
 /* Return the user pointer associated with the memory functions */
-PNG_EXPORT(83, png_voidp, png_get_mem_ptr, (png_const_structrp png_ptr));
+PNG_EXPORT(png_voidp, png_get_mem_ptr, (png_const_structrp png_ptr));
 #endif
 
 #ifdef PNG_READ_USER_TRANSFORM_SUPPORTED
-PNG_EXPORT(84, void, png_set_read_user_transform_fn, (png_structrp png_ptr,
+PNG_EXPORT(void, png_set_read_user_transform_fn, (png_structrp png_ptr,
     png_user_transform_ptr read_user_transform_fn));
 #endif
 
 #ifdef PNG_WRITE_USER_TRANSFORM_SUPPORTED
-PNG_EXPORT(85, void, png_set_write_user_transform_fn, (png_structrp png_ptr,
+PNG_EXPORT(void, png_set_write_user_transform_fn, (png_structrp png_ptr,
     png_user_transform_ptr write_user_transform_fn));
 #endif
 
 #ifdef PNG_USER_TRANSFORM_PTR_SUPPORTED
-PNG_EXPORT(86, void, png_set_user_transform_info, (png_structrp png_ptr,
+PNG_EXPORT(void, png_set_user_transform_info, (png_structrp png_ptr,
     png_voidp user_transform_ptr, int user_transform_depth,
     int user_transform_channels));
 /* Return the user pointer associated with the user transform functions */
-PNG_EXPORT(87, png_voidp, png_get_user_transform_ptr,
+PNG_EXPORT(png_voidp, png_get_user_transform_ptr,
     (png_const_structrp png_ptr));
 #endif
 
@@ -1638,8 +1633,8 @@ PNG_EXPORT(87, png_voidp, png_get_user_transform_ptr,
  * find the output pixel (x,y) given an interlaced sub-image pixel
  * (row,col,pass).  (See below for these macros.)
  */
-PNG_EXPORT(217, png_uint_32, png_get_current_row_number, (png_const_structrp));
-PNG_EXPORT(218, png_byte, png_get_current_pass_number, (png_const_structrp));
+PNG_EXPORT(png_uint_32, png_get_current_row_number, (png_const_structrp));
+PNG_EXPORT(png_byte, png_get_current_pass_number, (png_const_structrp));
 #endif
 
 #ifdef PNG_READ_USER_CHUNKS_SUPPORTED
@@ -1662,28 +1657,28 @@ PNG_EXPORT(218, png_byte, png_get_current_pass_number, (png_const_structrp));
  * See "INTERACTION WITH USER CHUNK CALLBACKS" below for important notes about
  * how this behavior will change in libpng 1.7
  */
-PNG_EXPORT(88, void, png_set_read_user_chunk_fn, (png_structrp png_ptr,
+PNG_EXPORT(void, png_set_read_user_chunk_fn, (png_structrp png_ptr,
     png_voidp user_chunk_ptr, png_user_chunk_ptr read_user_chunk_fn));
 #endif
 
 #ifdef PNG_USER_CHUNKS_SUPPORTED
-PNG_EXPORT(89, png_voidp, png_get_user_chunk_ptr, (png_const_structrp png_ptr));
+PNG_EXPORT(png_voidp, png_get_user_chunk_ptr, (png_const_structrp png_ptr));
 #endif
 
 #ifdef PNG_PROGRESSIVE_READ_SUPPORTED
 /* Sets the function callbacks for the push reader, and a pointer to a
  * user-defined structure available to the callback functions.
  */
-PNG_EXPORT(90, void, png_set_progressive_read_fn, (png_structrp png_ptr,
+PNG_EXPORT(void, png_set_progressive_read_fn, (png_structrp png_ptr,
     png_voidp progressive_ptr, png_progressive_info_ptr info_fn,
     png_progressive_row_ptr row_fn, png_progressive_end_ptr end_fn));
 
 /* Returns the user pointer associated with the push read functions */
-PNG_EXPORT(91, png_voidp, png_get_progressive_ptr,
+PNG_EXPORT(png_voidp, png_get_progressive_ptr,
     (png_const_structrp png_ptr));
 
 /* Function to be called when data becomes available */
-PNG_EXPORT(92, void, png_process_data, (png_structrp png_ptr,
+PNG_EXPORT(void, png_process_data, (png_structrp png_ptr,
     png_inforp info_ptr, png_bytep buffer, size_t buffer_size));
 
 /* A function which may be called *only* within png_process_data to stop the
@@ -1693,7 +1688,7 @@ PNG_EXPORT(92, void, png_process_data, (png_structrp png_ptr,
  * 'save' is set to true the routine will first save all the pending data and
  * will always return 0.
  */
-PNG_EXPORT(219, size_t, png_process_data_pause, (png_structrp, int save));
+PNG_EXPORT(size_t, png_process_data_pause, (png_structrp, int save));
 
 /* A function which may be called *only* outside (after) a call to
  * png_process_data.  It returns the number of bytes of data to skip in the
@@ -1701,39 +1696,39 @@ PNG_EXPORT(219, size_t, png_process_data_pause, (png_structrp, int save));
  * application must skip than number of bytes of input data and pass the
  * following data to the next call to png_process_data.
  */
-PNG_EXPORT(220, png_uint_32, png_process_data_skip, (png_structrp));
+PNG_EXPORT(png_uint_32, png_process_data_skip, (png_structrp));
 
 /* Function that combines rows.  'new_row' is a flag that should come from
  * the callback and be non-NULL if anything needs to be done; the library
  * stores its own version of the new data internally and ignores the passed
  * in value.
  */
-PNG_EXPORT(93, void, png_progressive_combine_row, (png_const_structrp png_ptr,
+PNG_EXPORT(void, png_progressive_combine_row, (png_const_structrp png_ptr,
     png_bytep old_row, png_const_bytep new_row));
 #endif /* PROGRESSIVE_READ */
 
-PNG_EXPORTA(94, png_voidp, png_malloc, (png_const_structrp png_ptr,
+PNG_EXPORTA(png_voidp, png_malloc, (png_const_structrp png_ptr,
     png_alloc_size_t size), PNG_ALLOCATED);
 /* Added at libpng version 1.4.0 */
-PNG_EXPORTA(95, png_voidp, png_calloc, (png_const_structrp png_ptr,
+PNG_EXPORTA(png_voidp, png_calloc, (png_const_structrp png_ptr,
     png_alloc_size_t size), PNG_ALLOCATED);
 
 /* Added at libpng version 1.2.4 */
-PNG_EXPORTA(96, png_voidp, png_malloc_warn, (png_const_structrp png_ptr,
+PNG_EXPORTA(png_voidp, png_malloc_warn, (png_const_structrp png_ptr,
     png_alloc_size_t size), PNG_ALLOCATED);
 
 /* Frees a pointer allocated by png_malloc() */
-PNG_EXPORT(97, void, png_free, (png_const_structrp png_ptr, png_voidp ptr));
+PNG_EXPORT(void, png_free, (png_const_structrp png_ptr, png_voidp ptr));
 
 /* Free data that was allocated internally */
-PNG_EXPORT(98, void, png_free_data, (png_const_structrp png_ptr,
+PNG_EXPORT(void, png_free_data, (png_const_structrp png_ptr,
     png_inforp info_ptr, png_uint_32 free_me, int num));
 
 /* Reassign the responsibility for freeing existing data, whether allocated
  * by libpng or by the application; this works on the png_info structure passed
  * in, without changing the state for other png_info structures.
  */
-PNG_EXPORT(99, void, png_data_freer, (png_const_structrp png_ptr,
+PNG_EXPORT(void, png_data_freer, (png_const_structrp png_ptr,
     png_inforp info_ptr, int freer, png_uint_32 mask));
 
 /* Assignments for png_data_freer */
@@ -1759,35 +1754,35 @@ PNG_EXPORT(99, void, png_data_freer, (png_const_structrp png_ptr,
 #define PNG_FREE_MUL  0x4220U /* PNG_FREE_SPLT|PNG_FREE_TEXT|PNG_FREE_UNKN */
 
 #ifdef PNG_USER_MEM_SUPPORTED
-PNG_EXPORTA(100, png_voidp, png_malloc_default, (png_const_structrp png_ptr,
+PNG_EXPORTA(png_voidp, png_malloc_default, (png_const_structrp png_ptr,
     png_alloc_size_t size), PNG_ALLOCATED PNG_DEPRECATED);
-PNG_EXPORTA(101, void, png_free_default, (png_const_structrp png_ptr,
+PNG_EXPORTA(void, png_free_default, (png_const_structrp png_ptr,
     png_voidp ptr), PNG_DEPRECATED);
 #endif
 
 #ifdef PNG_ERROR_TEXT_SUPPORTED
 /* Fatal error in PNG image of libpng - can't continue */
-PNG_EXPORTA(102, void, png_error, (png_const_structrp png_ptr,
+PNG_EXPORTA(void, png_error, (png_const_structrp png_ptr,
     png_const_charp error_message), PNG_NORETURN);
 
 /* The same, but the chunk name is prepended to the error string. */
-PNG_EXPORTA(103, void, png_chunk_error, (png_const_structrp png_ptr,
+PNG_EXPORTA(void, png_chunk_error, (png_const_structrp png_ptr,
     png_const_charp error_message), PNG_NORETURN);
 
 #else
 /* Fatal error in PNG image of libpng - can't continue */
-PNG_EXPORTA(104, void, png_err, (png_const_structrp png_ptr), PNG_NORETURN);
+PNG_EXPORTA(void, png_err, (png_const_structrp png_ptr), PNG_NORETURN);
 #  define png_error(s1,s2) png_err(s1)
 #  define png_chunk_error(s1,s2) png_err(s1)
 #endif
 
 #ifdef PNG_WARNINGS_SUPPORTED
 /* Non-fatal error in libpng.  Can continue, but may have a problem. */
-PNG_EXPORT(105, void, png_warning, (png_const_structrp png_ptr,
+PNG_EXPORT(void, png_warning, (png_const_structrp png_ptr,
     png_const_charp warning_message));
 
 /* Non-fatal error in libpng, chunk name is prepended to message. */
-PNG_EXPORT(106, void, png_chunk_warning, (png_const_structrp png_ptr,
+PNG_EXPORT(void, png_chunk_warning, (png_const_structrp png_ptr,
     png_const_charp warning_message));
 #else
 #  define png_warning(s1,s2) ((void)(s1))
@@ -1797,16 +1792,16 @@ PNG_EXPORT(106, void, png_chunk_warning, (png_const_structrp png_ptr,
 #ifdef PNG_BENIGN_ERRORS_SUPPORTED
 /* Benign error in libpng.  Can continue, but may have a problem.
  * User can choose whether to handle as a fatal error or as a warning. */
-PNG_EXPORT(107, void, png_benign_error, (png_const_structrp png_ptr,
+PNG_EXPORT(void, png_benign_error, (png_const_structrp png_ptr,
     png_const_charp warning_message));
 
 #ifdef PNG_READ_SUPPORTED
 /* Same, chunk name is prepended to message (only during read) */
-PNG_EXPORT(108, void, png_chunk_benign_error, (png_const_structrp png_ptr,
+PNG_EXPORT(void, png_chunk_benign_error, (png_const_structrp png_ptr,
     png_const_charp warning_message));
 #endif
 
-PNG_EXPORT(109, void, png_set_benign_errors,
+PNG_EXPORT(void, png_set_benign_errors,
     (png_structrp png_ptr, int allowed));
 #else
 #  ifdef PNG_ALLOW_BENIGN_ERRORS
@@ -1831,118 +1826,118 @@ PNG_EXPORT(109, void, png_set_benign_errors,
  * png_info_struct.
  */
 /* Returns "flag" if chunk data is valid in info_ptr. */
-PNG_EXPORT(110, png_uint_32, png_get_valid, (png_const_structrp png_ptr,
+PNG_EXPORT(png_uint_32, png_get_valid, (png_const_structrp png_ptr,
     png_const_inforp info_ptr, png_uint_32 flag));
 
 /* Returns number of bytes needed to hold a transformed row. */
-PNG_EXPORT(111, size_t, png_get_rowbytes, (png_const_structrp png_ptr,
+PNG_EXPORT(size_t, png_get_rowbytes, (png_const_structrp png_ptr,
     png_const_inforp info_ptr));
 
 #ifdef PNG_INFO_IMAGE_SUPPORTED
 /* Returns row_pointers, which is an array of pointers to scanlines that was
  * returned from png_read_png().
  */
-PNG_EXPORT(112, png_bytepp, png_get_rows, (png_const_structrp png_ptr,
+PNG_EXPORT(png_bytepp, png_get_rows, (png_const_structrp png_ptr,
     png_const_inforp info_ptr));
 
 /* Set row_pointers, which is an array of pointers to scanlines for use
  * by png_write_png().
  */
-PNG_EXPORT(113, void, png_set_rows, (png_const_structrp png_ptr,
+PNG_EXPORT(void, png_set_rows, (png_const_structrp png_ptr,
     png_inforp info_ptr, png_bytepp row_pointers));
 #endif
 
 /* Returns number of color channels in image. */
-PNG_EXPORT(114, png_byte, png_get_channels, (png_const_structrp png_ptr,
+PNG_EXPORT(png_byte, png_get_channels, (png_const_structrp png_ptr,
     png_const_inforp info_ptr));
 
 #ifdef PNG_EASY_ACCESS_SUPPORTED
 /* Returns image width in pixels. */
-PNG_EXPORT(115, png_uint_32, png_get_image_width, (png_const_structrp png_ptr,
+PNG_EXPORT(png_uint_32, png_get_image_width, (png_const_structrp png_ptr,
     png_const_inforp info_ptr));
 
 /* Returns image height in pixels. */
-PNG_EXPORT(116, png_uint_32, png_get_image_height, (png_const_structrp png_ptr,
+PNG_EXPORT(png_uint_32, png_get_image_height, (png_const_structrp png_ptr,
     png_const_inforp info_ptr));
 
 /* Returns image bit_depth. */
-PNG_EXPORT(117, png_byte, png_get_bit_depth, (png_const_structrp png_ptr,
+PNG_EXPORT(png_byte, png_get_bit_depth, (png_const_structrp png_ptr,
     png_const_inforp info_ptr));
 
 /* Returns image color_type. */
-PNG_EXPORT(118, png_byte, png_get_color_type, (png_const_structrp png_ptr,
+PNG_EXPORT(png_byte, png_get_color_type, (png_const_structrp png_ptr,
     png_const_inforp info_ptr));
 
 /* Returns image filter_type. */
-PNG_EXPORT(119, png_byte, png_get_filter_type, (png_const_structrp png_ptr,
+PNG_EXPORT(png_byte, png_get_filter_type, (png_const_structrp png_ptr,
     png_const_inforp info_ptr));
 
 /* Returns image interlace_type. */
-PNG_EXPORT(120, png_byte, png_get_interlace_type, (png_const_structrp png_ptr,
+PNG_EXPORT(png_byte, png_get_interlace_type, (png_const_structrp png_ptr,
     png_const_inforp info_ptr));
 
 /* Returns image compression_type. */
-PNG_EXPORT(121, png_byte, png_get_compression_type, (png_const_structrp png_ptr,
+PNG_EXPORT(png_byte, png_get_compression_type, (png_const_structrp png_ptr,
     png_const_inforp info_ptr));
 
 /* Returns image resolution in pixels per meter, from pHYs chunk data. */
-PNG_EXPORT(122, png_uint_32, png_get_pixels_per_meter,
+PNG_EXPORT(png_uint_32, png_get_pixels_per_meter,
     (png_const_structrp png_ptr, png_const_inforp info_ptr));
-PNG_EXPORT(123, png_uint_32, png_get_x_pixels_per_meter,
+PNG_EXPORT(png_uint_32, png_get_x_pixels_per_meter,
     (png_const_structrp png_ptr, png_const_inforp info_ptr));
-PNG_EXPORT(124, png_uint_32, png_get_y_pixels_per_meter,
+PNG_EXPORT(png_uint_32, png_get_y_pixels_per_meter,
     (png_const_structrp png_ptr, png_const_inforp info_ptr));
 
 /* Returns pixel aspect ratio, computed from pHYs chunk data.  */
-PNG_FP_EXPORT(125, float, png_get_pixel_aspect_ratio,
+PNG_FP_EXPORT(float, png_get_pixel_aspect_ratio,
     (png_const_structrp png_ptr, png_const_inforp info_ptr))
-PNG_FIXED_EXPORT(210, png_fixed_point, png_get_pixel_aspect_ratio_fixed,
+PNG_FIXED_EXPORT(png_fixed_point, png_get_pixel_aspect_ratio_fixed,
     (png_const_structrp png_ptr, png_const_inforp info_ptr))
 
 /* Returns image x, y offset in pixels or microns, from oFFs chunk data. */
-PNG_EXPORT(126, png_int_32, png_get_x_offset_pixels,
+PNG_EXPORT(png_int_32, png_get_x_offset_pixels,
     (png_const_structrp png_ptr, png_const_inforp info_ptr));
-PNG_EXPORT(127, png_int_32, png_get_y_offset_pixels,
+PNG_EXPORT(png_int_32, png_get_y_offset_pixels,
     (png_const_structrp png_ptr, png_const_inforp info_ptr));
-PNG_EXPORT(128, png_int_32, png_get_x_offset_microns,
+PNG_EXPORT(png_int_32, png_get_x_offset_microns,
     (png_const_structrp png_ptr, png_const_inforp info_ptr));
-PNG_EXPORT(129, png_int_32, png_get_y_offset_microns,
+PNG_EXPORT(png_int_32, png_get_y_offset_microns,
     (png_const_structrp png_ptr, png_const_inforp info_ptr));
 
 #endif /* EASY_ACCESS */
 
 #ifdef PNG_READ_SUPPORTED
 /* Returns pointer to signature string read from PNG header */
-PNG_EXPORT(130, png_const_bytep, png_get_signature, (png_const_structrp png_ptr,
+PNG_EXPORT(png_const_bytep, png_get_signature, (png_const_structrp png_ptr,
     png_const_inforp info_ptr));
 #endif
 
 #ifdef PNG_bKGD_SUPPORTED
-PNG_EXPORT(131, png_uint_32, png_get_bKGD, (png_const_structrp png_ptr,
+PNG_EXPORT(png_uint_32, png_get_bKGD, (png_const_structrp png_ptr,
     png_inforp info_ptr, png_color_16p *background));
 #endif
 
 #ifdef PNG_bKGD_SUPPORTED
-PNG_EXPORT(132, void, png_set_bKGD, (png_const_structrp png_ptr,
+PNG_EXPORT(void, png_set_bKGD, (png_const_structrp png_ptr,
     png_inforp info_ptr, png_const_color_16p background));
 #endif
 
 #ifdef PNG_cHRM_SUPPORTED
-PNG_FP_EXPORT(133, png_uint_32, png_get_cHRM, (png_const_structrp png_ptr,
+PNG_FP_EXPORT(png_uint_32, png_get_cHRM, (png_const_structrp png_ptr,
     png_const_inforp info_ptr, double *white_x, double *white_y, double *red_x,
     double *red_y, double *green_x, double *green_y, double *blue_x,
     double *blue_y))
-PNG_FP_EXPORT(230, png_uint_32, png_get_cHRM_XYZ, (png_const_structrp png_ptr,
+PNG_FP_EXPORT(png_uint_32, png_get_cHRM_XYZ, (png_const_structrp png_ptr,
     png_const_inforp info_ptr, double *red_X, double *red_Y, double *red_Z,
     double *green_X, double *green_Y, double *green_Z, double *blue_X,
     double *blue_Y, double *blue_Z))
-PNG_FIXED_EXPORT(134, png_uint_32, png_get_cHRM_fixed,
+PNG_FIXED_EXPORT(png_uint_32, png_get_cHRM_fixed,
     (png_const_structrp png_ptr, png_const_inforp info_ptr,
     png_fixed_point *int_white_x, png_fixed_point *int_white_y,
     png_fixed_point *int_red_x, png_fixed_point *int_red_y,
     png_fixed_point *int_green_x, png_fixed_point *int_green_y,
     png_fixed_point *int_blue_x, png_fixed_point *int_blue_y))
-PNG_FIXED_EXPORT(231, png_uint_32, png_get_cHRM_XYZ_fixed,
+PNG_FIXED_EXPORT(png_uint_32, png_get_cHRM_XYZ_fixed,
     (png_const_structrp png_ptr, png_const_inforp info_ptr,
     png_fixed_point *int_red_X, png_fixed_point *int_red_Y,
     png_fixed_point *int_red_Z, png_fixed_point *int_green_X,
@@ -1952,21 +1947,21 @@ PNG_FIXED_EXPORT(231, png_uint_32, png_get_cHRM_XYZ_fixed,
 #endif
 
 #ifdef PNG_cHRM_SUPPORTED
-PNG_FP_EXPORT(135, void, png_set_cHRM, (png_const_structrp png_ptr,
+PNG_FP_EXPORT(void, png_set_cHRM, (png_const_structrp png_ptr,
     png_inforp info_ptr,
     double white_x, double white_y, double red_x, double red_y, double green_x,
     double green_y, double blue_x, double blue_y))
-PNG_FP_EXPORT(232, void, png_set_cHRM_XYZ, (png_const_structrp png_ptr,
+PNG_FP_EXPORT(void, png_set_cHRM_XYZ, (png_const_structrp png_ptr,
     png_inforp info_ptr, double red_X, double red_Y, double red_Z,
     double green_X, double green_Y, double green_Z, double blue_X,
     double blue_Y, double blue_Z))
-PNG_FIXED_EXPORT(136, void, png_set_cHRM_fixed, (png_const_structrp png_ptr,
+PNG_FIXED_EXPORT(void, png_set_cHRM_fixed, (png_const_structrp png_ptr,
     png_inforp info_ptr, png_fixed_point int_white_x,
     png_fixed_point int_white_y, png_fixed_point int_red_x,
     png_fixed_point int_red_y, png_fixed_point int_green_x,
     png_fixed_point int_green_y, png_fixed_point int_blue_x,
     png_fixed_point int_blue_y))
-PNG_FIXED_EXPORT(233, void, png_set_cHRM_XYZ_fixed, (png_const_structrp png_ptr,
+PNG_FIXED_EXPORT(void, png_set_cHRM_XYZ_fixed, (png_const_structrp png_ptr,
     png_inforp info_ptr, png_fixed_point int_red_X, png_fixed_point int_red_Y,
     png_fixed_point int_red_Z, png_fixed_point int_green_X,
     png_fixed_point int_green_Y, png_fixed_point int_green_Z,
@@ -1975,24 +1970,24 @@ PNG_FIXED_EXPORT(233, void, png_set_cHRM_XYZ_fixed, (png_const_structrp png_ptr,
 #endif
 
 #ifdef PNG_cICP_SUPPORTED
-PNG_EXPORT(250, png_uint_32, png_get_cICP, (png_const_structrp png_ptr,
+PNG_EXPORT(png_uint_32, png_get_cICP, (png_const_structrp png_ptr,
     png_const_inforp info_ptr, png_bytep colour_primaries,
     png_bytep transfer_function, png_bytep matrix_coefficients,
     png_bytep video_full_range_flag));
 #endif
 
 #ifdef PNG_cICP_SUPPORTED
-PNG_EXPORT(251, void, png_set_cICP, (png_const_structrp png_ptr,
+PNG_EXPORT(void, png_set_cICP, (png_const_structrp png_ptr,
     png_inforp info_ptr, png_byte colour_primaries,
     png_byte transfer_function, png_byte matrix_coefficients,
     png_byte video_full_range_flag));
 #endif
 
 #ifdef PNG_cLLI_SUPPORTED
-PNG_FP_EXPORT(252, png_uint_32, png_get_cLLI, (png_const_structrp png_ptr,
+PNG_FP_EXPORT(png_uint_32, png_get_cLLI, (png_const_structrp png_ptr,
          png_const_inforp info_ptr, double *maximum_content_light_level,
          double *maximum_frame_average_light_level))
-PNG_FIXED_EXPORT(253, png_uint_32, png_get_cLLI_fixed,
+PNG_FIXED_EXPORT(png_uint_32, png_get_cLLI_fixed,
     (png_const_structrp png_ptr, png_const_inforp info_ptr,
     /* The values below are in cd/m2 (nits) and are scaled by 10,000; not
      * 100,000 as in the case of png_fixed_point.
@@ -2002,10 +1997,10 @@ PNG_FIXED_EXPORT(253, png_uint_32, png_get_cLLI_fixed,
 #endif
 
 #ifdef PNG_cLLI_SUPPORTED
-PNG_FP_EXPORT(254, void, png_set_cLLI, (png_const_structrp png_ptr,
+PNG_FP_EXPORT(void, png_set_cLLI, (png_const_structrp png_ptr,
          png_inforp info_ptr, double maximum_content_light_level,
          double maximum_frame_average_light_level))
-PNG_FIXED_EXPORT(255, void, png_set_cLLI_fixed, (png_const_structrp png_ptr,
+PNG_FIXED_EXPORT(void, png_set_cLLI_fixed, (png_const_structrp png_ptr,
     png_inforp info_ptr,
     /* The values below are in cd/m2 (nits) and are scaled by 10,000; not
      * 100,000 as in the case of png_fixed_point.
@@ -2015,51 +2010,51 @@ PNG_FIXED_EXPORT(255, void, png_set_cLLI_fixed, (png_const_structrp png_ptr,
 #endif
 
 #ifdef PNG_eXIf_SUPPORTED
-PNG_REMOVED(246, png_uint_32, png_get_eXIf, (png_const_structrp png_ptr,
+PNG_REMOVED(png_uint_32, png_get_eXIf, (png_const_structrp png_ptr,
     png_inforp info_ptr, png_bytep *exif),PNG_DEPRECATED);
-PNG_REMOVED(247, void, png_set_eXIf, (png_const_structrp png_ptr,
+PNG_REMOVED(void, png_set_eXIf, (png_const_structrp png_ptr,
     png_inforp info_ptr, png_bytep exif),PNG_DEPRECATED);
 
-PNG_EXPORT(248, png_uint_32, png_get_eXIf_1, (png_const_structrp png_ptr,
+PNG_EXPORT(png_uint_32, png_get_eXIf_1, (png_const_structrp png_ptr,
     png_const_inforp info_ptr, png_uint_32 *num_exif, png_bytep *exif));
-PNG_EXPORT(249, void, png_set_eXIf_1, (png_const_structrp png_ptr,
+PNG_EXPORT(void, png_set_eXIf_1, (png_const_structrp png_ptr,
     png_inforp info_ptr, png_uint_32 num_exif, png_bytep exif));
 #endif
 
 #ifdef PNG_gAMA_SUPPORTED
-PNG_FP_EXPORT(137, png_uint_32, png_get_gAMA, (png_const_structrp png_ptr,
+PNG_FP_EXPORT(png_uint_32, png_get_gAMA, (png_const_structrp png_ptr,
     png_const_inforp info_ptr, double *file_gamma))
-PNG_FIXED_EXPORT(138, png_uint_32, png_get_gAMA_fixed,
+PNG_FIXED_EXPORT(png_uint_32, png_get_gAMA_fixed,
     (png_const_structrp png_ptr, png_const_inforp info_ptr,
     png_fixed_point *int_file_gamma))
 #endif
 
 #ifdef PNG_gAMA_SUPPORTED
-PNG_FP_EXPORT(139, void, png_set_gAMA, (png_const_structrp png_ptr,
+PNG_FP_EXPORT(void, png_set_gAMA, (png_const_structrp png_ptr,
     png_inforp info_ptr, double file_gamma))
-PNG_FIXED_EXPORT(140, void, png_set_gAMA_fixed, (png_const_structrp png_ptr,
+PNG_FIXED_EXPORT(void, png_set_gAMA_fixed, (png_const_structrp png_ptr,
     png_inforp info_ptr, png_fixed_point int_file_gamma))
 #endif
 
 #ifdef PNG_hIST_SUPPORTED
-PNG_EXPORT(141, png_uint_32, png_get_hIST, (png_const_structrp png_ptr,
+PNG_EXPORT(png_uint_32, png_get_hIST, (png_const_structrp png_ptr,
     png_inforp info_ptr, png_uint_16p *hist));
-PNG_EXPORT(142, void, png_set_hIST, (png_const_structrp png_ptr,
+PNG_EXPORT(void, png_set_hIST, (png_const_structrp png_ptr,
     png_inforp info_ptr, png_const_uint_16p hist));
 #endif
 
-PNG_EXPORT(143, png_uint_32, png_get_IHDR, (png_const_structrp png_ptr,
+PNG_EXPORT(png_uint_32, png_get_IHDR, (png_const_structrp png_ptr,
     png_const_inforp info_ptr, png_uint_32 *width, png_uint_32 *height,
     int *bit_depth, int *color_type, int *interlace_method,
     int *compression_method, int *filter_method));
 
-PNG_EXPORT(144, void, png_set_IHDR, (png_const_structrp png_ptr,
+PNG_EXPORT(void, png_set_IHDR, (png_const_structrp png_ptr,
     png_inforp info_ptr, png_uint_32 width, png_uint_32 height, int bit_depth,
     int color_type, int interlace_method, int compression_method,
     int filter_method));
 
 #ifdef PNG_mDCV_SUPPORTED
-PNG_FP_EXPORT(256, png_uint_32, png_get_mDCV, (png_const_structrp png_ptr,
+PNG_FP_EXPORT(png_uint_32, png_get_mDCV, (png_const_structrp png_ptr,
     png_const_inforp info_ptr,
     /* The chromaticities of the mastering display.  As cHRM, but independent of
      * the encoding endpoints in cHRM, or cICP, or iCCP.  These values will
@@ -2071,7 +2066,7 @@ PNG_FP_EXPORT(256, png_uint_32, png_get_mDCV, (png_const_structrp png_ptr,
     double *mastering_display_maximum_luminance,
     double *mastering_display_minimum_luminance))
 
-PNG_FIXED_EXPORT(257, png_uint_32, png_get_mDCV_fixed,
+PNG_FIXED_EXPORT(png_uint_32, png_get_mDCV_fixed,
     (png_const_structrp png_ptr, png_const_inforp info_ptr,
     png_fixed_point *int_white_x, png_fixed_point *int_white_y,
     png_fixed_point *int_red_x, png_fixed_point *int_red_y,
@@ -2085,7 +2080,7 @@ PNG_FIXED_EXPORT(257, png_uint_32, png_get_mDCV_fixed,
 #endif
 
 #ifdef PNG_mDCV_SUPPORTED
-PNG_FP_EXPORT(258, void, png_set_mDCV, (png_const_structrp png_ptr,
+PNG_FP_EXPORT(void, png_set_mDCV, (png_const_structrp png_ptr,
     png_inforp info_ptr,
     /* The chromaticities of the mastering display.  As cHRM, but independent of
      * the encoding endpoints in cHRM, or cICP, or iCCP.
@@ -2096,7 +2091,7 @@ PNG_FP_EXPORT(258, void, png_set_mDCV, (png_const_structrp png_ptr,
     double mastering_display_maximum_luminance,
     double mastering_display_minimum_luminance))
 
-PNG_FIXED_EXPORT(259, void, png_set_mDCV_fixed, (png_const_structrp png_ptr,
+PNG_FIXED_EXPORT(void, png_set_mDCV_fixed, (png_const_structrp png_ptr,
     png_inforp info_ptr,
     /* The admissible range of these values is not the full range of a PNG
      * fixed point value.  Negative values cannot be encoded and the maximum
@@ -2113,94 +2108,94 @@ PNG_FIXED_EXPORT(259, void, png_set_mDCV_fixed, (png_const_structrp png_ptr,
 #endif
 
 #ifdef PNG_oFFs_SUPPORTED
-PNG_EXPORT(145, png_uint_32, png_get_oFFs, (png_const_structrp png_ptr,
+PNG_EXPORT(png_uint_32, png_get_oFFs, (png_const_structrp png_ptr,
    png_const_inforp info_ptr, png_int_32 *offset_x, png_int_32 *offset_y,
    int *unit_type));
 #endif
 
 #ifdef PNG_oFFs_SUPPORTED
-PNG_EXPORT(146, void, png_set_oFFs, (png_const_structrp png_ptr,
+PNG_EXPORT(void, png_set_oFFs, (png_const_structrp png_ptr,
     png_inforp info_ptr, png_int_32 offset_x, png_int_32 offset_y,
     int unit_type));
 #endif
 
 #ifdef PNG_pCAL_SUPPORTED
-PNG_EXPORT(147, png_uint_32, png_get_pCAL, (png_const_structrp png_ptr,
+PNG_EXPORT(png_uint_32, png_get_pCAL, (png_const_structrp png_ptr,
     png_inforp info_ptr, png_charp *purpose, png_int_32 *X0,
     png_int_32 *X1, int *type, int *nparams, png_charp *units,
     png_charpp *params));
 #endif
 
 #ifdef PNG_pCAL_SUPPORTED
-PNG_EXPORT(148, void, png_set_pCAL, (png_const_structrp png_ptr,
+PNG_EXPORT(void, png_set_pCAL, (png_const_structrp png_ptr,
     png_inforp info_ptr, png_const_charp purpose, png_int_32 X0, png_int_32 X1,
     int type, int nparams, png_const_charp units, png_charpp params));
 #endif
 
 #ifdef PNG_pHYs_SUPPORTED
-PNG_EXPORT(149, png_uint_32, png_get_pHYs, (png_const_structrp png_ptr,
+PNG_EXPORT(png_uint_32, png_get_pHYs, (png_const_structrp png_ptr,
     png_const_inforp info_ptr, png_uint_32 *res_x, png_uint_32 *res_y,
     int *unit_type));
 #endif
 
 #ifdef PNG_pHYs_SUPPORTED
-PNG_EXPORT(150, void, png_set_pHYs, (png_const_structrp png_ptr,
+PNG_EXPORT(void, png_set_pHYs, (png_const_structrp png_ptr,
     png_inforp info_ptr, png_uint_32 res_x, png_uint_32 res_y, int unit_type));
 #endif
 
-PNG_EXPORT(151, png_uint_32, png_get_PLTE, (png_const_structrp png_ptr,
+PNG_EXPORT(png_uint_32, png_get_PLTE, (png_const_structrp png_ptr,
    png_inforp info_ptr, png_colorp *palette, int *num_palette));
 
-PNG_EXPORT(152, void, png_set_PLTE, (png_structrp png_ptr,
+PNG_EXPORT(void, png_set_PLTE, (png_structrp png_ptr,
     png_inforp info_ptr, png_const_colorp palette, int num_palette));
 
 #ifdef PNG_sBIT_SUPPORTED
-PNG_EXPORT(153, png_uint_32, png_get_sBIT, (png_const_structrp png_ptr,
+PNG_EXPORT(png_uint_32, png_get_sBIT, (png_const_structrp png_ptr,
     png_inforp info_ptr, png_color_8p *sig_bit));
 #endif
 
 #ifdef PNG_sBIT_SUPPORTED
-PNG_EXPORT(154, void, png_set_sBIT, (png_const_structrp png_ptr,
+PNG_EXPORT(void, png_set_sBIT, (png_const_structrp png_ptr,
     png_inforp info_ptr, png_const_color_8p sig_bit));
 #endif
 
 #ifdef PNG_sRGB_SUPPORTED
-PNG_EXPORT(155, png_uint_32, png_get_sRGB, (png_const_structrp png_ptr,
+PNG_EXPORT(png_uint_32, png_get_sRGB, (png_const_structrp png_ptr,
     png_const_inforp info_ptr, int *file_srgb_intent));
 #endif
 
 #ifdef PNG_sRGB_SUPPORTED
-PNG_EXPORT(156, void, png_set_sRGB, (png_const_structrp png_ptr,
+PNG_EXPORT(void, png_set_sRGB, (png_const_structrp png_ptr,
     png_inforp info_ptr, int srgb_intent));
-PNG_EXPORT(157, void, png_set_sRGB_gAMA_and_cHRM, (png_const_structrp png_ptr,
+PNG_EXPORT(void, png_set_sRGB_gAMA_and_cHRM, (png_const_structrp png_ptr,
     png_inforp info_ptr, int srgb_intent));
 #endif
 
 #ifdef PNG_iCCP_SUPPORTED
-PNG_EXPORT(158, png_uint_32, png_get_iCCP, (png_const_structrp png_ptr,
+PNG_EXPORT(png_uint_32, png_get_iCCP, (png_const_structrp png_ptr,
     png_inforp info_ptr, png_charpp name, int *compression_type,
     png_bytepp profile, png_uint_32 *proflen));
 #endif
 
 #ifdef PNG_iCCP_SUPPORTED
-PNG_EXPORT(159, void, png_set_iCCP, (png_const_structrp png_ptr,
+PNG_EXPORT(void, png_set_iCCP, (png_const_structrp png_ptr,
     png_inforp info_ptr, png_const_charp name, int compression_type,
     png_const_bytep profile, png_uint_32 proflen));
 #endif
 
 #ifdef PNG_sPLT_SUPPORTED
-PNG_EXPORT(160, int, png_get_sPLT, (png_const_structrp png_ptr,
+PNG_EXPORT(int, png_get_sPLT, (png_const_structrp png_ptr,
     png_inforp info_ptr, png_sPLT_tpp entries));
 #endif
 
 #ifdef PNG_sPLT_SUPPORTED
-PNG_EXPORT(161, void, png_set_sPLT, (png_const_structrp png_ptr,
+PNG_EXPORT(void, png_set_sPLT, (png_const_structrp png_ptr,
     png_inforp info_ptr, png_const_sPLT_tp entries, int nentries));
 #endif
 
 #ifdef PNG_TEXT_SUPPORTED
 /* png_get_text also returns the number of text chunks in *num_text */
-PNG_EXPORT(162, int, png_get_text, (png_const_structrp png_ptr,
+PNG_EXPORT(int, png_get_text, (png_const_structrp png_ptr,
     png_inforp info_ptr, png_textp *text_ptr, int *num_text));
 #endif
 
@@ -2212,34 +2207,34 @@ PNG_EXPORT(162, int, png_get_text, (png_const_structrp png_ptr,
  */
 
 #ifdef PNG_TEXT_SUPPORTED
-PNG_EXPORT(163, void, png_set_text, (png_const_structrp png_ptr,
+PNG_EXPORT(void, png_set_text, (png_const_structrp png_ptr,
     png_inforp info_ptr, png_const_textp text_ptr, int num_text));
 #endif
 
 #ifdef PNG_tIME_SUPPORTED
-PNG_EXPORT(164, png_uint_32, png_get_tIME, (png_const_structrp png_ptr,
+PNG_EXPORT(png_uint_32, png_get_tIME, (png_const_structrp png_ptr,
     png_inforp info_ptr, png_timep *mod_time));
 #endif
 
 #ifdef PNG_tIME_SUPPORTED
-PNG_EXPORT(165, void, png_set_tIME, (png_const_structrp png_ptr,
+PNG_EXPORT(void, png_set_tIME, (png_const_structrp png_ptr,
     png_inforp info_ptr, png_const_timep mod_time));
 #endif
 
 #ifdef PNG_tRNS_SUPPORTED
-PNG_EXPORT(166, png_uint_32, png_get_tRNS, (png_const_structrp png_ptr,
+PNG_EXPORT(png_uint_32, png_get_tRNS, (png_const_structrp png_ptr,
     png_inforp info_ptr, png_bytep *trans_alpha, int *num_trans,
     png_color_16p *trans_color));
 #endif
 
 #ifdef PNG_tRNS_SUPPORTED
-PNG_EXPORT(167, void, png_set_tRNS, (png_structrp png_ptr,
+PNG_EXPORT(void, png_set_tRNS, (png_structrp png_ptr,
     png_inforp info_ptr, png_const_bytep trans_alpha, int num_trans,
     png_const_color_16p trans_color));
 #endif
 
 #ifdef PNG_sCAL_SUPPORTED
-PNG_FP_EXPORT(168, png_uint_32, png_get_sCAL, (png_const_structrp png_ptr,
+PNG_FP_EXPORT(png_uint_32, png_get_sCAL, (png_const_structrp png_ptr,
     png_const_inforp info_ptr, int *unit, double *width, double *height))
 #if defined(PNG_FLOATING_ARITHMETIC_SUPPORTED) || \
    defined(PNG_FLOATING_POINT_SUPPORTED)
@@ -2248,20 +2243,20 @@ PNG_FP_EXPORT(168, png_uint_32, png_get_sCAL, (png_const_structrp png_ptr,
  * In any case the range of values supported by png_fixed_point is small and it
  * is highly recommended that png_get_sCAL_s be used instead.
  */
-PNG_FIXED_EXPORT(214, png_uint_32, png_get_sCAL_fixed,
+PNG_FIXED_EXPORT(png_uint_32, png_get_sCAL_fixed,
     (png_const_structrp png_ptr, png_const_inforp info_ptr, int *unit,
     png_fixed_point *width, png_fixed_point *height))
 #endif
-PNG_EXPORT(169, png_uint_32, png_get_sCAL_s,
+PNG_EXPORT(png_uint_32, png_get_sCAL_s,
     (png_const_structrp png_ptr, png_const_inforp info_ptr, int *unit,
     png_charpp swidth, png_charpp sheight));
 
-PNG_FP_EXPORT(170, void, png_set_sCAL, (png_const_structrp png_ptr,
+PNG_FP_EXPORT(void, png_set_sCAL, (png_const_structrp png_ptr,
     png_inforp info_ptr, int unit, double width, double height))
-PNG_FIXED_EXPORT(213, void, png_set_sCAL_fixed, (png_const_structrp png_ptr,
+PNG_FIXED_EXPORT(void, png_set_sCAL_fixed, (png_const_structrp png_ptr,
    png_inforp info_ptr, int unit, png_fixed_point width,
    png_fixed_point height))
-PNG_EXPORT(171, void, png_set_sCAL_s, (png_const_structrp png_ptr,
+PNG_EXPORT(void, png_set_sCAL_s, (png_const_structrp png_ptr,
     png_inforp info_ptr, int unit,
     png_const_charp swidth, png_const_charp sheight));
 #endif /* sCAL */
@@ -2366,7 +2361,7 @@ PNG_EXPORT(171, void, png_set_sCAL_s, (png_const_structrp png_ptr,
  *    be processed by libpng.
  */
 #ifdef PNG_HANDLE_AS_UNKNOWN_SUPPORTED
-PNG_EXPORT(172, void, png_set_keep_unknown_chunks, (png_structrp png_ptr,
+PNG_EXPORT(void, png_set_keep_unknown_chunks, (png_structrp png_ptr,
     int keep, png_const_bytep chunk_list, int num_chunks));
 #endif /* HANDLE_AS_UNKNOWN */
 
@@ -2374,12 +2369,12 @@ PNG_EXPORT(172, void, png_set_keep_unknown_chunks, (png_structrp png_ptr,
  * the result is therefore true (non-zero) if special handling is required,
  * false for the default handling.
  */
-PNG_EXPORT(173, int, png_handle_as_unknown, (png_const_structrp png_ptr,
+PNG_EXPORT(int, png_handle_as_unknown, (png_const_structrp png_ptr,
     png_const_bytep chunk_name));
 #endif /* SET_UNKNOWN_CHUNKS */
 
 #ifdef PNG_STORE_UNKNOWN_CHUNKS_SUPPORTED
-PNG_EXPORT(174, void, png_set_unknown_chunks, (png_const_structrp png_ptr,
+PNG_EXPORT(void, png_set_unknown_chunks, (png_const_structrp png_ptr,
     png_inforp info_ptr, png_const_unknown_chunkp unknowns,
     int num_unknowns));
    /* NOTE: prior to 1.6.0 this routine set the 'location' field of the added
@@ -2391,10 +2386,10 @@ PNG_EXPORT(174, void, png_set_unknown_chunks, (png_const_structrp png_ptr,
     * the correct thing.
     */
 
-PNG_EXPORT(175, void, png_set_unknown_chunk_location,
+PNG_EXPORT(void, png_set_unknown_chunk_location,
     (png_const_structrp png_ptr, png_inforp info_ptr, int chunk, int location));
 
-PNG_EXPORT(176, int, png_get_unknown_chunks, (png_const_structrp png_ptr,
+PNG_EXPORT(int, png_get_unknown_chunks, (png_const_structrp png_ptr,
     png_inforp info_ptr, png_unknown_chunkpp entries));
 #endif
 
@@ -2402,32 +2397,32 @@ PNG_EXPORT(176, int, png_get_unknown_chunks, (png_const_structrp png_ptr,
  * If you need to turn it off for a chunk that your application has freed,
  * you can use png_set_invalid(png_ptr, info_ptr, PNG_INFO_CHNK);
  */
-PNG_EXPORT(177, void, png_set_invalid, (png_const_structrp png_ptr,
+PNG_EXPORT(void, png_set_invalid, (png_const_structrp png_ptr,
     png_inforp info_ptr, int mask));
 
 #ifdef PNG_INFO_IMAGE_SUPPORTED
 /* The "params" pointer is currently not used and is for future expansion. */
 #ifdef PNG_SEQUENTIAL_READ_SUPPORTED
-PNG_EXPORT(178, void, png_read_png, (png_structrp png_ptr, png_inforp info_ptr,
+PNG_EXPORT(void, png_read_png, (png_structrp png_ptr, png_inforp info_ptr,
     int transforms, png_voidp params));
 #endif
 #ifdef PNG_WRITE_SUPPORTED
-PNG_EXPORT(179, void, png_write_png, (png_structrp png_ptr, png_inforp info_ptr,
+PNG_EXPORT(void, png_write_png, (png_structrp png_ptr, png_inforp info_ptr,
     int transforms, png_voidp params));
 #endif
 #endif
 
-PNG_EXPORT(180, png_const_charp, png_get_copyright,
+PNG_EXPORT(png_const_charp, png_get_copyright,
     (png_const_structrp png_ptr));
-PNG_EXPORT(181, png_const_charp, png_get_header_ver,
+PNG_EXPORT(png_const_charp, png_get_header_ver,
     (png_const_structrp png_ptr));
-PNG_EXPORT(182, png_const_charp, png_get_header_version,
+PNG_EXPORT(png_const_charp, png_get_header_version,
     (png_const_structrp png_ptr));
-PNG_EXPORT(183, png_const_charp, png_get_libpng_ver,
+PNG_EXPORT(png_const_charp, png_get_libpng_ver,
     (png_const_structrp png_ptr));
 
 #ifdef PNG_MNG_FEATURES_SUPPORTED
-PNG_EXPORT(184, png_uint_32, png_permit_mng_features, (png_structrp png_ptr,
+PNG_EXPORT(png_uint_32, png_permit_mng_features, (png_structrp png_ptr,
     png_uint_32 mng_features_permitted));
 #endif
 
@@ -2442,56 +2437,56 @@ PNG_EXPORT(184, png_uint_32, png_permit_mng_features, (png_structrp png_ptr,
  * messages before passing them to the error or warning handler.
  */
 #ifdef PNG_ERROR_NUMBERS_SUPPORTED
-PNG_EXPORT(185, void, png_set_strip_error_numbers, (png_structrp png_ptr,
+PNG_EXPORT(void, png_set_strip_error_numbers, (png_structrp png_ptr,
     png_uint_32 strip_mode));
 #endif
 
 /* Added in libpng-1.2.6 */
 #ifdef PNG_SET_USER_LIMITS_SUPPORTED
-PNG_EXPORT(186, void, png_set_user_limits, (png_structrp png_ptr,
+PNG_EXPORT(void, png_set_user_limits, (png_structrp png_ptr,
     png_uint_32 user_width_max, png_uint_32 user_height_max));
-PNG_EXPORT(187, png_uint_32, png_get_user_width_max,
+PNG_EXPORT(png_uint_32, png_get_user_width_max,
     (png_const_structrp png_ptr));
-PNG_EXPORT(188, png_uint_32, png_get_user_height_max,
+PNG_EXPORT(png_uint_32, png_get_user_height_max,
     (png_const_structrp png_ptr));
 /* Added in libpng-1.4.0 */
-PNG_EXPORT(189, void, png_set_chunk_cache_max, (png_structrp png_ptr,
+PNG_EXPORT(void, png_set_chunk_cache_max, (png_structrp png_ptr,
     png_uint_32 user_chunk_cache_max));
-PNG_EXPORT(190, png_uint_32, png_get_chunk_cache_max,
+PNG_EXPORT(png_uint_32, png_get_chunk_cache_max,
     (png_const_structrp png_ptr));
 /* Added in libpng-1.4.1 */
-PNG_EXPORT(191, void, png_set_chunk_malloc_max, (png_structrp png_ptr,
+PNG_EXPORT(void, png_set_chunk_malloc_max, (png_structrp png_ptr,
     png_alloc_size_t user_chunk_cache_max));
-PNG_EXPORT(192, png_alloc_size_t, png_get_chunk_malloc_max,
+PNG_EXPORT(png_alloc_size_t, png_get_chunk_malloc_max,
     (png_const_structrp png_ptr));
 #endif
 
 #if defined(PNG_INCH_CONVERSIONS_SUPPORTED)
-PNG_EXPORT(193, png_uint_32, png_get_pixels_per_inch,
+PNG_EXPORT(png_uint_32, png_get_pixels_per_inch,
     (png_const_structrp png_ptr, png_const_inforp info_ptr));
 
-PNG_EXPORT(194, png_uint_32, png_get_x_pixels_per_inch,
+PNG_EXPORT(png_uint_32, png_get_x_pixels_per_inch,
     (png_const_structrp png_ptr, png_const_inforp info_ptr));
 
-PNG_EXPORT(195, png_uint_32, png_get_y_pixels_per_inch,
+PNG_EXPORT(png_uint_32, png_get_y_pixels_per_inch,
     (png_const_structrp png_ptr, png_const_inforp info_ptr));
 
-PNG_FP_EXPORT(196, float, png_get_x_offset_inches,
+PNG_FP_EXPORT(float, png_get_x_offset_inches,
     (png_const_structrp png_ptr, png_const_inforp info_ptr))
 #ifdef PNG_FIXED_POINT_SUPPORTED /* otherwise not implemented. */
-PNG_FIXED_EXPORT(211, png_fixed_point, png_get_x_offset_inches_fixed,
+PNG_FIXED_EXPORT(png_fixed_point, png_get_x_offset_inches_fixed,
     (png_const_structrp png_ptr, png_const_inforp info_ptr))
 #endif
 
-PNG_FP_EXPORT(197, float, png_get_y_offset_inches, (png_const_structrp png_ptr,
+PNG_FP_EXPORT(float, png_get_y_offset_inches, (png_const_structrp png_ptr,
     png_const_inforp info_ptr))
 #ifdef PNG_FIXED_POINT_SUPPORTED /* otherwise not implemented. */
-PNG_FIXED_EXPORT(212, png_fixed_point, png_get_y_offset_inches_fixed,
+PNG_FIXED_EXPORT(png_fixed_point, png_get_y_offset_inches_fixed,
     (png_const_structrp png_ptr, png_const_inforp info_ptr))
 #endif
 
 #  ifdef PNG_pHYs_SUPPORTED
-PNG_EXPORT(198, png_uint_32, png_get_pHYs_dpi, (png_const_structrp png_ptr,
+PNG_EXPORT(png_uint_32, png_get_pHYs_dpi, (png_const_structrp png_ptr,
     png_const_inforp info_ptr, png_uint_32 *res_x, png_uint_32 *res_y,
     int *unit_type));
 #  endif /* pHYs */
@@ -2499,13 +2494,13 @@ PNG_EXPORT(198, png_uint_32, png_get_pHYs_dpi, (png_const_structrp png_ptr,
 
 /* Added in libpng-1.4.0 */
 #ifdef PNG_IO_STATE_SUPPORTED
-PNG_EXPORT(199, png_uint_32, png_get_io_state, (png_const_structrp png_ptr));
+PNG_EXPORT(png_uint_32, png_get_io_state, (png_const_structrp png_ptr));
 
 /* Removed from libpng 1.6; use png_get_io_chunk_type. */
-PNG_REMOVED(200, png_const_bytep, png_get_io_chunk_name, (png_structrp png_ptr),
+PNG_REMOVED(png_const_bytep, png_get_io_chunk_name, (png_structrp png_ptr),
     PNG_DEPRECATED)
 
-PNG_EXPORT(216, png_uint_32, png_get_io_chunk_type,
+PNG_EXPORT(png_uint_32, png_get_io_chunk_type,
     (png_const_structrp png_ptr));
 
 /* The flags returned by png_get_io_state() are the following: */
@@ -2631,21 +2626,21 @@ PNG_EXPORT(216, png_uint_32, png_get_io_chunk_type,
 #endif /* READ_COMPOSITE_NODIV */
 
 #ifdef PNG_READ_INT_FUNCTIONS_SUPPORTED
-PNG_EXPORT(201, png_uint_32, png_get_uint_32, (png_const_bytep buf));
-PNG_EXPORT(202, png_uint_16, png_get_uint_16, (png_const_bytep buf));
-PNG_EXPORT(203, png_int_32, png_get_int_32, (png_const_bytep buf));
+PNG_EXPORT(png_uint_32, png_get_uint_32, (png_const_bytep buf));
+PNG_EXPORT(png_uint_16, png_get_uint_16, (png_const_bytep buf));
+PNG_EXPORT(png_int_32, png_get_int_32, (png_const_bytep buf));
 #endif
 
-PNG_EXPORT(204, png_uint_32, png_get_uint_31, (png_const_structrp png_ptr,
+PNG_EXPORT(png_uint_32, png_get_uint_31, (png_const_structrp png_ptr,
     png_const_bytep buf));
 /* No png_get_int_16 -- may be added if there's a real need for it. */
 
 /* Place a 32-bit number into a buffer in PNG byte order (big-endian). */
 #ifdef PNG_WRITE_INT_FUNCTIONS_SUPPORTED
-PNG_EXPORT(205, void, png_save_uint_32, (png_bytep buf, png_uint_32 i));
+PNG_EXPORT(void, png_save_uint_32, (png_bytep buf, png_uint_32 i));
 #endif
 #ifdef PNG_SAVE_INT_32_SUPPORTED
-PNG_EXPORT(206, void, png_save_int_32, (png_bytep buf, png_int_32 i));
+PNG_EXPORT(void, png_save_int_32, (png_bytep buf, png_int_32 i));
 #endif
 
 /* Place a 16-bit number into a buffer in PNG byte order.
@@ -2653,7 +2648,7 @@ PNG_EXPORT(206, void, png_save_int_32, (png_bytep buf, png_int_32 i));
  * just to avoid potential problems on pre-ANSI C compilers.
  */
 #ifdef PNG_WRITE_INT_FUNCTIONS_SUPPORTED
-PNG_EXPORT(207, void, png_save_uint_16, (png_bytep buf, unsigned int i));
+PNG_EXPORT(void, png_save_uint_16, (png_bytep buf, unsigned int i));
 /* No png_save_int_16 -- may be added if there's a real need for it. */
 #endif
 
@@ -2699,10 +2694,10 @@ PNG_EXPORT(207, void, png_save_uint_16, (png_bytep buf, unsigned int i));
 #endif
 
 #ifdef PNG_CHECK_FOR_INVALID_INDEX_SUPPORTED
-PNG_EXPORT(242, void, png_set_check_for_invalid_index,
+PNG_EXPORT(void, png_set_check_for_invalid_index,
     (png_structrp png_ptr, int allowed));
 #  ifdef PNG_GET_PALETTE_MAX_SUPPORTED
-PNG_EXPORT(243, int, png_get_palette_max, (png_const_structp png_ptr,
+PNG_EXPORT(int, png_get_palette_max, (png_const_structp png_ptr,
     png_const_infop info_ptr));
 #  endif
 #endif /* CHECK_FOR_INVALID_INDEX */
@@ -3067,22 +3062,22 @@ typedef struct
  * the png_controlp field 'opaque' to NULL (or, safer, memset the whole thing.)
  */
 #ifdef PNG_STDIO_SUPPORTED
-PNG_EXPORT(234, int, png_image_begin_read_from_file, (png_imagep image,
+PNG_EXPORT(int, png_image_begin_read_from_file, (png_imagep image,
    const char *file_name));
    /* The named file is opened for read and the image header is filled in
     * from the PNG header in the file.
     */
 
-PNG_EXPORT(235, int, png_image_begin_read_from_stdio, (png_imagep image,
+PNG_EXPORT(int, png_image_begin_read_from_stdio, (png_imagep image,
    FILE* file));
    /* The PNG header is read from the stdio FILE object. */
 #endif /* STDIO */
 
-PNG_EXPORT(236, int, png_image_begin_read_from_memory, (png_imagep image,
+PNG_EXPORT(int, png_image_begin_read_from_memory, (png_imagep image,
    png_const_voidp memory, size_t size));
    /* The PNG header is read from the given memory buffer. */
 
-PNG_EXPORT(237, int, png_image_finish_read, (png_imagep image,
+PNG_EXPORT(int, png_image_finish_read, (png_imagep image,
    png_const_colorp background, void *buffer, png_int_32 row_stride,
    void *colormap));
    /* Finish reading the image into the supplied buffer and clean up the
@@ -3117,7 +3112,7 @@ PNG_EXPORT(237, int, png_image_finish_read, (png_imagep image,
     * written to the colormap; this may be less than the original value.
     */
 
-PNG_EXPORT(238, void, png_image_free, (png_imagep image));
+PNG_EXPORT(void, png_image_free, (png_imagep image));
    /* Free any data allocated by libpng in image->opaque, setting the pointer to
     * NULL.  May be called at any time after the structure is initialized.
     */
@@ -3141,12 +3136,12 @@ PNG_EXPORT(238, void, png_image_free, (png_imagep image));
  * colormap_entries: set to the number of entries in the color-map (0 to 256)
  */
 #ifdef PNG_SIMPLIFIED_WRITE_STDIO_SUPPORTED
-PNG_EXPORT(239, int, png_image_write_to_file, (png_imagep image,
+PNG_EXPORT(int, png_image_write_to_file, (png_imagep image,
    const char *file, int convert_to_8bit, const void *buffer,
    png_int_32 row_stride, const void *colormap));
    /* Write the image to the named file. */
 
-PNG_EXPORT(240, int, png_image_write_to_stdio, (png_imagep image, FILE *file,
+PNG_EXPORT(int, png_image_write_to_stdio, (png_imagep image, FILE *file,
    int convert_to_8_bit, const void *buffer, png_int_32 row_stride,
    const void *colormap));
    /* Write the image to the given (FILE*). */
@@ -3173,7 +3168,7 @@ PNG_EXPORT(240, int, png_image_write_to_stdio, (png_imagep image, FILE *file,
  * notices) you need to use one of the other APIs.
  */
 
-PNG_EXPORT(245, int, png_image_write_to_memory, (png_imagep image, void *memory,
+PNG_EXPORT(int, png_image_write_to_memory, (png_imagep image, void *memory,
    png_alloc_size_t * PNG_RESTRICT memory_bytes, int convert_to_8_bit,
    const void *buffer, png_int_32 row_stride, const void *colormap));
    /* Write the image to the given memory buffer.  The function both writes the
@@ -3318,7 +3313,7 @@ PNG_EXPORT(245, int, png_image_write_to_memory, (png_imagep image, void *memory,
 #define PNG_OPTION_OFF     2
 #define PNG_OPTION_ON      3
 
-PNG_EXPORT(244, int, png_set_option, (png_structrp png_ptr, int option,
+PNG_EXPORT(int, png_set_option, (png_structrp png_ptr, int option,
    int onoff));
 
 /*******************************************************************************
@@ -3328,13 +3323,6 @@ PNG_EXPORT(244, int, png_set_option, (png_structrp png_ptr, int option,
 /* Maintainer: Put new public prototypes here ^, in libpng.3, in project
  * defs, and in scripts/symbols.def.
  */
-
-/* The last ordinal number (this is the *last* one already used; the next
- * one to use is one more than this.)
- */
-#ifdef PNG_EXPORT_LAST_ORDINAL
-  PNG_EXPORT_LAST_ORDINAL(259);
-#endif
 
 #ifdef __cplusplus
 }

--- a/pngconf.h
+++ b/pngconf.h
@@ -290,13 +290,8 @@
 #  define PNG_EXPORT_TYPE(type) PNG_IMPEXP type
 #endif
 
-   /* The ordinal value is only relevant when preprocessing png.h for symbol
-    * table entries, so we discard it here.  See the .dfn files in the
-    * scripts directory.
-    */
-
 #ifndef PNG_EXPORTA
-#  define PNG_EXPORTA(ordinal, type, name, args, attributes) \
+#  define PNG_EXPORTA(type, name, args, attributes) \
       PNG_FUNCTION(PNG_EXPORT_TYPE(type), (PNGAPI name), args, \
       PNG_LINKAGE_API attributes)
 #endif
@@ -306,12 +301,11 @@
  */
 #define PNG_EMPTY /*empty list*/
 
-#define PNG_EXPORT(ordinal, type, name, args) \
-   PNG_EXPORTA(ordinal, type, name, args, PNG_EMPTY)
+#define PNG_EXPORT(type, name, args) PNG_EXPORTA(type, name, args, PNG_EMPTY)
 
 /* Use PNG_REMOVED to comment out a removed interface. */
 #ifndef PNG_REMOVED
-#  define PNG_REMOVED(ordinal, type, name, args, attributes)
+#  define PNG_REMOVED(type, name, args, attributes)
 #endif
 
 #ifndef PNG_CALLBACK
@@ -446,18 +440,16 @@
 
 #ifndef PNG_FP_EXPORT     /* A floating point API. */
 #  ifdef PNG_FLOATING_POINT_SUPPORTED
-#     define PNG_FP_EXPORT(ordinal, type, name, args)\
-         PNG_EXPORT(ordinal, type, name, args);
+#     define PNG_FP_EXPORT(type, name, args) PNG_EXPORT(type, name, args);
 #  else                   /* No floating point APIs */
-#     define PNG_FP_EXPORT(ordinal, type, name, args)
+#     define PNG_FP_EXPORT(type, name, args)
 #  endif
 #endif
 #ifndef PNG_FIXED_EXPORT  /* A fixed point API. */
 #  ifdef PNG_FIXED_POINT_SUPPORTED
-#     define PNG_FIXED_EXPORT(ordinal, type, name, args)\
-         PNG_EXPORT(ordinal, type, name, args);
+#     define PNG_FIXED_EXPORT(type, name, args) PNG_EXPORT(type, name, args);
 #  else                   /* No fixed point APIs */
-#     define PNG_FIXED_EXPORT(ordinal, type, name, args)
+#     define PNG_FIXED_EXPORT(type, name, args)
 #  endif
 #endif
 

--- a/pngpriv.h
+++ b/pngpriv.h
@@ -1,6 +1,6 @@
 /* pngpriv.h - private declarations for use inside libpng
  *
- * Copyright (c) 2018-2024 Cosmin Truta
+ * Copyright (c) 2018-2025 Cosmin Truta
  * Copyright (c) 1998-2002,2004,2006-2018 Glenn Randers-Pehrson
  * Copyright (c) 1996-1997 Andreas Dilger
  * Copyright (c) 1995-1996 Guy Eric Schalnat, Group 42, Inc.
@@ -185,7 +185,7 @@
  */
 #ifndef PNG_FP_EXPORT
 #  ifndef PNG_FLOATING_POINT_SUPPORTED
-#     define PNG_FP_EXPORT(ordinal, type, name, args)\
+#     define PNG_FP_EXPORT(type, name, args)\
          PNG_INTERNAL_FUNCTION(type, name, args, PNG_EMPTY);
 #     ifndef PNG_VERSION_INFO_ONLY
          typedef struct png_incomplete png_double;
@@ -197,7 +197,7 @@
 #endif
 #ifndef PNG_FIXED_EXPORT
 #  ifndef PNG_FIXED_POINT_SUPPORTED
-#     define PNG_FIXED_EXPORT(ordinal, type, name, args)\
+#     define PNG_FIXED_EXPORT(type, name, args)\
          PNG_INTERNAL_FUNCTION(type, name, args, PNG_EMPTY);
 #  endif
 #endif

--- a/scripts/checksym.awk
+++ b/scripts/checksym.awk
@@ -17,39 +17,18 @@
 BEGIN {
    err = 0
    master = ""        # master file
-   official[1] = ""   # defined symbols from master file
-   symbol[1] = ""     # defined symbols from png.h
-   removed[1] = ""    # removed symbols from png.h
-   lasto = 0          # last ordinal value from png.h
-   mastero = 0        # highest ordinal in master file
-   symbolo = 0        # highest ordinal in png.h
+   official[""] = ""  # defined symbols from master file
+   symbol[""] = ""    # defined symbols from png.h
+   removed[""] = ""   # removed symbols from png.h
    missing = "error"  # log an error on missing symbols
    of = "symbols.new" # default to a fixed name
 }
 
 # Read existing definitions from the master file (the first
-# file on the command line.)  This must be a def file and it
-# has definition lines (others are ignored) of the form:
-#
-#   symbol @ordinal
-#
+# file on the command line.)  This is a Windows .def file
+# which must NOT have definitions of the form "symbol @ordinal".
 master == "" {
    master = FILENAME
-}
-FILENAME == master && NF == 2 && $2 ~ /^@/ && $1 !~ /^;/ {
-   o = 0 + substr($2, 2)
-   if (o > 0) {
-      if (official[o] == "") {
-         official[o] = $1
-         if (o > mastero) mastero = o
-         next
-      } else {
-         print master ": duplicated symbol:", official[o] ":", $0
-      }
-   } else {
-      print master ": bad export line format:", $0
-   }
-   err = 1
 }
 FILENAME == master && $1 == ";missing" && NF == 2 {
    # This allows the master file to control how missing symbols
@@ -65,64 +44,33 @@ FILENAME == master {
 # Read new definitions, these are free form but the lines must
 # just be symbol definitions.  Lines will be commented out for
 # 'removed' symbols, introduced in png.h using PNG_REMOVED rather
-# than PNG_EXPORT.  Use symbols.dfn or pngwin.dfn to generate the
-# input file.
+# than PNG_EXPORT.  Use symbols.dfn to generate the input file.
 #
-#  symbol @ordinal   # two fields, exported symbol
-#  ; symbol @ordinal # three fields, removed symbol
-#  ; @ordinal        # two fields, the last ordinal
-NF == 2 && $1 == ";" && $2 ~ /^@[1-9][0-9]*$/ {
-   # last ordinal
-   o = 0 + substr($2, 2)
-   if (lasto == 0 || lasto == o) {
-      lasto = o
-   } else {
-      print "png.h: duplicated last ordinal:", lasto, o
-      err = 1
-   }
+#  symbol   # one field, exported symbol
+#  ; symbol # two fields, removed symbol
+#
+NF == 0 {
+   # empty line
    next
 }
-NF == 3 && $1 == ";" && $3 ~ /^@[1-9][0-9]*$/ {
-   # removed symbol
-   o = 0 + substr($3, 2)
-   if (removed[o] == "" || removed[o] == $2) {
-      removed[o] = $2
-      if (o > symbolo) symbolo = o
-   } else {
-      print "png.h: duplicated removed symbol", o ": '" removed[o] "' != '" $2 "'"
-      err = 1
-   }
+NF == 1 && $1 ~ /^[A-Za-z_][A-Za-z_0-9]*$/ {
+   # exported symbol (one field)
+   symbol[$1] = $1
    next
 }
-NF == 2 && $2 ~ /^@[1-9][0-9]*$/ {
-   # exported symbol
-   o = 0 + substr($2, 2)
-   if (symbol[o] == "" || symbol[o] == $1) {
-      symbol[o] = $1
-      if (o > symbolo) symbolo = o
-   } else {
-      print "png.h: duplicated symbol", o ": '" symbol[o] "' != '" $1 "'"
-      err = 1
-   }
+NF == 2 && $1 == ";" && $2 ~ /^[A-Za-z_][A-Za-z_0-9]*$/ {
+   # removed symbol (two fields)
+   removed[$1] = $1
+   next
 }
 {
-   next # skip all other lines
+   print "error: invalid line:", $0
+   err = 1
+   next
 }
 
-# At the end check for symbols marked as both duplicated and removed
 END {
-   if (symbolo > lasto) {
-      print "highest symbol ordinal in png.h,",
-            symbolo ", exceeds last ordinal from png.h", lasto
-      err = 1
-   }
-   if (mastero > lasto) {
-      print "highest symbol ordinal in", master ",",
-            mastero ", exceeds last ordinal from png.h", lasto
-      err = 1
-   }
-   unexported = 0
-   # Add a standard header to symbols.new:
+   # Write the standard header to "symbols.new":
    print ";Version INSERT-VERSION-HERE" >of
    print ";--------------------------------------------------------------" >of
    print "; LIBPNG symbol list as a Win32 DEF file" >of
@@ -132,59 +80,22 @@ END {
    print "" >of
    print "EXPORTS" >of
 
-   for (o = 1; o <= lasto; ++o) {
-      if (symbol[o] == "" && removed[o] == "") {
-         if (unexported == 0) unexported = o
-         if (official[o] == "") {
-            # missing in export list too, so ok
-            if (o < lasto) continue
-         }
-      }
-      if (unexported != 0) {
-         # Symbols in the .def but not in the new file are errors, but
-         # the 'unexported' symbols aren't in either.  By default this
-         # is an error too (see the setting of 'missing' at the start),
-         # but this can be reset on the command line or by stuff in the
-         # file - see the comments above.
-         if (missing != "ignore") {
-            if (o - 1 > unexported) {
-               print "png.h:", missing ": missing symbols:", unexported "-" o - 1
-            } else {
-               print "png.h:", missing ": missing symbol:", unexported
-            }
-            if (missing != "warning") {
-               err = 1
-            }
-         }
-         unexported = 0
-      }
-      if (symbol[o] != "" && removed[o] != "") {
-         print "png.h: symbol", o,
-               "both exported as '" symbol[o] "' and removed as '" removed[o] "'"
-         err = 1
-      } else if (symbol[o] != official[o]) {
-         # either the symbol is missing somewhere or it changed
-         err = 1
-         if (symbol[o] == "") {
-            print "png.h: symbol", o,
-                  "is exported as '" official[o] "' in", master
-         } else if (official[o] == "") {
-            print "png.h: exported symbol", o,
-                  "'" symbol[o] "' not present in", master
-         } else {
-            print "png.h: exported symbol", o,
-                  "'" symbol[o] "' exists as '" official[o] "' in", master
-         }
-      }
+   # Collect all unique symbols into a plain array for sorting.
+   i = 1
+   for (sym in symbol) {
+      if (sym != "") sorted_symbols[i++] = sym
+   }
 
-      # Finally generate symbols.new
-      if (symbol[o] != "") {
-         print " " symbol[o], "@" o > of
-      }
+   # Sort and print the symbols.
+   asort(sorted_symbols)
+   for (i = 1; i <= length(sorted_symbols); i++) {
+      print " " sorted_symbols[i] >of
    }
 
    if (err != 0) {
       print "*** A new list is in", of, "***"
       exit 1
    }
+
+   # TODO: Check for symbols that are both defined and removed.
 }

--- a/scripts/prefix.c
+++ b/scripts/prefix.c
@@ -7,7 +7,7 @@
  * and license in png.h
  */
 
-#define PNG_EXPORTA(ordinal, type, name, args, attributes)\
+#define PNG_EXPORTA(type, name, args, attributes)\
         PNG_DFN "@" name "@"
 
 /* The configuration information *before* the additional of symbol renames,

--- a/scripts/sym.c
+++ b/scripts/sym.c
@@ -7,7 +7,7 @@
  * and license in png.h
  */
 
-#define PNG_EXPORTA(ordinal, type, name, args, attributes)\
+#define PNG_EXPORTA(type, name, args, attributes)\
         PNG_DFN "@" SYMBOL_PREFIX "@@" name "@"
 
 #include "../png.h"

--- a/scripts/symbols.c
+++ b/scripts/symbols.c
@@ -14,12 +14,10 @@
  * scripts/pnglibconf.dfa then this checks the .dfa file too.
  */
 
-#define PNG_EXPORTA(ordinal, type, name, args, attributes)\
-        PNG_DFN "@" name "@ @@" ordinal "@"
-#define PNG_REMOVED(ordinal, type, name, args, attributes)\
-        PNG_DFN "; @" name "@ @@" ordinal "@"
-#define PNG_EXPORT_LAST_ORDINAL(ordinal)\
-        PNG_DFN "; @@" ordinal "@"
+#define PNG_EXPORTA(type, name, args, attributes)\
+        PNG_DFN "@" name "@"
+#define PNG_REMOVED(type, name, args, attributes)\
+        PNG_DFN "; @" name "@"
 
 /* Read the defaults, but use scripts/pnglibconf.h.prebuilt; the 'standard'
  * header file.

--- a/scripts/symbols.def
+++ b/scripts/symbols.def
@@ -5,256 +5,256 @@
 LIBRARY
 
 EXPORTS
- png_access_version_number @1
- png_set_sig_bytes @2
- png_sig_cmp @3
- png_create_read_struct @4
- png_create_write_struct @5
- png_get_compression_buffer_size @6
- png_set_compression_buffer_size @7
- png_set_longjmp_fn @8
- png_longjmp @9
- png_reset_zstream @10
- png_create_read_struct_2 @11
- png_create_write_struct_2 @12
- png_write_sig @13
- png_write_chunk @14
- png_write_chunk_start @15
- png_write_chunk_data @16
- png_write_chunk_end @17
- png_create_info_struct @18
- png_info_init_3 @19
- png_write_info_before_PLTE @20
- png_write_info @21
- png_read_info @22
- png_convert_from_struct_tm @24
- png_convert_from_time_t @25
- png_set_expand @26
- png_set_expand_gray_1_2_4_to_8 @27
- png_set_palette_to_rgb @28
- png_set_tRNS_to_alpha @29
- png_set_bgr @30
- png_set_gray_to_rgb @31
- png_set_rgb_to_gray @32
- png_set_rgb_to_gray_fixed @33
- png_get_rgb_to_gray_status @34
- png_build_grayscale_palette @35
- png_set_strip_alpha @36
- png_set_swap_alpha @37
- png_set_invert_alpha @38
- png_set_filler @39
- png_set_add_alpha @40
- png_set_swap @41
- png_set_packing @42
- png_set_packswap @43
- png_set_shift @44
- png_set_interlace_handling @45
- png_set_invert_mono @46
- png_set_background @47
- png_set_strip_16 @48
- png_set_quantize @49
- png_set_gamma @50
- png_set_flush @51
- png_write_flush @52
- png_start_read_image @53
- png_read_update_info @54
- png_read_rows @55
- png_read_row @56
- png_read_image @57
- png_write_row @58
- png_write_rows @59
- png_write_image @60
- png_write_end @61
- png_read_end @62
- png_destroy_info_struct @63
- png_destroy_read_struct @64
- png_destroy_write_struct @65
- png_set_crc_action @66
- png_set_filter @67
- png_set_compression_level @69
- png_set_compression_mem_level @70
- png_set_compression_strategy @71
- png_set_compression_window_bits @72
- png_set_compression_method @73
- png_init_io @74
- png_set_error_fn @75
- png_get_error_ptr @76
- png_set_write_fn @77
- png_set_read_fn @78
- png_get_io_ptr @79
- png_set_read_status_fn @80
- png_set_write_status_fn @81
- png_set_mem_fn @82
- png_get_mem_ptr @83
- png_set_read_user_transform_fn @84
- png_set_write_user_transform_fn @85
- png_set_user_transform_info @86
- png_get_user_transform_ptr @87
- png_set_read_user_chunk_fn @88
- png_get_user_chunk_ptr @89
- png_set_progressive_read_fn @90
- png_get_progressive_ptr @91
- png_process_data @92
- png_progressive_combine_row @93
- png_malloc @94
- png_calloc @95
- png_malloc_warn @96
- png_free @97
- png_free_data @98
- png_data_freer @99
- png_malloc_default @100
- png_free_default @101
- png_error @102
- png_chunk_error @103
- png_err @104
- png_warning @105
- png_chunk_warning @106
- png_benign_error @107
- png_chunk_benign_error @108
- png_set_benign_errors @109
- png_get_valid @110
- png_get_rowbytes @111
- png_get_rows @112
- png_set_rows @113
- png_get_channels @114
- png_get_image_width @115
- png_get_image_height @116
- png_get_bit_depth @117
- png_get_color_type @118
- png_get_filter_type @119
- png_get_interlace_type @120
- png_get_compression_type @121
- png_get_pixels_per_meter @122
- png_get_x_pixels_per_meter @123
- png_get_y_pixels_per_meter @124
- png_get_pixel_aspect_ratio @125
- png_get_x_offset_pixels @126
- png_get_y_offset_pixels @127
- png_get_x_offset_microns @128
- png_get_y_offset_microns @129
- png_get_signature @130
- png_get_bKGD @131
- png_set_bKGD @132
- png_get_cHRM @133
- png_get_cHRM_fixed @134
- png_set_cHRM @135
- png_set_cHRM_fixed @136
- png_get_gAMA @137
- png_get_gAMA_fixed @138
- png_set_gAMA @139
- png_set_gAMA_fixed @140
- png_get_hIST @141
- png_set_hIST @142
- png_get_IHDR @143
- png_set_IHDR @144
- png_get_oFFs @145
- png_set_oFFs @146
- png_get_pCAL @147
- png_set_pCAL @148
- png_get_pHYs @149
- png_set_pHYs @150
- png_get_PLTE @151
- png_set_PLTE @152
- png_get_sBIT @153
- png_set_sBIT @154
- png_get_sRGB @155
- png_set_sRGB @156
- png_set_sRGB_gAMA_and_cHRM @157
- png_get_iCCP @158
- png_set_iCCP @159
- png_get_sPLT @160
- png_set_sPLT @161
- png_get_text @162
- png_set_text @163
- png_get_tIME @164
- png_set_tIME @165
- png_get_tRNS @166
- png_set_tRNS @167
- png_get_sCAL @168
- png_get_sCAL_s @169
- png_set_sCAL @170
- png_set_sCAL_s @171
- png_set_keep_unknown_chunks @172
- png_handle_as_unknown @173
- png_set_unknown_chunks @174
- png_set_unknown_chunk_location @175
- png_get_unknown_chunks @176
- png_set_invalid @177
- png_read_png @178
- png_write_png @179
- png_get_copyright @180
- png_get_header_ver @181
- png_get_header_version @182
- png_get_libpng_ver @183
- png_permit_mng_features @184
- png_set_strip_error_numbers @185
- png_set_user_limits @186
- png_get_user_width_max @187
- png_get_user_height_max @188
- png_set_chunk_cache_max @189
- png_get_chunk_cache_max @190
- png_set_chunk_malloc_max @191
- png_get_chunk_malloc_max @192
- png_get_pixels_per_inch @193
- png_get_x_pixels_per_inch @194
- png_get_y_pixels_per_inch @195
- png_get_x_offset_inches @196
- png_get_y_offset_inches @197
- png_get_pHYs_dpi @198
- png_get_io_state @199
- png_get_uint_32 @201
- png_get_uint_16 @202
- png_get_int_32 @203
- png_get_uint_31 @204
- png_save_uint_32 @205
- png_save_int_32 @206
- png_save_uint_16 @207
- png_set_gamma_fixed @208
- png_get_pixel_aspect_ratio_fixed @210
- png_get_x_offset_inches_fixed @211
- png_get_y_offset_inches_fixed @212
- png_set_sCAL_fixed @213
- png_get_sCAL_fixed @214
- png_set_background_fixed @215
- png_get_io_chunk_type @216
- png_get_current_row_number @217
- png_get_current_pass_number @218
- png_process_data_pause @219
- png_process_data_skip @220
- png_set_expand_16 @221
- png_set_text_compression_level @222
- png_set_text_compression_mem_level @223
- png_set_text_compression_strategy @224
- png_set_text_compression_window_bits @225
- png_set_text_compression_method @226
- png_set_alpha_mode @227
- png_set_alpha_mode_fixed @228
- png_set_scale_16 @229
- png_get_cHRM_XYZ @230
- png_get_cHRM_XYZ_fixed @231
- png_set_cHRM_XYZ @232
- png_set_cHRM_XYZ_fixed @233
- png_image_begin_read_from_file @234
- png_image_begin_read_from_stdio @235
- png_image_begin_read_from_memory @236
- png_image_finish_read @237
- png_image_free @238
- png_image_write_to_file @239
- png_image_write_to_stdio @240
- png_convert_to_rfc1123_buffer @241
- png_set_check_for_invalid_index @242
- png_get_palette_max @243
- png_set_option @244
- png_image_write_to_memory @245
- png_get_eXIf_1 @248
- png_set_eXIf_1 @249
- png_get_cICP @250
- png_set_cICP @251
- png_get_cLLI @252
- png_get_cLLI_fixed @253
- png_set_cLLI @254
- png_set_cLLI_fixed @255
- png_get_mDCV @256
- png_get_mDCV_fixed @257
- png_set_mDCV @258
- png_set_mDCV_fixed @259
+ png_access_version_number
+ png_set_sig_bytes
+ png_sig_cmp
+ png_create_read_struct
+ png_create_write_struct
+ png_get_compression_buffer_size
+ png_set_compression_buffer_size
+ png_set_longjmp_fn
+ png_longjmp
+ png_reset_zstream
+ png_create_read_struct_2
+ png_create_write_struct_2
+ png_write_sig
+ png_write_chunk
+ png_write_chunk_start
+ png_write_chunk_data
+ png_write_chunk_end
+ png_create_info_struct
+ png_info_init_3
+ png_write_info_before_PLTE
+ png_write_info
+ png_read_info
+ png_convert_from_struct_tm
+ png_convert_from_time_t
+ png_set_expand
+ png_set_expand_gray_1_2_4_to_8
+ png_set_palette_to_rgb
+ png_set_tRNS_to_alpha
+ png_set_bgr
+ png_set_gray_to_rgb
+ png_set_rgb_to_gray
+ png_set_rgb_to_gray_fixed
+ png_get_rgb_to_gray_status
+ png_build_grayscale_palette
+ png_set_strip_alpha
+ png_set_swap_alpha
+ png_set_invert_alpha
+ png_set_filler
+ png_set_add_alpha
+ png_set_swap
+ png_set_packing
+ png_set_packswap
+ png_set_shift
+ png_set_interlace_handling
+ png_set_invert_mono
+ png_set_background
+ png_set_strip_16
+ png_set_quantize
+ png_set_gamma
+ png_set_flush
+ png_write_flush
+ png_start_read_image
+ png_read_update_info
+ png_read_rows
+ png_read_row
+ png_read_image
+ png_write_row
+ png_write_rows
+ png_write_image
+ png_write_end
+ png_read_end
+ png_destroy_info_struct
+ png_destroy_read_struct
+ png_destroy_write_struct
+ png_set_crc_action
+ png_set_filter
+ png_set_compression_level
+ png_set_compression_mem_level
+ png_set_compression_strategy
+ png_set_compression_window_bits
+ png_set_compression_method
+ png_init_io
+ png_set_error_fn
+ png_get_error_ptr
+ png_set_write_fn
+ png_set_read_fn
+ png_get_io_ptr
+ png_set_read_status_fn
+ png_set_write_status_fn
+ png_set_mem_fn
+ png_get_mem_ptr
+ png_set_read_user_transform_fn
+ png_set_write_user_transform_fn
+ png_set_user_transform_info
+ png_get_user_transform_ptr
+ png_set_read_user_chunk_fn
+ png_get_user_chunk_ptr
+ png_set_progressive_read_fn
+ png_get_progressive_ptr
+ png_process_data
+ png_progressive_combine_row
+ png_malloc
+ png_calloc
+ png_malloc_warn
+ png_free
+ png_free_data
+ png_data_freer
+ png_malloc_default
+ png_free_default
+ png_error
+ png_chunk_error
+ png_err
+ png_warning
+ png_chunk_warning
+ png_benign_error
+ png_chunk_benign_error
+ png_set_benign_errors
+ png_get_valid
+ png_get_rowbytes
+ png_get_rows
+ png_set_rows
+ png_get_channels
+ png_get_image_width
+ png_get_image_height
+ png_get_bit_depth
+ png_get_color_type
+ png_get_filter_type
+ png_get_interlace_type
+ png_get_compression_type
+ png_get_pixels_per_meter
+ png_get_x_pixels_per_meter
+ png_get_y_pixels_per_meter
+ png_get_pixel_aspect_ratio
+ png_get_x_offset_pixels
+ png_get_y_offset_pixels
+ png_get_x_offset_microns
+ png_get_y_offset_microns
+ png_get_signature
+ png_get_bKGD
+ png_set_bKGD
+ png_get_cHRM
+ png_get_cHRM_fixed
+ png_set_cHRM
+ png_set_cHRM_fixed
+ png_get_gAMA
+ png_get_gAMA_fixed
+ png_set_gAMA
+ png_set_gAMA_fixed
+ png_get_hIST
+ png_set_hIST
+ png_get_IHDR
+ png_set_IHDR
+ png_get_oFFs
+ png_set_oFFs
+ png_get_pCAL
+ png_set_pCAL
+ png_get_pHYs
+ png_set_pHYs
+ png_get_PLTE
+ png_set_PLTE
+ png_get_sBIT
+ png_set_sBIT
+ png_get_sRGB
+ png_set_sRGB
+ png_set_sRGB_gAMA_and_cHRM
+ png_get_iCCP
+ png_set_iCCP
+ png_get_sPLT
+ png_set_sPLT
+ png_get_text
+ png_set_text
+ png_get_tIME
+ png_set_tIME
+ png_get_tRNS
+ png_set_tRNS
+ png_get_sCAL
+ png_get_sCAL_s
+ png_set_sCAL
+ png_set_sCAL_s
+ png_set_keep_unknown_chunks
+ png_handle_as_unknown
+ png_set_unknown_chunks
+ png_set_unknown_chunk_location
+ png_get_unknown_chunks
+ png_set_invalid
+ png_read_png
+ png_write_png
+ png_get_copyright
+ png_get_header_ver
+ png_get_header_version
+ png_get_libpng_ver
+ png_permit_mng_features
+ png_set_strip_error_numbers
+ png_set_user_limits
+ png_get_user_width_max
+ png_get_user_height_max
+ png_set_chunk_cache_max
+ png_get_chunk_cache_max
+ png_set_chunk_malloc_max
+ png_get_chunk_malloc_max
+ png_get_pixels_per_inch
+ png_get_x_pixels_per_inch
+ png_get_y_pixels_per_inch
+ png_get_x_offset_inches
+ png_get_y_offset_inches
+ png_get_pHYs_dpi
+ png_get_io_state
+ png_get_uint_32
+ png_get_uint_16
+ png_get_int_32
+ png_get_uint_31
+ png_save_uint_32
+ png_save_int_32
+ png_save_uint_16
+ png_set_gamma_fixed
+ png_get_pixel_aspect_ratio_fixed
+ png_get_x_offset_inches_fixed
+ png_get_y_offset_inches_fixed
+ png_set_sCAL_fixed
+ png_get_sCAL_fixed
+ png_set_background_fixed
+ png_get_io_chunk_type
+ png_get_current_row_number
+ png_get_current_pass_number
+ png_process_data_pause
+ png_process_data_skip
+ png_set_expand_16
+ png_set_text_compression_level
+ png_set_text_compression_mem_level
+ png_set_text_compression_strategy
+ png_set_text_compression_window_bits
+ png_set_text_compression_method
+ png_set_alpha_mode
+ png_set_alpha_mode_fixed
+ png_set_scale_16
+ png_get_cHRM_XYZ
+ png_get_cHRM_XYZ_fixed
+ png_set_cHRM_XYZ
+ png_set_cHRM_XYZ_fixed
+ png_image_begin_read_from_file
+ png_image_begin_read_from_stdio
+ png_image_begin_read_from_memory
+ png_image_finish_read
+ png_image_free
+ png_image_write_to_file
+ png_image_write_to_stdio
+ png_convert_to_rfc1123_buffer
+ png_set_check_for_invalid_index
+ png_get_palette_max
+ png_set_option
+ png_image_write_to_memory
+ png_get_eXIf_1
+ png_set_eXIf_1
+ png_get_cICP
+ png_set_cICP
+ png_get_cLLI
+ png_get_cLLI_fixed
+ png_set_cLLI
+ png_set_cLLI_fixed
+ png_get_mDCV
+ png_get_mDCV_fixed
+ png_set_mDCV
+ png_set_mDCV_fixed

--- a/scripts/vers.c
+++ b/scripts/vers.c
@@ -7,7 +7,7 @@
  * and license in png.h
  */
 
-#define PNG_EXPORTA(ordinal, type, name, args, attributes)\
+#define PNG_EXPORTA(type, name, args, attributes)\
         PNG_DFN " @" SYMBOL_PREFIX "@@" name "@;"
 
 PNG_DFN "@" PNGLIB_LIBNAME "@ {global:"


### PR DESCRIPTION
@jbowler please review.

This is only the beginning of the function ordinal cleanup. Whatever I made out of scripts/checksym.awk is kinda gooey ("lame, but working"), and it should be cleaned up much more, if not actually removed altogether.

It's png.h that preoccupies me, though. We have the chance to restore readability. We should make the functions look like functions, to the best of our abilities, without breaking the existing build workflow.