### PR TITLE
build: Move the pnglibconf files and scripts to scripts/pnglibconf/

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,7 +178,7 @@ endif()
 
 if(NOT AWK OR (ANDROID OR IOS))
   # No awk available to generate sources; use pre-built pnglibconf.h
-  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/scripts/pnglibconf.h.prebuilt
+  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/pnglibconf.h.prebuilt
                  ${CMAKE_CURRENT_BINARY_DIR}/pnglibconf.h)
   add_custom_target(png_genfiles)
 else()
@@ -186,41 +186,39 @@ else()
   include(${CMAKE_CURRENT_SOURCE_DIR}/scripts/cmake/PNGGenConfig.cmake)
 
   # Copy the awk scripts, converting their line endings to Unix (LF)
-  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/scripts/checksym.awk
-                 ${CMAKE_CURRENT_BINARY_DIR}/scripts/checksym.awk
+  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/scripts/pnglibconf/checksym.awk
+                 ${CMAKE_CURRENT_BINARY_DIR}/scripts/pnglibconf/checksym.awk
                  @ONLY
                  NEWLINE_STYLE LF)
-  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/scripts/options.awk
-                 ${CMAKE_CURRENT_BINARY_DIR}/scripts/options.awk
+  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/scripts/pnglibconf/options.awk
+                 ${CMAKE_CURRENT_BINARY_DIR}/scripts/pnglibconf/options.awk
                  @ONLY
                  NEWLINE_STYLE LF)
-  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/scripts/dfn.awk
-                 ${CMAKE_CURRENT_BINARY_DIR}/scripts/dfn.awk
+  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/scripts/pnglibconf/dfn.awk
+                 ${CMAKE_CURRENT_BINARY_DIR}/scripts/pnglibconf/dfn.awk
                  @ONLY
                  NEWLINE_STYLE LF)
 
-  # Generate scripts/pnglibconf.h
-  generate_source(OUTPUT "scripts/pnglibconf.c"
-                  DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/scripts/pnglibconf.dfa"
-                          "${CMAKE_CURRENT_BINARY_DIR}/scripts/options.awk"
+  # Generate pnglibconf.c and pnglibconf.h
+  generate_source(OUTPUT "scripts/pnglibconf/pnglibconf.c"
+                  DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/scripts/pnglibconf/options.awk"
+                          "${CMAKE_CURRENT_SOURCE_DIR}/scripts/pnglibconf/pnglibconf.dfa"
                           "${CMAKE_CURRENT_SOURCE_DIR}/pngconf.h")
   add_custom_target(png_scripts_pnglibconf_c
-                    DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/scripts/pnglibconf.c")
-
-  # Generate pnglibconf.c
+                    DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/scripts/pnglibconf/pnglibconf.c")
   generate_source(OUTPUT "pnglibconf.c"
-                  DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/scripts/pnglibconf.dfa"
-                          "${CMAKE_CURRENT_BINARY_DIR}/scripts/options.awk"
+                  DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/scripts/pnglibconf/options.awk"
+                          "${CMAKE_CURRENT_SOURCE_DIR}/scripts/pnglibconf/pnglibconf.dfa"
                           "${CMAKE_CURRENT_SOURCE_DIR}/pngconf.h")
   add_custom_target(pnglibconf_c
                     DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/pnglibconf.c")
 
   if(PNG_PREFIX)
     set(PNGLIBCONF_H_EXTRA_DEPENDS
-        "${CMAKE_CURRENT_BINARY_DIR}/scripts/prefix.out"
+        "${CMAKE_CURRENT_BINARY_DIR}/scripts/pnglibconf/prefix.out"
         "${CMAKE_CURRENT_SOURCE_DIR}/scripts/macro.lst")
     set(PNGPREFIX_H_EXTRA_DEPENDS
-        "${CMAKE_CURRENT_BINARY_DIR}/scripts/intprefix.out")
+        "${CMAKE_CURRENT_BINARY_DIR}/scripts/pnglibconf/intprefix.out")
   endif()
 
   generate_out(INPUT "${CMAKE_CURRENT_BINARY_DIR}/pnglibconf.c"
@@ -236,19 +234,19 @@ else()
   add_custom_target(pnglibconf_h
                     DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/pnglibconf.h")
 
-  generate_out(INPUT "${CMAKE_CURRENT_SOURCE_DIR}/scripts/intprefix.c"
-               OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/scripts/intprefix.out"
+  generate_out(INPUT "${CMAKE_CURRENT_SOURCE_DIR}/scripts/pnglibconf/intprefix.c"
+               OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/scripts/pnglibconf/intprefix.out"
                DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/pnglibconf.h" pnglibconf_h)
   add_custom_target(png_scripts_intprefix_out
-                    DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/scripts/intprefix.out")
+                    DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/scripts/pnglibconf/intprefix.out")
 
-  generate_out(INPUT "${CMAKE_CURRENT_SOURCE_DIR}/scripts/prefix.c"
-               OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/scripts/prefix.out"
+  generate_out(INPUT "${CMAKE_CURRENT_SOURCE_DIR}/scripts/pnglibconf/prefix.c"
+               OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/scripts/pnglibconf/prefix.out"
                DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/png.h"
                        "${CMAKE_CURRENT_SOURCE_DIR}/pngconf.h"
                        "${CMAKE_CURRENT_BINARY_DIR}/pnglibconf.out" pnglibconf_out)
   add_custom_target(png_scripts_prefix_out
-                    DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/scripts/prefix.out")
+                    DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/scripts/pnglibconf/prefix.out")
 
   # Generate pngprefix.h
   generate_source(OUTPUT "pngprefix.h"
@@ -256,41 +254,41 @@ else()
   add_custom_target(pngprefix_h
                     DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/pngprefix.h")
 
-  generate_out(INPUT "${CMAKE_CURRENT_SOURCE_DIR}/scripts/sym.c"
-               OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/scripts/sym.out"
+  generate_out(INPUT "${CMAKE_CURRENT_SOURCE_DIR}/scripts/pnglibconf/sym.c"
+               OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/scripts/pnglibconf/sym.out"
                DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/pnglibconf.h" pnglibconf_h)
   add_custom_target(png_scripts_sym_out
-                    DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/scripts/sym.out")
+                    DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/scripts/pnglibconf/sym.out")
 
-  generate_out(INPUT "${CMAKE_CURRENT_SOURCE_DIR}/scripts/symbols.c"
-               OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/scripts/symbols.out"
+  generate_out(INPUT "${CMAKE_CURRENT_SOURCE_DIR}/scripts/pnglibconf/symbols.c"
+               OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/scripts/pnglibconf/symbols.out"
                DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/png.h"
                        "${CMAKE_CURRENT_SOURCE_DIR}/pngconf.h"
-                       "${CMAKE_CURRENT_SOURCE_DIR}/scripts/pnglibconf.h.prebuilt")
+                       "${CMAKE_CURRENT_SOURCE_DIR}/pnglibconf.h.prebuilt")
   add_custom_target(png_scripts_symbols_out
-                    DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/scripts/symbols.out")
+                    DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/scripts/pnglibconf/symbols.out")
 
-  generate_out(INPUT "${CMAKE_CURRENT_SOURCE_DIR}/scripts/vers.c"
-               OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/scripts/vers.out"
+  generate_out(INPUT "${CMAKE_CURRENT_SOURCE_DIR}/scripts/pnglibconf/vers.c"
+               OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/scripts/pnglibconf/vers.out"
                DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/png.h"
                        "${CMAKE_CURRENT_SOURCE_DIR}/pngconf.h"
                        "${CMAKE_CURRENT_BINARY_DIR}/pnglibconf.h" pnglibconf_h)
   add_custom_target(png_scripts_vers_out
-                    DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/scripts/vers.out")
+                    DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/scripts/pnglibconf/vers.out")
 
-  generate_chk(INPUT "${CMAKE_CURRENT_BINARY_DIR}/scripts/symbols.out"
-               OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/scripts/symbols.chk"
+  generate_chk(INPUT "${CMAKE_CURRENT_BINARY_DIR}/scripts/pnglibconf/symbols.out"
+               OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/scripts/pnglibconf/symbols.chk"
                DEPENDS png_scripts_symbols_out
-                       "${CMAKE_CURRENT_BINARY_DIR}/scripts/checksym.awk"
+                       "${CMAKE_CURRENT_BINARY_DIR}/scripts/pnglibconf/checksym.awk"
                        "${CMAKE_CURRENT_SOURCE_DIR}/scripts/symbols.def")
 
   add_custom_target(png_scripts_symbols_chk
-                    DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/scripts/symbols.chk")
+                    DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/scripts/pnglibconf/symbols.chk")
 
-  generate_copy(INPUT "${CMAKE_CURRENT_BINARY_DIR}/scripts/sym.out"
+  generate_copy(INPUT "${CMAKE_CURRENT_BINARY_DIR}/scripts/pnglibconf/sym.out"
                 OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/libpng.sym"
                 DEPENDS png_scripts_sym_out)
-  generate_copy(INPUT "${CMAKE_CURRENT_BINARY_DIR}/scripts/vers.out"
+  generate_copy(INPUT "${CMAKE_CURRENT_BINARY_DIR}/scripts/pnglibconf/vers.out"
                 OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/libpng.vers"
                 DEPENDS png_scripts_vers_out)
 
@@ -301,7 +299,7 @@ else()
 
   add_custom_target(png_genprebuilt
                     COMMAND "${CMAKE_COMMAND}"
-                            "-DOUTPUT=scripts/pnglibconf.h.prebuilt"
+                            "-DOUTPUT=pnglibconf.h.prebuilt"
                             -P "${CMAKE_CURRENT_BINARY_DIR}/scripts/cmake/gensrc.cmake"
                     WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
 
@@ -313,13 +311,13 @@ else()
                             "${CMAKE_CURRENT_BINARY_DIR}/pnglibconf.h" pnglibconf_h
                             "${CMAKE_CURRENT_BINARY_DIR}/pnglibconf.out" pnglibconf_out
                             "${CMAKE_CURRENT_BINARY_DIR}/pngprefix.h" pngprefix_h
-                            "${CMAKE_CURRENT_BINARY_DIR}/scripts/intprefix.out" png_scripts_intprefix_out
-                            "${CMAKE_CURRENT_BINARY_DIR}/scripts/pnglibconf.c" png_scripts_pnglibconf_c
-                            "${CMAKE_CURRENT_BINARY_DIR}/scripts/prefix.out" png_scripts_prefix_out
-                            "${CMAKE_CURRENT_BINARY_DIR}/scripts/sym.out" png_scripts_sym_out
-                            "${CMAKE_CURRENT_BINARY_DIR}/scripts/symbols.chk" png_scripts_symbols_chk
-                            "${CMAKE_CURRENT_BINARY_DIR}/scripts/symbols.out" png_scripts_symbols_out
-                            "${CMAKE_CURRENT_BINARY_DIR}/scripts/vers.out" png_scripts_vers_out)
+                            "${CMAKE_CURRENT_BINARY_DIR}/scripts/pnglibconf/intprefix.out" png_scripts_intprefix_out
+                            "${CMAKE_CURRENT_BINARY_DIR}/scripts/pnglibconf/pnglibconf.c" png_scripts_pnglibconf_c
+                            "${CMAKE_CURRENT_BINARY_DIR}/scripts/pnglibconf/prefix.out" png_scripts_prefix_out
+                            "${CMAKE_CURRENT_BINARY_DIR}/scripts/pnglibconf/sym.out" png_scripts_sym_out
+                            "${CMAKE_CURRENT_BINARY_DIR}/scripts/pnglibconf/symbols.chk" png_scripts_symbols_chk
+                            "${CMAKE_CURRENT_BINARY_DIR}/scripts/pnglibconf/symbols.out" png_scripts_symbols_out
+                            "${CMAKE_CURRENT_BINARY_DIR}/scripts/pnglibconf/vers.out" png_scripts_vers_out)
 endif(NOT AWK OR (ANDROID OR IOS))
 
 # List the source code files.

--- a/Makefile.am
+++ b/Makefile.am
@@ -147,7 +147,7 @@ EXTRA_DIST= \
 	$(TESTS) $(XFAIL_TESTS) tests/pngstest \
 	CMakeLists.txt example.c libpng-manual.txt
 
-SCRIPT_CLEANFILES=scripts/*.out scripts/*.chk
+SCRIPT_CLEANFILES=scripts/pnglibconf/*.out scripts/pnglibconf/*.chk
 
 CLEANFILES= *.tf? pngout.png libpng@PNGLIB_MAJOR@@PNGLIB_MINOR@.pc \
 	libpng@PNGLIB_MAJOR@@PNGLIB_MINOR@-config libpng.vers libpng.sym \
@@ -179,33 +179,35 @@ $(PNGLIB_BASENAME).pc: libpng.pc
 $(PNGLIB_BASENAME)-config: libpng-config
 	cp libpng-config $@
 
-scripts/sym.out scripts/vers.out: png.h pngconf.h pnglibconf.h
-scripts/prefix.out: png.h pngconf.h pnglibconf.out
-scripts/symbols.out: png.h pngconf.h $(srcdir)/scripts/pnglibconf.h.prebuilt
-scripts/intprefix.out: pnglibconf.h
+scripts/pnglibconf/sym.out scripts/pnglibconf/vers.out: png.h pngconf.h pnglibconf.h
+scripts/pnglibconf/prefix.out: png.h pngconf.h pnglibconf.out
+scripts/pnglibconf/symbols.out: png.h pngconf.h $(srcdir)/pnglibconf.h.prebuilt
+scripts/pnglibconf/intprefix.out: pnglibconf.h
 
-libpng.sym: scripts/sym.out
+libpng.sym: scripts/pnglibconf/sym.out
 	rm -f $@
 	cp $? $@
-libpng.vers: scripts/vers.out
+libpng.vers: scripts/pnglibconf/vers.out
 	rm -f $@
 	cp $? $@
 
 if DO_PNG_PREFIX
-# Rename functions in scripts/prefix.out with a PNG_PREFIX prefix.
+# Rename functions in scripts/pnglibconf/prefix.out with a PNG_PREFIX prefix.
 # Rename macros in scripts/macro.lst from PNG_PREFIXpng_ to PNG_ (the actual
 # implementation of the macro).
-pnglibconf.h: pnglibconf.out scripts/prefix.out scripts/macro.lst
+pnglibconf.h: pnglibconf.out scripts/pnglibconf/prefix.out scripts/macro.lst
 	rm -f $@
 	$(AWK) 's==0 && NR>1{print prev}\
 	   s==0{prev=$$0}\
 	   s==1{print "#define", $$1, "@PNG_PREFIX@" $$1}\
 	   s==2{print "#define @PNG_PREFIX@png_" $$1, "PNG_" $$1}\
-	   END{print prev}' s=0 pnglibconf.out s=1 scripts/prefix.out\
-	   s=2 ${srcdir}/scripts/macro.lst >pnglibconf.tf8
+	   END{print prev}'\
+           s=0 pnglibconf.out\
+           s=1 scripts/pnglibconf/prefix.out\
+	   s=2 "${srcdir}/scripts/macro.lst" >pnglibconf.tf8
 	mv pnglibconf.tf8 $@
 
-pngprefix.h: scripts/intprefix.out
+pngprefix.h: scripts/pnglibconf/intprefix.out
 	rm -f pngprefix.tf1
 	$(AWK) '{print "#define", $$1, "@PNG_PREFIX@" $$1}' $? >pngprefix.tf1
 	mv pngprefix.tf1 $@
@@ -218,11 +220,11 @@ pngprefix.h: # is empty
 	:>$@
 endif
 
-$(srcdir)/scripts/pnglibconf.h.prebuilt:
+$(srcdir)/pnglibconf.h.prebuilt:
 	@echo "Attempting to build $@" >&2
 	@echo "This is a machine generated file, but if you want to make" >&2
-	@echo "a new one simply make 'scripts/pnglibconf.out', copy that" >&2
-	@echo "AND set PNG_ZLIB_VERNUM to 0 (you MUST do this)" >&2
+	@echo "a new one simply make 'scripts/pnglibconf/pnglibconf.out'," >&2
+	@echo "copy that AND set PNG_ZLIB_VERNUM to 0 (you MUST do this)" >&2
 	@exit 1
 
 # The following is necessary to ensure that the local pnglibconf.h is used, not
@@ -260,52 +262,60 @@ endif
 .c.out:
 	rm -f $@ $*.tf[12]
 	test -d scripts || mkdir scripts || test -d scripts
+	test -d scripts/pnglibconf || mkdir scripts/pnglibconf || test -d scripts/pnglibconf
 	$(DFNCPP) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES)\
 	    $(CPPFLAGS) $(SYMBOL_CFLAGS) $< > $*.tf1
-	$(AWK) -f "${srcdir}/scripts/dfn.awk" out="$*.tf2" $*.tf1 1>&2
+	$(AWK) -f "${srcdir}/scripts/pnglibconf/dfn.awk"\
+	    out=$*.tf2 $*.tf1 1>&2
 	rm -f $*.tf1
 	mv $*.tf2 $@
 
 # The .c file for pnglibconf.h is machine generated
-pnglibconf.c: scripts/pnglibconf.dfa scripts/options.awk pngconf.h pngusr.dfa $(DFA_XTRA)
+pnglibconf.c: scripts/pnglibconf/pnglibconf.dfa scripts/pnglibconf/options.awk pngconf.h \
+              pngusr.dfa $(DFA_XTRA)
 	rm -f $@ $*.tf[45]
-	$(AWK) -f ${srcdir}/scripts/options.awk out=$*.tf4 version=search\
-	    ${srcdir}/pngconf.h ${srcdir}/scripts/pnglibconf.dfa\
-	    ${srcdir}/pngusr.dfa $(DFA_XTRA) 1>&2
-	$(AWK) -f ${srcdir}/scripts/options.awk out=$*.tf5 $*.tf4 1>&2
+	$(AWK) -f "${srcdir}/scripts/pnglibconf/options.awk"\
+	    out=$*.tf4 version=search\
+	    "${srcdir}/pngconf.h" "${srcdir}/scripts/pnglibconf/pnglibconf.dfa"\
+	    "${srcdir}/pngusr.dfa" $(DFA_XTRA) 1>&2
+	$(AWK) -f "${srcdir}/scripts/pnglibconf/options.awk"\
+	    out=$*.tf5 $*.tf4 1>&2
 	rm $*.tf4
 	mv $*.tf5 $@
 
 # Symbol checks (.def and .out files should match)
-scripts/symbols.chk: scripts/checksym.awk scripts/symbols.def scripts/symbols.out
+scripts/pnglibconf/symbols.chk: scripts/pnglibconf/checksym.awk scripts/pnglibconf/symbols.def \
+                                scripts/pnglibconf/symbols.out
 
 .out.chk:
 	rm -f $@ $*.new
-	$(AWK) -f ${srcdir}/scripts/checksym.awk ${srcdir}/scripts/${*F}.def\
-	    of="$*.new" $< >&2
+	$(AWK) -f "${srcdir}/scripts/pnglibconf/checksym.awk"\
+	    of=$*.new ${srcdir}/scripts/${*F}.def $*.out >&2
 	mv $*.new $@
 
 # used on demand to regenerate the standard header, CPPFLAGS should
 # be empty - no non-standard defines
-scripts/pnglibconf.c: scripts/pnglibconf.dfa scripts/options.awk pngconf.h
+scripts/pnglibconf/pnglibconf.c: scripts/pnglibconf/pnglibconf.dfa scripts/pnglibconf/options.awk \
+                                 pngconf.h
 	rm -f $@ pnglibconf.tf[67]
 	test -z "$(CPPFLAGS)"
 	echo "com @PNGLIB_VERSION@ STANDARD API DEFINITION" |\
-	$(AWK) -f ${srcdir}/scripts/options.awk out=pnglibconf.tf6\
-	    logunsupported=1 version=search ${srcdir}/pngconf.h -\
-	    ${srcdir}/scripts/pnglibconf.dfa 1>&2
-	$(AWK) -f ${srcdir}/scripts/options.awk out=pnglibconf.tf7\
-	    pnglibconf.tf6 1>&2
+	$(AWK) -f "${srcdir}/scripts/pnglibconf/options.awk"\
+	    out=pnglibconf.tf6 logunsupported=1 version=search\
+	    "${srcdir}/pngconf.h" -\
+	    "${srcdir}/scripts/pnglibconf/pnglibconf.dfa" 1>&2
+	$(AWK) -f "${srcdir}/scripts/pnglibconf/options.awk"\
+	    out=pnglibconf.tf7 pnglibconf.tf6 1>&2
 	rm pnglibconf.tf6
 	mv pnglibconf.tf7 $@
 
-$(libpng@PNGLIB_MAJOR@@PNGLIB_MINOR@_la_OBJECTS): png.h pngconf.h \
-	pnglibconf.h pngpriv.h pngdebug.h pnginfo.h pngstruct.h pngprefix.h
+$(libpng@PNGLIB_MAJOR@@PNGLIB_MINOR@_la_OBJECTS): png.h pngconf.h pnglibconf.h pngpriv.h \
+                                                  pngdebug.h pnginfo.h pngstruct.h pngprefix.h
 
 test: check-am
 
 # Extra checks
-check: scripts/symbols.chk
+check: scripts/pnglibconf/symbols.chk
 
 # Don't distribute the generated script files
 dist-hook:

--- a/configure.ac
+++ b/configure.ac
@@ -74,9 +74,11 @@ AC_ARG_VAR(AWK, [AWK language processor])
 # Some awk implementations crash when confronted with pnglibconf.dfa.
 # Run a test now, to make sure this doesn't happen.
 AC_MSG_CHECKING([if awk ($AWK) works])
-if ${AWK} -f ${srcdir}/scripts/options.awk out="/dev/null" version=search\
-   ${srcdir}/pngconf.h ${srcdir}/scripts/pnglibconf.dfa\
-   ${srcdir}/pngusr.dfa 1>&2
+if ${AWK} -f "${srcdir}/scripts/pnglibconf/options.awk"\
+   out="/dev/null" version=search\
+   "${srcdir}/pngconf.h"\
+   "${srcdir}/scripts/pnglibconf/pnglibconf.dfa"\
+   "${srcdir}/pngusr.dfa" 1>&2
 then
    AC_MSG_RESULT([yes])
 else

--- a/contrib/conftest/README
+++ b/contrib/conftest/README
@@ -27,10 +27,10 @@ Examples:
    ${srcdir}/contrib/pngminim/*/pngusr.dfa
 
 Documentation of the options:
-   ${srcdir}/scripts/pnglibconf.dfa
+   ${srcdir}/scripts/pnglibconf/pnglibconf.dfa
 
 Documentation of the file format:
-   ${srcdir}/scripts/options.awk
+   ${srcdir}/scripts/pnglibconf/options.awk
 
 FILE NAMING
 ===========

--- a/contrib/pngminim/decoder/makefile
+++ b/contrib/pngminim/decoder/makefile
@@ -96,16 +96,16 @@ pngm2pnm$(E): $(OBJS)
 # The CPP_FLAGS setting causes pngusr.h to be included in
 # both the build of pnglibconf.h and, subsequently, when
 # building libpng itself.
-$(PNGCONF): $(PNGSRC)/scripts/pnglibconf.mak $(ZH)\
-	$(PNGSRC)/scripts/pnglibconf.dfa \
-	$(PNGSRC)/scripts/options.awk pngusr.h pngusr.dfa
+$(PNGCONF): $(PNGSRC)/scripts/pnglibconf/pnglibconf.mak $(ZH) \
+	$(PNGSRC)/scripts/pnglibconf/pnglibconf.dfa \
+	$(PNGSRC)/scripts/pnglibconf/options.awk pngusr.h pngusr.dfa
 	$(RM) pnglibconf.h pnglibconf.dfn
-	$(MAKE) -f $(PNGSRC)/scripts/pnglibconf.mak $(MAKEFLAGS)\
+	$(MAKE) -f $(PNGSRC)/scripts/pnglibconf/pnglibconf.mak $(MAKEFLAGS)\
 	    srcdir=$(PNGSRC) CPPFLAGS="-DPNG_USER_CONFIG -I."\
 	    DFA_XTRA="pngusr.dfa" $@
 
 clean:
-	$(MAKE) -f $(PNGSRC)/scripts/pnglibconf.mak $(MAKEFLAGS)\
+	$(MAKE) -f $(PNGSRC)/scripts/pnglibconf/pnglibconf.mak $(MAKEFLAGS)\
 	    srcdir=$(PNGSRC) clean
 	$(RM) pngm2pnm$(O)
 	$(RM) pngm2pnm$(E)

--- a/contrib/pngminim/encoder/makefile
+++ b/contrib/pngminim/encoder/makefile
@@ -95,16 +95,16 @@ pnm2pngm$(E): $(OBJS)
 # The CPP_FLAGS setting causes pngusr.h to be included in
 # both the build of pnglibconf.h and, subsequently, when
 # building libpng itself.
-$(PNGCONF): $(PNGSRC)/scripts/pnglibconf.mak $(ZH)\
-	$(PNGSRC)/scripts/pnglibconf.dfa \
-	$(PNGSRC)/scripts/options.awk pngusr.h pngusr.dfa
+$(PNGCONF): $(PNGSRC)/scripts/pnglibconf/pnglibconf.mak $(ZH) \
+	$(PNGSRC)/scripts/pnglibconf/pnglibconf.dfa \
+	$(PNGSRC)/scripts/pnglibconf/options.awk pngusr.h pngusr.dfa
 	$(RM) pnglibconf.h pnglibconf.dfn
-	$(MAKE) -f $(PNGSRC)/scripts/pnglibconf.mak $(MAKEFLAGS)\
+	$(MAKE) -f $(PNGSRC)/scripts/pnglibconf/pnglibconf.mak $(MAKEFLAGS)\
 	    srcdir=$(PNGSRC) CPPFLAGS="-DPNG_USER_CONFIG -I."\
 	    DFA_XTRA="pngusr.dfa" $@
 
 clean:
-	$(MAKE) -f $(PNGSRC)/scripts/pnglibconf.mak $(MAKEFLAGS)\
+	$(MAKE) -f $(PNGSRC)/scripts/pnglibconf/pnglibconf.mak $(MAKEFLAGS)\
 	    srcdir=$(PNGSRC) clean
 	$(RM) pnm2pngm$(O)
 	$(RM) pnm2pngm$(E)

--- a/contrib/pngminim/preader/makefile
+++ b/contrib/pngminim/preader/makefile
@@ -111,16 +111,16 @@ rpng2-x$(E): $(OBJS)
 # The CPP_FLAGS setting causes pngusr.h to be included in
 # both the build of pnglibconf.h and, subsequently, when
 # building libpng itself.
-$(PNGCONF): $(PNGSRC)/scripts/pnglibconf.mak $(ZH)\
-	$(PNGSRC)/scripts/pnglibconf.dfa \
-	$(PNGSRC)/scripts/options.awk pngusr.h pngusr.dfa
+$(PNGCONF): $(PNGSRC)/scripts/pnglibconf/pnglibconf.mak $(ZH) \
+	$(PNGSRC)/scripts/pnglibconf/pnglibconf.dfa \
+	$(PNGSRC)/scripts/pnglibconf/options.awk pngusr.h pngusr.dfa
 	$(RM) pnglibconf.h pnglibconf.dfn
-	$(MAKE) -f $(PNGSRC)/scripts/pnglibconf.mak $(MAKEFLAGS)\
+	$(MAKE) -f $(PNGSRC)/scripts/pnglibconf/pnglibconf.mak $(MAKEFLAGS)\
 	    srcdir=$(PNGSRC) CPPFLAGS="-DPNG_USER_CONFIG -I."\
 	    DFA_XTRA="pngusr.dfa" $@
 
 clean:
-	$(MAKE) -f $(PNGSRC)/scripts/pnglibconf.mak $(MAKEFLAGS)\
+	$(MAKE) -f $(PNGSRC)/scripts/pnglibconf/pnglibconf.mak $(MAKEFLAGS)\
 	    srcdir=$(PNGSRC) clean
 	$(RM) rpng2-x$(O)
 	$(RM) rpng2-x$(E)

--- a/manuals/libpng-install.txt
+++ b/manuals/libpng-install.txt
@@ -66,7 +66,7 @@ III. Using scripts/makefile*
 Instead, you can use one of the custom-built makefiles in the
 "scripts" directory
 
-    cp scripts/pnglibconf.h.prebuilt pnglibconf.h
+    cp pnglibconf.h.prebuilt pnglibconf.h
     cp scripts/makefile.system makefile
     make test
     make install
@@ -394,16 +394,16 @@ copied to pnglibconf.h and this may produce macro redefinition warnings
 when the individual C files are compiled.
 
 All configuration now only works if pnglibconf.h is built from
-scripts/pnglibconf.dfa.  This requires the program awk.  Brian Kernighan
-(the original author of awk) maintains C source code of that awk and this
-and all known later implementations (often called by subtly different
+scripts/pnglibconf/pnglibconf.dfa. This requires the awk program.
+Brian Kernighan (the original author of awk) maintains C source code of awk,
+and this and all known later implementations (often called by subtly different
 names - nawk and gawk for example) are adequate to build pnglibconf.h.
-The Sun Microsystems (now Oracle) program 'awk' is an earlier version
-and does not work; this may also apply to other systems that have a
-functioning awk called 'nawk'.
+The Sun Microsystems (now Oracle) program 'awk' is an earlier version which
+does not work; this may also apply to other systems that have a functioning
+awk called 'nawk'.
 
-Configuration options are now documented in scripts/pnglibconf.dfa.  This
-file also includes dependency information that ensures a configuration is
+Configuration options are now documented in scripts/pnglibconf/pnglibconf.dfa.
+This file also includes dependency information that ensures a configuration is
 consistent; that is, if a feature is switched off, dependent features are
 also switched off.  As a recommended alternative to using feature macros in
 pngusr.h a system builder may also define equivalent options in pngusr.dfa

--- a/manuals/libpng-manual.txt
+++ b/manuals/libpng-manual.txt
@@ -203,7 +203,7 @@ the next section ("Reading").
 
 Notice that some of the makefiles in the 'scripts' directory and (in 1.5.0) all
 of the build project files in the 'projects' directory simply copy
-scripts/pnglibconf.h.prebuilt to pnglibconf.h.  This means that these build
+pnglibconf.h.prebuilt to pnglibconf.h.  This means that these build
 systems do not permit easy auto-configuration of the library - they only
 support the default configuration.
 
@@ -227,12 +227,13 @@ form of 'option' settings.
 A. Changing pnglibconf.h
 
 A variety of methods exist to build libpng.  Not all of these support
-reconfiguration of pnglibconf.h.  To reconfigure pnglibconf.h it must either be
-rebuilt from scripts/pnglibconf.dfa using awk or it must be edited by hand.
+reconfiguration of pnglibconf.h.  To reconfigure pnglibconf.h, it must either
+be rebuilt from scripts/pnglibconf/pnglibconf.dfa using awk, or it must be
+edited by hand.
 
-Hand editing is achieved by copying scripts/pnglibconf.h.prebuilt to
-pnglibconf.h and changing the lines defining the supported features, paying
-very close attention to the 'option' information in scripts/pnglibconf.dfa
+Hand editing is achieved by copying pnglibconf.h.prebuilt to pnglibconf.h and
+changing the lines defining the supported features, paying close attention to
+the 'option' information in scripts/pnglibconf/pnglibconf.dfa
 that describes those features and their requirements.  This is easy to get
 wrong.
 
@@ -241,14 +242,14 @@ B. Configuration using DFA_XTRA
 Rebuilding from pnglibconf.dfa is easy if a functioning 'awk', or a later
 variant such as 'nawk' or 'gawk', is available.  The configure build will
 automatically find an appropriate awk and build pnglibconf.h.
-The scripts/pnglibconf.mak file contains a set of make rules for doing the
-same thing if configure is not used, and many of the makefiles in the scripts
-directory use this approach.
+The scripts/pnglibconf/pnglibconf.mak file contains a set of make rules for
+doing the same thing if configure is not used, and many of the makefiles in
+the scripts directory use this approach.
 
 When rebuilding simply write a new file containing changed options and set
-DFA_XTRA to the name of this file.  This causes the build to append the new file
-to the end of scripts/pnglibconf.dfa.  The pngusr.dfa file should contain lines
-of the following forms:
+DFA_XTRA to the name of this file.  This causes the build to append the new
+file to the end of scripts/pnglibconf/pnglibconf.dfa.  The pngusr.dfa file
+should contain lines of the following forms:
 
 everything = off
 
@@ -280,8 +281,8 @@ C. Configuration using PNG_USER_CONFIG
 
 If -DPNG_USER_CONFIG is added to the CPPFLAGS when pnglibconf.h is built,
 the file pngusr.h will automatically be included before the options in
-scripts/pnglibconf.dfa are processed.  Your pngusr.h file should contain only
-macro definitions turning features on or off or setting settings.
+scripts/pnglibconf/pnglibconf.dfa are processed.  Your pngusr.h file should
+contain only macro definitions turning features on or off or setting settings.
 
 Apart from the global setting "everything = off" all the options listed above
 can be set using macros in pngusr.h:
@@ -305,7 +306,8 @@ is equivalent to:
 setting feature default value
 
 Notice that in both cases, pngusr.dfa and pngusr.h, the contents of the
-pngusr file you supply override the contents of scripts/pnglibconf.dfa
+pngusr file you supply override the contents of
+scripts/pnglibconf/pnglibconf.dfa
 
 If confusing or incomprehensible behavior results it is possible to
 examine the intermediate file pnglibconf.dfn to find the full set of

--- a/manuals/libpng.3
+++ b/manuals/libpng.3
@@ -712,7 +712,7 @@ the next section ("Reading").
 
 Notice that some of the makefiles in the 'scripts' directory and (in 1.5.0) all
 of the build project files in the 'projects' directory simply copy
-scripts/pnglibconf.h.prebuilt to pnglibconf.h.  This means that these build
+pnglibconf.h.prebuilt to pnglibconf.h.  This means that these build
 systems do not permit easy auto-configuration of the library - they only
 support the default configuration.
 
@@ -736,12 +736,13 @@ form of 'option' settings.
 A. Changing pnglibconf.h
 
 A variety of methods exist to build libpng.  Not all of these support
-reconfiguration of pnglibconf.h.  To reconfigure pnglibconf.h it must either be
-rebuilt from scripts/pnglibconf.dfa using awk or it must be edited by hand.
+reconfiguration of pnglibconf.h.  To reconfigure pnglibconf.h, it must either
+be rebuilt from scripts/pnglibconf/pnglibconf.dfa using awk, or it must be
+edited by hand.
 
-Hand editing is achieved by copying scripts/pnglibconf.h.prebuilt to
-pnglibconf.h and changing the lines defining the supported features, paying
-very close attention to the 'option' information in scripts/pnglibconf.dfa
+Hand editing is achieved by copying pnglibconf.h.prebuilt to pnglibconf.h and
+changing the lines defining the supported features, paying close attention to
+the 'option' information in scripts/pnglibconf/pnglibconf.dfa
 that describes those features and their requirements.  This is easy to get
 wrong.
 
@@ -750,14 +751,14 @@ B. Configuration using DFA_XTRA
 Rebuilding from pnglibconf.dfa is easy if a functioning 'awk', or a later
 variant such as 'nawk' or 'gawk', is available.  The configure build will
 automatically find an appropriate awk and build pnglibconf.h.
-The scripts/pnglibconf.mak file contains a set of make rules for doing the
-same thing if configure is not used, and many of the makefiles in the scripts
-directory use this approach.
+The scripts/pnglibconf/pnglibconf.mak file contains a set of make rules for
+doing the same thing if configure is not used, and many of the makefiles in
+the scripts directory use this approach.
 
 When rebuilding simply write a new file containing changed options and set
-DFA_XTRA to the name of this file.  This causes the build to append the new file
-to the end of scripts/pnglibconf.dfa.  The pngusr.dfa file should contain lines
-of the following forms:
+DFA_XTRA to the name of this file.  This causes the build to append the new
+file to the end of scripts/pnglibconf/pnglibconf.dfa.  The pngusr.dfa file
+should contain lines of the following forms:
 
 everything = off
 
@@ -789,8 +790,8 @@ C. Configuration using PNG_USER_CONFIG
 
 If \-DPNG_USER_CONFIG is added to the CPPFLAGS when pnglibconf.h is built,
 the file pngusr.h will automatically be included before the options in
-scripts/pnglibconf.dfa are processed.  Your pngusr.h file should contain only
-macro definitions turning features on or off or setting settings.
+scripts/pnglibconf/pnglibconf.dfa are processed.  Your pngusr.h file should
+contain only macro definitions turning features on or off or setting settings.
 
 Apart from the global setting "everything = off" all the options listed above
 can be set using macros in pngusr.h:
@@ -814,7 +815,8 @@ is equivalent to:
 setting feature default value
 
 Notice that in both cases, pngusr.dfa and pngusr.h, the contents of the
-pngusr file you supply override the contents of scripts/pnglibconf.dfa
+pngusr file you supply override the contents of
+scripts/pnglibconf/pnglibconf.dfa
 
 If confusing or incomprehensible behavior results it is possible to
 examine the intermediate file pnglibconf.dfn to find the full set of

--- a/png.h
+++ b/png.h
@@ -322,8 +322,8 @@
  * the library has been built.
  */
 #ifndef PNGLCONF_H
-/* If pnglibconf.h is missing, you can
- * copy scripts/pnglibconf.h.prebuilt to pnglibconf.h
+/* If pnglibconf.h is missing, you can copy
+ * pnglibconf.h.prebuilt to pnglibconf.h
  */
 #   include "pnglibconf.h"
 #endif

--- a/pnglibconf.h.prebuilt
+++ b/pnglibconf.h.prebuilt
@@ -11,7 +11,7 @@
 
 /* pnglibconf.h */
 /* Machine generated file: DO NOT EDIT */
-/* Derived from: scripts/pnglibconf.dfa */
+/* Derived from: scripts/pnglibconf/pnglibconf.dfa */
 #ifndef PNGLCONF_H
 #define PNGLCONF_H
 /* options */

--- a/pngpriv.h
+++ b/pngpriv.h
@@ -228,8 +228,8 @@
 /* SECURITY and SAFETY:
  *
  * libpng is built with support for internal limits on image dimensions and
- * memory usage.  These are documented in scripts/pnglibconf.dfa of the
- * source and recorded in the machine generated header file pnglibconf.h.
+ * memory usage.  These are documented in scripts/pnglibconf/pnglibconf.dfa of
+ * the source and recorded in the machine generated header file pnglibconf.h.
  */
 
 /* If you are running on a machine where you cannot allocate more

--- a/pngrtran.c
+++ b/pngrtran.c
@@ -1528,9 +1528,10 @@ png_init_read_transformations(png_structrp png_ptr)
    }
 #endif
 
-   /* NOTE: below 'PNG_READ_ALPHA_MODE_SUPPORTED' is presumed to also enable the
-    * background support (see the comments in scripts/pnglibconf.dfa), this
-    * allows pre-multiplication of the alpha channel to be implemented as
+   /* NOTE:
+    * Below 'PNG_READ_ALPHA_MODE_SUPPORTED' is presumed to also enable the
+    * background support; see comments in scripts/pnglibconf/pnglibconf.dfa.
+    * This allows pre-multiplication of the alpha channel to be implemented as
     * compositing on black.  This is probably sub-optimal and has been done in
     * 1.5.4 betas simply to enable external critique and testing (i.e. to
     * implement the new API quickly, without lots of internal changes.)

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -21,22 +21,11 @@ Makefiles for libpng
 Other supporting files and scripts
 ----------------------------------
 
-    pnglibconf.h.prebuilt  =>  Pre-built configuration settings
     libpng-config-body.in  =>  Used by several makefiles to create libpng-config
     libpng-config-head.in  =>  Used by several makefiles to create libpng-config
     libpng.pc.in       =>  Used by several makefiles to create libpng.pc
     macro.lst          =>  Used by GNU Autotools
     pngwin.rc          =>  Used by the Visual Studio project
-    checksym.awk       =>  Used for maintaining pnglibconf.h
-    dfn.awk            =>  Used for maintaining pnglibconf.h
-    options.awk        =>  Used for maintaining pnglibconf.h
-    pnglibconf.dfa     =>  Used for maintaining pnglibconf.h
-    pnglibconf.mak     =>  Used for maintaining pnglibconf.h
-    intprefix.c        =>  Used for symbol versioning
-    prefix.c           =>  Used for symbol versioning
-    sym.c              =>  Used for symbol versioning
-    symbols.c          =>  Used for symbol versioning
-    vers.c             =>  Used for symbol versioning
     README.txt         =>  This file
 
 Further information can be found in comments in the individual scripts and

--- a/scripts/cmake/genchk.cmake.in
+++ b/scripts/cmake/genchk.cmake.in
@@ -1,7 +1,7 @@
 # genchk.cmake.in
 # Generate .chk from .out with awk (generic), based upon the automake logic.
 
-# Copyright (c) 2022-2024 Cosmin Truta
+# Copyright (c) 2022-2025 Cosmin Truta
 # Copyright (c) 2016 Glenn Randers-Pehrson
 # Written by Roger Leigh, 2016
 #
@@ -28,7 +28,7 @@ get_filename_component(OUTPUTDIR "${OUTPUT}" PATH)
 if(INPUTEXT STREQUAL ".out" AND OUTPUTEXT STREQUAL ".chk")
   # Generate .chk from .out with awk (generic)
   file(REMOVE "${OUTPUT}" "${OUTPUTDIR}/${OUTPUTBASE}.new")
-  execute_process(COMMAND "${AWK}" -f "${BINDIR}/scripts/checksym.awk"
+  execute_process(COMMAND "${AWK}" -f "${BINDIR}/scripts/pnglibconf/checksym.awk"
                           "${SRCDIR}/scripts/${INPUTBASE}.def"
                           "of=${OUTPUTDIR}/${OUTPUTBASE}.new"
                           "${INPUT}"

--- a/scripts/cmake/genout.cmake.in
+++ b/scripts/cmake/genout.cmake.in
@@ -1,7 +1,7 @@
 # genout.cmake.in
 # Generate .out from .c with awk (generic), based upon the automake logic.
 
-# Copyright (c) 2022-2024 Cosmin Truta
+# Copyright (c) 2022-2025 Cosmin Truta
 # Copyright (c) 2016 Glenn Randers-Pehrson
 # Written by Roger Leigh, 2016
 #
@@ -87,8 +87,9 @@ if(INPUTEXT STREQUAL ".c" AND OUTPUTEXT STREQUAL ".out")
     message(FATAL_ERROR "Failed to generate ${OUTPUT}.tf1")
   endif()
 
-  execute_process(COMMAND "${AWK}" -f "${SRCDIR}/scripts/dfn.awk"
-                          "out=${OUTPUT}.tf2" "${OUTPUT}.tf1"
+  execute_process(COMMAND "${AWK}" -f "${SRCDIR}/scripts/pnglibconf/dfn.awk"
+                          "out=${OUTPUT}.tf2"
+                          "${OUTPUT}.tf1"
                   WORKING_DIRECTORY "${BINDIR}"
                   RESULT_VARIABLE AWK_FAIL)
   if(AWK_FAIL)

--- a/scripts/cmake/gensrc.cmake.in
+++ b/scripts/cmake/gensrc.cmake.in
@@ -1,7 +1,7 @@
 # gensrc.cmake.in
 # Generate source files with awk, based upon the automake logic.
 
-# Copyright (c) 2022-2024 Cosmin Truta
+# Copyright (c) 2022-2025 Cosmin Truta
 # Copyright (c) 2016 Glenn Randers-Pehrson
 # Written by Roger Leigh, 2016
 #
@@ -21,24 +21,27 @@ set(DFA_XTRA "@DFA_XTRA@")
 set(PNG_PREFIX "@PNG_PREFIX@")
 set(PNGLIB_VERSION "@PNGLIB_VERSION@")
 
-if(OUTPUT STREQUAL "scripts/pnglibconf.c")
-  # Generate scripts/pnglibconf.c
+if(OUTPUT STREQUAL "scripts/pnglibconf/pnglibconf.c")
+  # Generate scripts/pnglibconf/pnglibconf.c
 
   file(REMOVE "${BINDIR}/pnglibconf.tf6" "${BINDIR}/pnglibconf.tf7")
 
   execute_process(COMMAND "${CMAKE_COMMAND}" -E echo "com ${PNGLIB_VERSION} STANDARD API DEFINITION"
-                  COMMAND "${AWK}" -f "${SRCDIR}/scripts/options.awk"
-                          "out=pnglibconf.tf6" "logunsupported=1" "version=search"
+                  COMMAND "${AWK}" -f "${SRCDIR}/scripts/pnglibconf/options.awk"
+                          "out=pnglibconf.tf6"
+                          "logunsupported=1"
+                          "version=search"
                           "${SRCDIR}/pngconf.h" "-"
-                          "${SRCDIR}/scripts/pnglibconf.dfa"
+                          "${SRCDIR}/scripts/pnglibconf/pnglibconf.dfa"
                   WORKING_DIRECTORY "${BINDIR}"
                   RESULT_VARIABLE AWK_FAIL)
   if(AWK_FAIL)
     message(FATAL_ERROR "Failed to generate pnglibconf.tf6")
   endif()
 
-  execute_process(COMMAND "${AWK}" -f "${SRCDIR}/scripts/options.awk"
-                  "out=pnglibconf.tf7" "pnglibconf.tf6"
+  execute_process(COMMAND "${AWK}" -f "${SRCDIR}/scripts/pnglibconf/options.awk"
+                  "out=pnglibconf.tf7"
+                  "pnglibconf.tf6"
                   WORKING_DIRECTORY "${BINDIR}"
                   RESULT_VARIABLE AWK_FAIL)
   if(AWK_FAIL)
@@ -47,25 +50,29 @@ if(OUTPUT STREQUAL "scripts/pnglibconf.c")
 
   file(REMOVE "pnglibconf.tf6")
   file(MAKE_DIRECTORY "${BINDIR}/scripts")
-  file(RENAME "pnglibconf.tf7" "${BINDIR}/scripts/pnglibconf.c")
+  file(RENAME "pnglibconf.tf7" "${BINDIR}/scripts/pnglibconf/pnglibconf.c")
 
 elseif(OUTPUT STREQUAL "pnglibconf.c")
   # Generate pnglibconf.c
 
   file(REMOVE "${BINDIR}/pnglibconf.tf4" "${BINDIR}/pnglibconf.tf5")
 
-  execute_process(COMMAND "${AWK}" -f "${SRCDIR}/scripts/options.awk"
-                  out=pnglibconf.tf4 version=search
-                  ${SRCDIR}/pngconf.h ${SRCDIR}/scripts/pnglibconf.dfa
-                  ${SRCDIR}/pngusr.dfa ${DFA_XTRA}
+  execute_process(COMMAND "${AWK}" -f "${SRCDIR}/scripts/pnglibconf/options.awk"
+                  "out=pnglibconf.tf4"
+                  "version=search"
+                  "${SRCDIR}/pngconf.h"
+                  "${SRCDIR}/scripts/pnglibconf/pnglibconf.dfa"
+                  "${SRCDIR}/pngusr.dfa"
+                  ${DFA_XTRA}
                   WORKING_DIRECTORY "${BINDIR}"
                   RESULT_VARIABLE AWK_FAIL)
   if(AWK_FAIL)
     message(FATAL_ERROR "Failed to generate pnglibconf.tf4")
   endif()
 
-  execute_process(COMMAND "${AWK}" -f "${SRCDIR}/scripts/options.awk"
-                  out=pnglibconf.tf5 pnglibconf.tf4
+  execute_process(COMMAND "${AWK}" -f "${SRCDIR}/scripts/pnglibconf/options.awk"
+                  "out=pnglibconf.tf5"
+                  "pnglibconf.tf4"
                   WORKING_DIRECTORY "${BINDIR}"
                   RESULT_VARIABLE AWK_FAIL)
   if(AWK_FAIL)
@@ -87,9 +94,11 @@ elseif(OUTPUT STREQUAL "pnglibconf.h")
                              s==0{prev=\$0}
                              s==1{print \"#define\", \$1, \"${PNG_PREFIX}\" \$1}
                              s==2{print \"#define ${PNG_PREFIX}png_\" \$1, \"PNG_\" \$1}
-                             END{print prev}" s=0 pnglibconf.out s=1 "${BINDIR}/scripts/prefix.out"
+                             END{print prev}"
+                             s=0 "pnglibconf.out"
+                             s=1 "${BINDIR}/scripts/pnglibconf/prefix.out"
                              s=2 "${SRCDIR}/scripts/macro.lst"
-                    OUTPUT_FILE pnglibconf.tf8
+                    OUTPUT_FILE "pnglibconf.tf8"
                     RESULT_VARIABLE AWK_FAIL)
     if(AWK_FAIL)
       message(FATAL_ERROR "Failed to generate pnglibconf.tf8")
@@ -115,7 +124,7 @@ elseif(OUTPUT STREQUAL "pngprefix.h")
 
     execute_process(COMMAND "${AWK}"
                             "{print \"#define\", \$1, \"${PNG_PREFIX}\" \$1}"
-                            "${BINDIR}/scripts/intprefix.out"
+                            "${BINDIR}/scripts/pnglibconf/intprefix.out"
                     OUTPUT_FILE "pngprefix.tf1"
                     RESULT_VARIABLE AWK_FAIL)
     if(AWK_FAIL)
@@ -127,13 +136,13 @@ elseif(OUTPUT STREQUAL "pngprefix.h")
     file(WRITE "${BINDIR}/${OUTPUT}" "/* No libpng symbol prefix configured. */")
   endif()
 
-elseif(OUTPUT STREQUAL "scripts/pnglibconf.h.prebuilt")
-  # Generate scripts/pnglibconf.h.prebuilt (fails build)
+elseif(OUTPUT STREQUAL "pnglibconf.h.prebuilt")
+  # Generate pnglibconf.h.prebuilt (fails build)
 
-  message(STATUS "Attempting to build scripts/pnglibconf.h.prebuilt")
+  message(STATUS "Attempting to build pnglibconf.h.prebuilt")
   message(STATUS "This is a machine generated file, but if you want to make")
   message(STATUS "a new one simply build the 'png_genfiles' target, and copy")
-  message(STATUS "scripts/pnglibconf.out to scripts/pnglibconf.h.prebuilt")
+  message(STATUS "scripts/pnglibconf/pnglibconf.out to pnglibconf.h.prebuilt")
   message(STATUS "AND set PNG_ZLIB_VERNUM to 0 (you MUST do this)")
   message(FATAL_ERROR "Stopping build")
 

--- a/scripts/makefile.amiga
+++ b/scripts/makefile.amiga
@@ -28,8 +28,8 @@ RM= delete quiet
 AR= oml
 
 # Pre-built configuration
-# See scripts/pnglibconf.mak for more options
-PNGLIBCONF_H_PREBUILT = scripts/pnglibconf.h.prebuilt
+# See scripts/pnglibconf/pnglibconf.mak for more options
+PNGLIBCONF_H_PREBUILT = pnglibconf.h.prebuilt
 
 OBJS = png.o pngerror.o pngget.o pngmem.o pngpread.o \
        pngread.o pngrio.o pngrtran.o pngrutil.o pngset.o \

--- a/scripts/makefile.atari
+++ b/scripts/makefile.atari
@@ -16,8 +16,8 @@ LBR = png.lib
 LDFLAGS = -L. -L../zlib -lpng -lz -lm
 
 # Pre-built configuration
-# See scripts/pnglibconf.mak for more options
-PNGLIBCONF_H_PREBUILT = scripts/pnglibconf.h.prebuilt
+# See scripts/pnglibconf/pnglibconf.mak for more options
+PNGLIBCONF_H_PREBUILT = pnglibconf.h.prebuilt
 
 OBJS = $(LBR)(png.o) $(LBR)(pngerror.o) $(LBR)(pngget.o) $(LBR)(pngmem.o) \
        $(LBR)(pngpread.o) $(LBR)(pngread.o) $(LBR)(pngrio.o) \

--- a/scripts/makefile.clang
+++ b/scripts/makefile.clang
@@ -38,8 +38,8 @@ LIBS = -lz -lm
 EXEEXT =
 
 # Pre-built configuration
-# See scripts/pnglibconf.mak for more options
-PNGLIBCONF_H_PREBUILT = scripts/pnglibconf.h.prebuilt
+# See scripts/pnglibconf/pnglibconf.mak for more options
+PNGLIBCONF_H_PREBUILT = pnglibconf.h.prebuilt
 
 # File lists
 OBJS = png.o pngerror.o pngget.o pngmem.o pngpread.o pngread.o \

--- a/scripts/makefile.emcc
+++ b/scripts/makefile.emcc
@@ -36,8 +36,8 @@ PNGTEST_LDFLAGS = --preload-file=pngtest.png
 LIBS = -lz -lm
 
 # Pre-built configuration
-# See scripts/pnglibconf.mak for more options
-PNGLIBCONF_H_PREBUILT = scripts/pnglibconf.h.prebuilt
+# See scripts/pnglibconf/pnglibconf.mak for more options
+PNGLIBCONF_H_PREBUILT = pnglibconf.h.prebuilt
 
 # File lists
 OBJS = png.o pngerror.o pngget.o pngmem.o pngpread.o pngread.o \

--- a/scripts/makefile.gcc
+++ b/scripts/makefile.gcc
@@ -38,8 +38,8 @@ LIBS = -lz -lm
 EXEEXT =
 
 # Pre-built configuration
-# See scripts/pnglibconf.mak for more options
-PNGLIBCONF_H_PREBUILT = scripts/pnglibconf.h.prebuilt
+# See scripts/pnglibconf/pnglibconf.mak for more options
+PNGLIBCONF_H_PREBUILT = pnglibconf.h.prebuilt
 
 # File lists
 OBJS = png.o pngerror.o pngget.o pngmem.o pngpread.o pngread.o \

--- a/scripts/makefile.ibmc
+++ b/scripts/makefile.ibmc
@@ -29,8 +29,8 @@ CFLAGS = -Mc -O2 -W3
 LDFLAGS =
 
 # Pre-built configuration
-# See scripts/pnglibconf.mak for more options
-PNGLIBCONF_H_PREBUILT = scripts/pnglibconf.h.prebuilt
+# See scripts/pnglibconf/pnglibconf.mak for more options
+PNGLIBCONF_H_PREBUILT = pnglibconf.h.prebuilt
 
 # File extensions
 O=.obj

--- a/scripts/makefile.std
+++ b/scripts/makefile.std
@@ -31,8 +31,8 @@ LDFLAGS = -L$(ZLIBLIB) -g
 LIBS = -lz -lm
 
 # Pre-built configuration
-# See scripts/pnglibconf.mak for more options
-PNGLIBCONF_H_PREBUILT = scripts/pnglibconf.h.prebuilt
+# See scripts/pnglibconf/pnglibconf.mak for more options
+PNGLIBCONF_H_PREBUILT = pnglibconf.h.prebuilt
 
 OBJS = png.o pngerror.o pngget.o pngmem.o pngpread.o pngread.o \
        pngrio.o pngrtran.o pngrutil.o pngset.o pngsimd.o \
@@ -43,24 +43,29 @@ OBJS = png.o pngerror.o pngget.o pngmem.o pngpread.o pngread.o \
 
 all: libpng.a pngtest
 
-# The standard pnglibconf.h exists as scripts/pnglibconf.h.prebuilt,
-# copy this if the following doesn't work.
+# The standard pnglibconf.h exists as pnglibconf.h.prebuilt.
+# Copy this over if the following doesn't work.
 pnglibconf.h: pnglibconf.dfn
 	$(RM_F) $@ pnglibconf.c pnglibconf.out pnglibconf.tmp
 	echo '#include "pnglibconf.dfn"' >pnglibconf.c
 	@echo "## If '$(CC) -E' fails, try /lib/cpp (e.g. CPP='/lib/cpp')" >&2
 	$(CPP) $(DFNFLAGS) pnglibconf.c >pnglibconf.out
-	$(AWK) -f scripts/dfn.awk out=pnglibconf.tmp pnglibconf.out >&2
+	$(AWK) -f scripts/pnglibconf/dfn.awk\
+	    out=pnglibconf.tmp pnglibconf.out >&2
 	$(MV_F) pnglibconf.tmp $@
 
-pnglibconf.dfn: scripts/pnglibconf.dfa scripts/options.awk pngconf.h pngusr.dfa $(DFA_XTRA)
+pnglibconf.dfn: scripts/pnglibconf/pnglibconf.dfa \
+                scripts/pnglibconf/options.awk \
+                pngconf.h pngusr.dfa $(DFA_XTRA)
 	$(RM_F) $@ pnglibconf.pre pnglibconf.tmp
-	@echo "## Calling $(AWK) from scripts/pnglibconf.mak" >&2
+	@echo "## Calling $(AWK) from scripts/pnglibconf/pnglibconf.mak" >&2
 	@echo "## If 'awk' fails, try a better awk (e.g. AWK='nawk')" >&2
-	$(AWK) -f scripts/options.awk out=pnglibconf.pre\
-	    version=search pngconf.h scripts/pnglibconf.dfa\
+	$(AWK) -f scripts/pnglibconf/options.awk\
+            out=pnglibconf.pre version=search\
+            pngconf.h scripts/pnglibconf/pnglibconf.dfa\
 	    pngusr.dfa $(DFA_XTRA) >&2
-	$(AWK) -f scripts/options.awk out=pnglibconf.tmp pnglibconf.pre >&2
+	$(AWK) -f scripts/pnglibconf/options.awk\
+	    out=pnglibconf.tmp pnglibconf.pre >&2
 	$(MV_F) pnglibconf.tmp $@
 
 libpng.a: $(OBJS)

--- a/scripts/pnglibconf/README.md
+++ b/scripts/pnglibconf/README.md
@@ -1,0 +1,15 @@
+pnglibconf - libpng configuration utilities
+===========================================
+
+Copyright Notice
+----------------
+
+ * Copyright (c) 2025 Cosmin Truta.
+ * Copyright (c) 2010-2014 Glenn Randers-Pehrson.
+ * Originally written by John Bowler, 2010.
+
+Use, modification and distribution of the pnglibconf
+software in the libpng distribution are subject to
+the same licensing terms and conditions as libpng.
+Please see the copyright notice in `png.h` or visit
+http://libpng.org/pub/png/src/libpng-LICENSE.txt

--- a/scripts/pnglibconf/checksym.awk
+++ b/scripts/pnglibconf/checksym.awk
@@ -94,8 +94,8 @@ END {
    }
 
    # Sort and print the symbols.
-   asort(sorted_symbols)
-   for (i = 1; i <= length(sorted_symbols); i++) {
+   num = do_sort(sorted_symbols)
+   for (i = 1; i <= num; i++) {
       print " " sorted_symbols[i] >of
    }
 
@@ -105,4 +105,21 @@ END {
    }
 
    # TODO: Check for symbols that are both defined and removed.
+}
+
+# Portable replacement for the gawk-specific asort function.
+function do_sort(arr) {
+   # Perform insertion sort, which should be fast enough for our use case.
+   num = length(arr)
+   for (i = 2; i <= num; i++) {
+      key = arr[i]
+      j = i - 1
+      while (j > 0 && arr[j] > key) {
+         arr[j + 1] = arr[j]
+         j = j - 1
+      }
+      arr[j + 1] = key
+   }
+   # Return the array size, as in the asort function.
+   return num
 }

--- a/scripts/pnglibconf/checksym.awk
+++ b/scripts/pnglibconf/checksym.awk
@@ -1,11 +1,18 @@
 #!/bin/awk -f
 
-# scripts/checksym.awk
-# check a list of symbols against the master definition list
+# checksym.awk - check a list of symbols against the master definition list
 #
 # Copyright (c) 2025 Cosmin Truta
 # Copyright (c) 2010 Glenn Randers-Pehrson
+# Originally written by John Bowler, 2010
 #
+# Use, modification and distribution are subject to
+# the same licensing terms and conditions as libpng.
+# Please see the copyright notice in png.h or visit
+# http://libpng.org/pub/png/src/libpng-LICENSE.txt
+#
+# SPDX-License-Identifier: libpng-2.0
+
 # Usage:
 # awk -f checksym.awk official-def list-to-check
 #

--- a/scripts/pnglibconf/dfn.awk
+++ b/scripts/pnglibconf/dfn.awk
@@ -1,13 +1,17 @@
 #!/bin/awk -f
 
-# scripts/dfn.awk - process a .dfn file
+# dfn.awk - process a .dfn file
 #
 # Copyright (c) 2025 Cosmin Truta
 # Copyright (c) 2013-2014 Glenn Randers-Pehrson
+# Originally written by John Bowler, 2013
 #
-# This code is released under the libpng license.
-# For conditions of distribution and use, see the disclaimer
-# and license in png.h
+# Use, modification and distribution are subject to
+# the same licensing terms and conditions as libpng.
+# Please see the copyright notice in png.h or visit
+# http://libpng.org/pub/png/src/libpng-LICENSE.txt
+#
+# SPDX-License-Identifier: libpng-2.0
 
 # The output of this script is written to the file given by
 # the variable 'out', which should be set on the command line.

--- a/scripts/pnglibconf/intprefix.c
+++ b/scripts/pnglibconf/intprefix.c
@@ -17,4 +17,4 @@
         PNG_DFN "@" name "@"
 
 #define PNGPREFIX_H /* self generation */
-#include "../pngpriv.h"
+#include "../../pngpriv.h"

--- a/scripts/pnglibconf/options.awk
+++ b/scripts/pnglibconf/options.awk
@@ -1,21 +1,25 @@
 #!/bin/awk -f
 
-# scripts/options.awk - library build configuration control
+# options.awk - control the libpng build configuration
 #
 # Copyright (c) 2025 Cosmin Truta
 # Copyright (c) 2010-2014 Glenn Randers-Pehrson
+# Originally written by John Bowler, 2010
 #
-# This code is released under the libpng license.
-# For conditions of distribution and use, see the disclaimer
-# and license in png.h
+# Use, modification and distribution are subject to
+# the same licensing terms and conditions as libpng.
+# Please see the copyright notice in png.h or visit
+# http://libpng.org/pub/png/src/libpng-LICENSE.txt
+#
+# SPDX-License-Identifier: libpng-2.0
 
 # The output of this script is written to the file given by
 # the variable 'out'.  The script is run twice, once with
 # an intermediate output file, 'options.tmp' then again on
 # that file to produce the final output:
 #
-#  awk -f scripts/options.awk out=options.tmp scripts/options.dfa 1>&2
-#  awk -f scripts/options.awk out=options.dfn options.tmp 1>&2
+#  awk -f options.awk out=options.tmp options.dfa 1>&2
+#  awk -f options.awk out=options.dfn options.tmp 1>&2
 #
 # Some options may be specified on the command line:
 #
@@ -234,6 +238,7 @@ $1 == "file" && NF >= 2 {
    print comment, "Machine generated file: DO NOT EDIT", cend >out
    if (NF >= 3)
       print comment, "Derived from:", $3, cend >out
+   print >out
    protect = $4
    if (protect != "") {
       print start "#ifndef", protect end >out

--- a/scripts/pnglibconf/pnglibconf.dfa
+++ b/scripts/pnglibconf/pnglibconf.dfa
@@ -1,7 +1,7 @@
-# scripts/pnglibconf.dfa - library build configuration control
+# pnglibconf.dfa - library build configuration control
 #
 @/*- pnglibconf.dfn intermediate file
-@ *  generated from scripts/pnglibconf.dfa
+@ *  generated from scripts/pnglibconf/pnglibconf.dfa
 @ */
 #
 com pnglibconf.h - library build configuration
@@ -16,17 +16,15 @@ com For conditions of distribution and use, see the disclaimer
 com and license in png.h
 com
 
-file pnglibconf.h scripts/pnglibconf.dfa PNGLCONF_H
+file pnglibconf.h scripts/pnglibconf/pnglibconf.dfa PNGLCONF_H
 
-# This file is preprocessed by scripts/options.awk and the
-# C compiler to generate 'pnglibconf.h' - a list of all the
-# configuration options.  The file lists the various options
-# that can *only* be specified during the libpng build;
-# pnglibconf.h freezes the definitions selected for the specific
-# build.
+# This file is preprocessed by options.awk and the C compiler to
+# generate 'pnglibconf.h' - a list of all configuration options.
+# The file lists the various options that can *only* be specified
+# during the libpng build; pnglibconf.h freezes the definitions
+# selected for the specific build.
 #
-# The syntax is detailed in scripts/options.awk; this is a summary
-# only:
+# The syntax is detailed in options.awk; This is a summary only:
 #
 # setting <name> [requires ...] [default]
 #    #define PNG_<name> <value>  /* value comes from current setting */

--- a/scripts/pnglibconf/pnglibconf.mak
+++ b/scripts/pnglibconf/pnglibconf.mak
@@ -1,9 +1,10 @@
 #!/usr/bin/make -f
 # pnglibconf.mak - standard make lines for pnglibconf.h
 #
-# These lines are copied from Makefile.am, they illustrate
-# how to automate the build of pnglibconf.h from scripts/pnglibconf.dfa
-# given just 'awk', a C preprocessor and standard command line utilities
+# The following lines are copied from Makefile.am.
+# They illustrate how to automate the build of pnglibconf.h from
+# scripts/pnglibconf/pnglibconf.dfa, given just the awk program,
+# a C preprocessor, and standard command-line utilities.
 
 # Override as appropriate, these definitions can be overridden on
 # the make command line (AWK='nawk' for example).
@@ -17,7 +18,7 @@ CPP = $(CC) -E # If this fails on SunOS 5.10, use '/lib/cpp'
 MOVE = mv -f
 DELETE = rm -f
 
-DFA_XTRA = # Put your configuration file here, see scripts/pnglibconf.dfa.  Eg:
+DFA_XTRA = # Put your configuration file here; see pnglibconf.dfa. For example:
 # DFA_XTRA = pngusr.dfa
 
 # CPPFLAGS should contain the options to control the result,
@@ -28,8 +29,8 @@ DFNFLAGS = $(DEFS) $(CPPFLAGS) $(CFLAGS)
 # srcdir is a de-facto standard for the location of the source
 srcdir = .
 
-# The standard pnglibconf.h exists as scripts/pnglibconf.h.prebuilt,
-# copy this if the following doesn't work.
+# The standard pnglibconf.h exists as pnglibconf.h.prebuilt.
+# Copy this over if the following doesn't work.
 pnglibconf.h: pnglibconf.dfn
 	$(DELETE) $@ pnglibconf.c pnglibconf.out pnglibconf.tmp
 	echo '#include "pnglibconf.dfn"' >pnglibconf.c
@@ -38,18 +39,20 @@ pnglibconf.h: pnglibconf.dfn
 	$(AWK) -f $(srcdir)/scripts/dfn.awk out=pnglibconf.tmp pnglibconf.out >&2
 	$(MOVE) pnglibconf.tmp $@
 
-pnglibconf.dfn: $(srcdir)/scripts/pnglibconf.dfa $(srcdir)/scripts/options.awk $(srcdir)/pngconf.h $(srcdir)/pngusr.dfa $(DFA_XTRA)
+pnglibconf.dfn: $(srcdir)/scripts/pnglibconf/pnglibconf.dfa \
+                $(srcdir)/scripts/pnglibconf/options.awk \
+                $(srcdir)/pngconf.h $(srcdir)/pngusr.dfa $(DFA_XTRA)
 	$(DELETE) $@ pnglibconf.pre pnglibconf.tmp
-	@echo "## Calling $(AWK) from scripts/pnglibconf.mak" >&2
+	@echo "## Calling $(AWK) from scripts/pnglibconf/pnglibconf.mak" >&2
 	@echo "## If 'awk' fails, try a better awk (e.g. AWK='nawk')" >&2
-	$(AWK) -f $(srcdir)/scripts/options.awk out=pnglibconf.pre\
-	    version=search $(srcdir)/pngconf.h $(srcdir)/scripts/pnglibconf.dfa\
+	$(AWK) -f $(srcdir)/scripts/options.awk\
+	    out=pnglibconf.pre version=search\
+	    $(srcdir)/pngconf.h $(srcdir)/scripts/pnglibconf/pnglibconf.dfa\
 	    $(srcdir)/pngusr.dfa $(DFA_XTRA) >&2
 	$(AWK) -f $(srcdir)/scripts/options.awk out=pnglibconf.tmp pnglibconf.pre >&2
 	$(MOVE) pnglibconf.tmp $@
 
 clean-pnglibconf:
-	$(DELETE) pnglibconf.h pnglibconf.c pnglibconf.out pnglibconf.pre \
-	pnglibconf.dfn
+	$(DELETE) pnglibconf.h pnglibconf.c pnglibconf.out pnglibconf.pre pnglibconf.dfn
 
 clean: clean-pnglibconf

--- a/scripts/pnglibconf/prefix.c
+++ b/scripts/pnglibconf/prefix.c
@@ -17,6 +17,6 @@
 
 PNG_DFN_START_SORT 1
 
-#include "../png.h"
+#include "../../png.h"
 
 PNG_DFN_END_SORT

--- a/scripts/pnglibconf/sym.c
+++ b/scripts/pnglibconf/sym.c
@@ -1,4 +1,4 @@
-/* vers.c - define format of libpng.vers
+/* sym.c - define format of libpng.sym
  *
  * Copyright (c) 2011-2014 Glenn Randers-Pehrson
  *
@@ -8,10 +8,6 @@
  */
 
 #define PNG_EXPORTA(type, name, args, attributes)\
-        PNG_DFN " @" SYMBOL_PREFIX "@@" name "@;"
+        PNG_DFN "@" SYMBOL_PREFIX "@@" name "@"
 
-PNG_DFN "@" PNGLIB_LIBNAME "@ {global:"
-
-#include "../png.h"
-
-PNG_DFN "local: *; };"
+#include "../../png.h"

--- a/scripts/pnglibconf/symbols.c
+++ b/scripts/pnglibconf/symbols.c
@@ -19,16 +19,16 @@
 #define PNG_REMOVED(type, name, args, attributes)\
         PNG_DFN "; @" name "@"
 
-/* Read the defaults, but use scripts/pnglibconf.h.prebuilt; the 'standard'
- * header file.
+/* Read the defaults, but use pnglibconf.h.prebuilt, i.e.,
+ * the 'standard' header file.
  */
-#include "pnglibconf.h.prebuilt"
-#include "../png.h"
+#include "../../pnglibconf.h.prebuilt"
+#include "../../png.h"
 
 /* Some things are turned off by default.  Turn these things
  * on here (by hand) to get the APIs they expose and validate
  * that no harm is done.  This list is the set of options
- * defaulted to 'off' in scripts/pnglibconf.dfa
+ * defaulted to 'off' in scripts/pnglibconf/pnglibconf.dfa
  *
  * Maintenance: if scripts/pnglibconf.dfa options are changed
  * from, or to, 'disabled' this needs updating!
@@ -41,7 +41,7 @@
 #define PNG_SET_OPTION_SUPPORTED
 
 #undef PNG_H
-#include "../png.h"
+#include "../../png.h"
 
 /* Finally there are a couple of places where option support
  * actually changes the APIs revealed using a #if/#else/#endif
@@ -51,4 +51,4 @@
 #undef  PNG_ERROR_TEXT_SUPPORTED     /* Exposes unsupported APIs */
 
 #undef PNG_H
-#include "../png.h"
+#include "../../png.h"

--- a/scripts/pnglibconf/vers.c
+++ b/scripts/pnglibconf/vers.c
@@ -1,4 +1,4 @@
-/* sym.c - define format of libpng.sym
+/* vers.c - define format of libpng.vers
  *
  * Copyright (c) 2011-2014 Glenn Randers-Pehrson
  *
@@ -8,6 +8,10 @@
  */
 
 #define PNG_EXPORTA(type, name, args, attributes)\
-        PNG_DFN "@" SYMBOL_PREFIX "@@" name "@"
+        PNG_DFN " @" SYMBOL_PREFIX "@@" name "@;"
 
-#include "../png.h"
+PNG_DFN "@" PNGLIB_LIBNAME "@ {global:"
+
+#include "../../png.h"
+
+PNG_DFN "local: *; };"


### PR DESCRIPTION
@jbowler please review.

Just so you know, after this change, the next fossil that I want to discard is the .DEF file and all the associated makefile-ing and scripting. We should neither produce it (with pnglibconf or not), nor consume it in any makefile or build file or project file any further. We should rather go back to using `__declspec(dllexport)` where applicable (i.e. on Windows), or `__attribute__((visibility("default")))` where applicable (on the Unix platforms with the compilers that allow it), which is what we used to use from libpng-1.0 to libpng-1.4, _except_ with one important difference: no more .DEF file.