### PR TITLE
Deimplementing complications in libpng18

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -284,7 +284,7 @@ pnglibconf.c: scripts/pnglibconf/pnglibconf.dfa scripts/pnglibconf/options.awk p
 	mv $*.tf5 $@
 
 # Symbol checks (.def and .out files should match)
-scripts/pnglibconf/symbols.chk: scripts/pnglibconf/checksym.awk scripts/pnglibconf/symbols.def \
+scripts/pnglibconf/symbols.chk: scripts/pnglibconf/checksym.awk scripts/symbols.def \
                                 scripts/pnglibconf/symbols.out
 
 .out.chk:

--- a/contrib/examples/pngpixel.c
+++ b/contrib/examples/pngpixel.c
@@ -184,11 +184,11 @@ int main(int argc, const char **argv)
                      compression_method, filter_method;
                   png_bytep row_tmp;
 
-                  /* Now associate the recently opened (FILE*) with the default
-                   * libpng initialization functions.  Sometimes libpng is
-                   * compiled without stdio support (it can be difficult to do
-                   * in some environments); in that case you will have to write
-                   * your own read callback to read data from the (FILE*).
+                  /* Now associate the recently opened FILE object with the
+                   * default libpng initialization functions.  Sometimes libpng
+                   * is compiled without stdio support (it can be difficult to
+                   * do in some environments); in that case you will have to
+                   * write your own read callback to read data from the stream.
                    */
                   png_init_io(png_ptr, f);
 

--- a/contrib/libtests/makepng.c
+++ b/contrib/libtests/makepng.c
@@ -745,7 +745,7 @@ generate_row(png_bytep row, size_t rowbytes, unsigned int y, int color_type,
 }
 
 
-static void PNGCBAPI
+static void
 makepng_warning(png_structp png_ptr, png_const_charp message)
 {
    const char **ep = png_get_error_ptr(png_ptr);
@@ -760,7 +760,7 @@ makepng_warning(png_structp png_ptr, png_const_charp message)
   fprintf(stderr, "%s: warning: %s\n", name, message);
 }
 
-static void PNGCBAPI
+static void
 makepng_error(png_structp png_ptr, png_const_charp message)
 {
    makepng_warning(png_ptr, message);

--- a/contrib/libtests/pngimage.c
+++ b/contrib/libtests/pngimage.c
@@ -768,13 +768,13 @@ display_log(struct display *dp, error_level level, const char *fmt, ...)
 }
 
 /* error handler callbacks for libpng */
-static void PNGCBAPI
+static void
 display_warning(png_structp pp, png_const_charp warning)
 {
    display_log(get_dp(pp), LIBPNG_WARNING, "%s", warning);
 }
 
-static void PNGCBAPI
+static void
 display_error(png_structp pp, png_const_charp error)
 {
    struct display *dp = get_dp(pp);
@@ -858,7 +858,7 @@ buffer_read(struct display *dp, struct buffer *bp, png_bytep data,
    bp->read_count = read_count;
 }
 
-static void PNGCBAPI
+static void
 read_function(png_structp pp, png_bytep data, size_t size)
 {
    buffer_read(get_dp(pp), get_buffer(pp), data, size);
@@ -1325,7 +1325,7 @@ buffer_write(struct display *dp, struct buffer *buffer, png_bytep data,
    buffer->end_count = end_count;
 }
 
-static void PNGCBAPI
+static void
 write_function(png_structp pp, png_bytep data, size_t size)
 {
    buffer_write(get_dp(pp), get_buffer(pp), data, size);

--- a/contrib/libtests/pngstest.c
+++ b/contrib/libtests/pngstest.c
@@ -593,7 +593,8 @@ newimage(Image *image)
    memset(image, 0, sizeof *image);
 }
 
-/* Reset the image to be read again - only needs to rewind the FILE* at present.
+/* Reset the image to be read again - only needs to rewind the FILE object at
+ * present.
  */
 static void
 resetimage(Image *image)

--- a/contrib/libtests/pngunknown.c
+++ b/contrib/libtests/pngunknown.c
@@ -457,7 +457,8 @@ clean_display(display *d)
    }
 }
 
-PNG_FUNCTION(void, display_exit, (display *d), static PNG_NORETURN)
+static PNG_NORETURN void
+display_exit(display *d)
 {
    ++(d->error_count);
 
@@ -480,8 +481,8 @@ display_rc(const display *d, int strict)
 }
 
 /* libpng error and warning callbacks */
-PNG_FUNCTION(void, (PNGCBAPI error), (png_structp png_ptr, const char *message),
-   static PNG_NORETURN)
+static PNG_NORETURN void
+error(png_structp png_ptr, const char *message)
 {
    display *d = (display*)png_get_error_ptr(png_ptr);
 
@@ -489,7 +490,7 @@ PNG_FUNCTION(void, (PNGCBAPI error), (png_structp png_ptr, const char *message),
    display_exit(d);
 }
 
-static void PNGCBAPI
+static void
 warning(png_structp png_ptr, const char *message)
 {
    display *d = (display*)png_get_error_ptr(png_ptr);
@@ -531,7 +532,7 @@ get_valid(display *d, png_infop info_ptr)
 }
 
 #ifdef PNG_READ_USER_CHUNKS_SUPPORTED
-static int PNGCBAPI
+static int
 read_callback(png_structp pp, png_unknown_chunkp pc)
 {
    /* This function mimics the behavior of png_set_keep_unknown_chunks by

--- a/contrib/libtests/pngvalid.c
+++ b/contrib/libtests/pngvalid.c
@@ -1093,7 +1093,7 @@ internal_error(png_store *ps, png_const_charp message)
 #endif /* PNG_READ_SUPPORTED */
 
 /* Functions to use as PNG callbacks. */
-static void PNGCBAPI
+static void
 store_error(png_structp ppIn, png_const_charp message) /* PNG_NORETURN */
 {
    png_const_structp pp = ppIn;
@@ -1109,7 +1109,7 @@ store_error(png_structp ppIn, png_const_charp message) /* PNG_NORETURN */
    }
 }
 
-static void PNGCBAPI
+static void
 store_warning(png_structp ppIn, png_const_charp message)
 {
    png_const_structp pp = ppIn;
@@ -1281,7 +1281,7 @@ valid_chunktype(png_uint_32 chunktype)
    return 1; /* It's valid */
 }
 
-static void PNGCBAPI
+static void
 store_write(png_structp ppIn, png_bytep pb, size_t st)
 {
    png_const_structp pp = ppIn;
@@ -1375,7 +1375,7 @@ store_write(png_structp ppIn, png_bytep pb, size_t st)
    ps->chunklen = chunklen;
 }
 
-static void PNGCBAPI
+static void
 store_flush(png_structp ppIn)
 {
    UNUSED(ppIn) /*DOES NOTHING*/
@@ -1700,7 +1700,7 @@ store_read_chunk(png_store *ps, png_bytep pb, size_t max, size_t min)
    return st; /* space left */
 }
 
-static void PNGCBAPI
+static void
 store_read(png_structp ppIn, png_bytep pb, size_t st)
 {
    png_const_structp pp = ppIn;
@@ -1903,7 +1903,7 @@ store_pool_delete(png_store *ps, store_pool *pool)
 }
 
 /* The memory callbacks: */
-static png_voidp PNGCBAPI
+static png_voidp
 store_malloc(png_structp ppIn, png_alloc_size_t cb)
 {
    png_const_structp pp = ppIn;
@@ -1952,7 +1952,7 @@ store_malloc(png_structp ppIn, png_alloc_size_t cb)
    return new;
 }
 
-static void PNGCBAPI
+static void
 store_free(png_structp ppIn, png_voidp memory)
 {
    png_const_structp pp = ppIn;
@@ -3198,7 +3198,7 @@ modifier_read_imp(png_modifier *pm, png_bytep pb, size_t st)
 }
 
 /* The callback: */
-static void PNGCBAPI
+static void
 modifier_read(png_structp ppIn, png_bytep pb, size_t st)
 {
    png_const_structp pp = ppIn;
@@ -5391,7 +5391,7 @@ standard_info_imp(standard_display *dp, png_structp pp, png_infop pi,
    standard_info_part2(dp, pp, pi, nImages);
 }
 
-static void PNGCBAPI
+static void
 standard_info(png_structp pp, png_infop pi)
 {
    standard_display *dp = voidcast(standard_display*,
@@ -5403,7 +5403,7 @@ standard_info(png_structp pp, png_infop pi)
    standard_info_imp(dp, pp, pi, 1 /*only one image*/);
 }
 
-static void PNGCBAPI
+static void
 progressive_row(png_structp ppIn, png_bytep new_row, png_uint_32 y, int pass)
 {
    png_const_structp pp = ppIn;
@@ -5703,7 +5703,7 @@ standard_image_validate(standard_display *dp, png_const_structp pp, int iImage,
    dp->ps->validated = 1;
 }
 
-static void PNGCBAPI
+static void
 standard_end(png_structp ppIn, png_infop pi)
 {
    png_const_structp pp = ppIn;
@@ -6703,7 +6703,7 @@ transform_info_imp(transform_display *dp, png_structp pp, png_infop pi)
    }
 }
 
-static void PNGCBAPI
+static void
 transform_info(png_structp pp, png_infop pi)
 {
    transform_info_imp(voidcast(transform_display*, png_get_progressive_ptr(pp)),
@@ -6919,7 +6919,7 @@ transform_image_validate(transform_display *dp, png_const_structp pp,
    dp->this.ps->validated = 1;
 }
 
-static void PNGCBAPI
+static void
 transform_end(png_structp ppIn, png_infop pi)
 {
    png_const_structp pp = ppIn;
@@ -9385,7 +9385,7 @@ gamma_info_imp(gamma_display *dp, png_structp pp, png_infop pi)
    standard_info_part2(&dp->this, pp, pi, 1 /*images*/);
 }
 
-static void PNGCBAPI
+static void
 gamma_info(png_structp pp, png_infop pi)
 {
    gamma_info_imp(voidcast(gamma_display*, png_get_progressive_ptr(pp)), pp,
@@ -10385,7 +10385,7 @@ gamma_image_validate(gamma_display *dp, png_const_structp pp,
    dp->this.ps->validated = 1;
 }
 
-static void PNGCBAPI
+static void
 gamma_end(png_structp ppIn, png_infop pi)
 {
    png_const_structp pp = ppIn;

--- a/contrib/tools/pngcp.c
+++ b/contrib/tools/pngcp.c
@@ -1674,7 +1674,7 @@ makename(struct display *dp, const char *dir, const char *infile)
 }
 
 /* error handler callbacks for libpng */
-static void PNGCBAPI
+static void
 display_warning(png_structp pp, png_const_charp warning)
 {
    struct display *dp = get_dp(pp);
@@ -1684,7 +1684,7 @@ display_warning(png_structp pp, png_const_charp warning)
       display_log(get_dp(pp), LIBPNG_WARNING, "%s", warning);
 }
 
-static void PNGCBAPI
+static void
 display_error(png_structp pp, png_const_charp error)
 {
    struct display *dp = get_dp(pp);
@@ -1716,7 +1716,7 @@ display_start_read(struct display *dp, const char *filename)
       display_log(dp, USER_ERROR, "file open failed (%s)", strerror(errno));
 }
 
-static void PNGCBAPI
+static void
 read_function(png_structp pp, png_bytep data, size_t size)
 {
    struct display *dp = get_dp(pp);
@@ -1896,7 +1896,7 @@ display_start_write(struct display *dp, const char *filename)
    }
 }
 
-static void PNGCBAPI
+static void
 write_function(png_structp pp, png_bytep data, size_t size)
 {
    struct display *dp = get_dp(pp);

--- a/contrib/tools/pngfix.c
+++ b/contrib/tools/pngfix.c
@@ -3149,13 +3149,13 @@ read_chunk(struct file *file)
 /* This returns a file* from a png_struct in an implementation specific way. */
 static struct file *get_control(png_const_structrp png_ptr);
 
-static void PNGCBAPI
+static void
 error_handler(png_structp png_ptr, png_const_charp message)
 {
    stop(get_control(png_ptr),  LIBPNG_ERROR_CODE, message);
 }
 
-static void PNGCBAPI
+static void
 warning_handler(png_structp png_ptr, png_const_charp message)
 {
    struct file *file = get_control(png_ptr);
@@ -3167,7 +3167,7 @@ warning_handler(png_structp png_ptr, png_const_charp message)
 /* Read callback - this is where the work gets done to check the stream before
  * passing it to libpng
  */
-static void PNGCBAPI
+static void
 read_callback(png_structp png_ptr, png_bytep buffer, size_t count)
    /* Return 'count' bytes to libpng in 'buffer' */
 {

--- a/example.c
+++ b/example.c
@@ -2,7 +2,7 @@
 
 /* example.c - an example of using libpng
  *
- * Maintained 2018-2024 Cosmin Truta
+ * Maintained 2018-2025 Cosmin Truta
  * Maintained 1998-2016 Glenn Randers-Pehrson
  * Maintained 1996-1997 Andreas Dilger
  * Written 1995-1996 Guy Eric Schalnat, Group 42, Inc.
@@ -179,11 +179,11 @@ int main(int argc, const char **argv)
  *    components.
  *
  * You do not have to read directly from a file.  You can read from memory or,
- * on systems that support it, from a <stdio.h> FILE*.  This is controlled by
- * the particular png_image_read_from_ function you call at the start.
- * Likewise, on write, you can write to a FILE* if your system supports it.
- * Check the macro PNG_STDIO_SUPPORTED to see if stdio support has been
- * included in your libpng build.
+ * on systems that support <stdio.h>, from a FILE object.  This is controlled
+ * by the particular png_image_read_from_ function you call at the start.
+ * Likewise, on write, you can write to a FILE object if your system supports
+ * <stdio.h>.  The macro PNG_STDIO_SUPPORTED indicates if stdio is available
+ * and accessible from your libpng build.
  *
  * If you read 16-bit (PNG_FORMAT_FLAG_LINEAR) data, you may need to write it
  * in the 8-bit format for display.  You do this by setting the convert_to_8bit

--- a/manuals/libpng-install.txt
+++ b/manuals/libpng-install.txt
@@ -345,30 +345,11 @@ way pngusr.h is used in the build has been changed; however, library
 builders will probably want to examine the changes to take advantage of
 new capabilities and to simplify their build system.
 
-A. Specific changes to library configuration capabilities
+A. Changes to the library configuration capabilities
 
-The exact mechanism used to control attributes of API functions has
-changed.  A single set of operating system independent macro definitions
-is used and operating system specific directives are defined in
-pnglibconf.h
-
-As part of this the mechanism used to choose procedure call standards on
-those systems that allow a choice has been changed.  At present this only
-affects certain Microsoft (DOS, Windows) and IBM (OS/2) operating systems
-running on Intel processors.  As before, PNGAPI is defined where required
-to control the exported API functions; however, two new macros, PNGCBAPI
-and PNGCAPI, are used instead for callback functions (PNGCBAPI) and
-(PNGCAPI) for functions that must match a C library prototype (currently
-only png_longjmp_ptr, which must match the C longjmp function.)  The new
-approach is documented in pngconf.h
-
-Despite these changes, libpng 1.5.0 only supports the native C function
-calling standard on those platforms tested so far ("__cdecl" on Microsoft
-Windows).  This is because the support requirements for alternative
-calling conventions seem to no longer exist.  Developers who find it
-necessary to set PNG_API_RULE to 1 should advise the mailing list
-(png-mng-implement) of this and library builders who use Openwatcom and
-therefore set PNG_API_RULE to 2 should also contact the mailing list.
+A new mechanism to control attributes of API functions was introduced in
+libpng-1.5.0.  A single set of system-independent macro definitions and
+directives is defined in pnglibconf.h
 
 B. Changes to the configuration mechanism
 

--- a/manuals/libpng-manual.txt
+++ b/manuals/libpng-manual.txt
@@ -4091,7 +4091,7 @@ READ APIs
      is filled in from the PNG header in the file.
 
    int png_image_begin_read_from_stdio (png_imagep image,
-     FILE* file)
+     FILE *file)
 
       The PNG header is read from the stdio FILE object.
 
@@ -4166,7 +4166,7 @@ be written:
       int convert_to_8_bit, const void *buffer,
       png_int_32 row_stride, const void *colormap)
 
-      Write the image to the given (FILE*).
+      Write the image to the given FILE object.
 
 With all write APIs if image is in one of the linear formats with
 (png_uint_16) data then setting convert_to_8_bit will cause the output to be

--- a/manuals/libpng-manual.txt
+++ b/manuals/libpng-manual.txt
@@ -5317,13 +5317,13 @@ We don't use C++ style ("//") comments. We have, however,
 used them in the past in some now-abandoned MMX assembler
 code.
 
-Functions and their curly braces are not indented, and
-exported functions are marked with PNGAPI:
+Functions and their curly braces are not indented. We used to mark
+the exported functions with PNGAPI, but we no longer do:
 
  /* This is a public function that is visible to
   * application programmers. It does thus-and-so.
   */
- void PNGAPI
+ void
  png_exported_function(png_ptr, png_info, foo)
  {
     body;

--- a/manuals/libpng.3
+++ b/manuals/libpng.3
@@ -5826,13 +5826,13 @@ We don't use C++ style ("//") comments. We have, however,
 used them in the past in some now-abandoned MMX assembler
 code.
 
-Functions and their curly braces are not indented, and
-exported functions are marked with PNGAPI:
+Functions and their curly braces are not indented. We used to mark
+the exported functions with PNGAPI, but we no longer do:
 
  /* This is a public function that is visible to
   * application programmers. It does thus-and-so.
   */
- void PNGAPI
+ void
  png_exported_function(png_ptr, png_info, foo)
  {
     body;

--- a/manuals/libpng.3
+++ b/manuals/libpng.3
@@ -219,7 +219,7 @@ libpng \- Portable Network Graphics (PNG) Reference Library 1.6.47
 
 \fBint png_image_begin_read_from_file (png_imagep \fP\fIimage\fP\fB, const char \fI*file_name\fP\fB);\fP
 
-\fBint png_image_begin_read_from_stdio (png_imagep \fP\fIimage\fP\fB, FILE* \fIfile\fP\fB);\fP
+\fBint png_image_begin_read_from_stdio (png_imagep \fP\fIimage\fP\fB, FILE *\fIfile\fP\fB);\fP
 
 \fBint, png_image_begin_read_from_memory (png_imagep \fP\fIimage\fP\fB, png_const_voidp \fP\fImemory\fP\fB, size_t \fIsize\fP\fB);\fP
 
@@ -4600,7 +4600,7 @@ READ APIs
      is filled in from the PNG header in the file.
 
    int png_image_begin_read_from_stdio (png_imagep image,
-     FILE* file)
+     FILE *file)
 
       The PNG header is read from the stdio FILE object.
 
@@ -4675,7 +4675,7 @@ be written:
       int convert_to_8_bit, const void *buffer,
       png_int_32 row_stride, const void *colormap)
 
-      Write the image to the given (FILE*).
+      Write the image to the given FILE object.
 
 With all write APIs if image is in one of the linear formats with
 (png_uint_16) data then setting convert_to_8_bit will cause the output to be

--- a/png.c
+++ b/png.c
@@ -3944,7 +3944,7 @@ png_image_free_function(png_voidp argument)
 #  ifdef PNG_STDIO_SUPPORTED
       if (cp->owned_file != 0)
       {
-         FILE *fp = png_voidcast(FILE*, cp->png_ptr->io_ptr);
+         FILE *fp = png_voidcast(FILE *, cp->png_ptr->io_ptr);
          cp->owned_file = 0;
 
          /* Ignore errors here. */

--- a/png.c
+++ b/png.c
@@ -49,7 +49,7 @@ typedef png_libpng_version_1_8_0_git Your_png_h_is_not_version_1_8_0_git;
  */
 
 #ifdef PNG_READ_SUPPORTED
-void PNGAPI
+void
 png_set_sig_bytes(png_structrp png_ptr, int num_bytes)
 {
    unsigned int nb = (unsigned int)num_bytes;
@@ -76,7 +76,7 @@ png_set_sig_bytes(png_structrp png_ptr, int num_bytes)
  * respectively, to be less than, to match, or be greater than the correct
  * PNG signature (this is the same behavior as strcmp, memcmp, etc).
  */
-int PNGAPI
+int
 png_sig_cmp(png_const_bytep sig, size_t start, size_t num_to_check)
 {
    static const png_byte png_signature[8] = {137, 80, 78, 71, 13, 10, 26, 10};
@@ -358,7 +358,7 @@ png_create_png_struct,(png_const_charp user_png_ver, png_voidp error_ptr,
 }
 
 /* Allocate the memory for an info_struct for the application. */
-PNG_FUNCTION(png_infop,PNGAPI
+PNG_FUNCTION(png_infop,
 png_create_info_struct,(png_const_structrp png_ptr),PNG_ALLOCATED)
 {
    png_inforp info_ptr;
@@ -390,7 +390,7 @@ png_create_info_struct,(png_const_structrp png_ptr),PNG_ALLOCATED)
  * APIs.  This ensures that all possible approaches free the same data (all of
  * it).
  */
-void PNGAPI
+void
 png_destroy_info_struct(png_const_structrp png_ptr, png_infopp info_ptr_ptr)
 {
    png_inforp info_ptr = NULL;
@@ -428,7 +428,7 @@ png_destroy_info_struct(png_const_structrp png_ptr, png_infopp info_ptr_ptr)
  * the user-memory mechanism and the user error handling/warning mechanisms in
  * those cases where it does anything other than a memset.
  */
-PNG_FUNCTION(void,PNGAPI
+PNG_FUNCTION(void,
 png_info_init_3,(png_infopp ptr_ptr, size_t png_info_struct_size),
     PNG_DEPRECATED)
 {
@@ -455,7 +455,7 @@ png_info_init_3,(png_infopp ptr_ptr, size_t png_info_struct_size),
    memset(info_ptr, 0, (sizeof *info_ptr));
 }
 
-void PNGAPI
+void
 png_data_freer(png_const_structrp png_ptr, png_inforp info_ptr,
     int freer, png_uint_32 mask)
 {
@@ -474,7 +474,7 @@ png_data_freer(png_const_structrp png_ptr, png_inforp info_ptr,
       png_error(png_ptr, "Unknown freer parameter in png_data_freer");
 }
 
-void PNGAPI
+void
 png_free_data(png_const_structrp png_ptr, png_inforp info_ptr, png_uint_32 mask,
     int num)
 {
@@ -682,7 +682,7 @@ png_free_data(png_const_structrp png_ptr, png_inforp info_ptr, png_uint_32 mask,
  * functions.  The application should free any memory associated with this
  * pointer before png_write_destroy() or png_read_destroy() are called.
  */
-png_voidp PNGAPI
+png_voidp
 png_get_io_ptr(png_const_structrp png_ptr)
 {
    if (png_ptr == NULL)
@@ -699,7 +699,7 @@ png_get_io_ptr(png_const_structrp png_ptr)
  * PNG_NO_STDIO or otherwise disabled PNG_STDIO_SUPPORTED, you must use a
  * function of your own because "FILE *" isn't necessarily available.
  */
-void PNGAPI
+void
 png_init_io(png_structrp png_ptr, FILE *fp)
 {
    png_debug(1, "in png_init_io");
@@ -722,7 +722,7 @@ png_init_io(png_structrp png_ptr, FILE *fp)
  * negative integral value is added the result will be an unsigned value
  * corresponding to the 2's complement representation.
  */
-void PNGAPI
+void
 png_save_int_32(png_bytep buf, png_int_32 i)
 {
    png_save_uint_32(buf, (png_uint_32)i);
@@ -733,7 +733,7 @@ png_save_int_32(png_bytep buf, png_int_32 i)
 /* Convert the supplied time into an RFC 1123 string suitable for use in
  * a "Creation Time" or other text-based time string.
  */
-int PNGAPI
+int
 png_convert_to_rfc1123_buffer(char out[29], png_const_timep ptime)
 {
    static const char short_months[12][4] =
@@ -784,7 +784,7 @@ png_convert_to_rfc1123_buffer(char out[29], png_const_timep ptime)
 
 #endif /* READ || WRITE */
 
-png_const_charp PNGAPI
+png_const_charp
 png_get_copyright(png_const_structrp png_ptr)
 {
    PNG_UNUSED(png_ptr)  /* Silence compiler warning about unused png_ptr */
@@ -810,14 +810,14 @@ png_get_copyright(png_const_structrp png_ptr)
  * png_get_header_ver().  Due to the version_nn_nn_nn typedef guard,
  * it is guaranteed that png.c uses the correct version of png.h.
  */
-png_const_charp PNGAPI
+png_const_charp
 png_get_libpng_ver(png_const_structrp png_ptr)
 {
    /* Version of *.c files used when building libpng */
    return png_get_header_ver(png_ptr);
 }
 
-png_const_charp PNGAPI
+png_const_charp
 png_get_header_ver(png_const_structrp png_ptr)
 {
    /* Version of *.h files used when building libpng */
@@ -825,7 +825,7 @@ png_get_header_ver(png_const_structrp png_ptr)
    return PNG_LIBPNG_VER_STRING;
 }
 
-png_const_charp PNGAPI
+png_const_charp
 png_get_header_version(png_const_structrp png_ptr)
 {
    /* Returns longer string containing both version and date */
@@ -848,7 +848,7 @@ png_get_header_version(png_const_structrp png_ptr)
  * paletted.  Most useful for gamma correction and simplification
  * of code.  This API is not used internally.
  */
-void PNGAPI
+void
 png_build_grayscale_palette(int bit_depth, png_colorp palette)
 {
    int num_palette;
@@ -899,7 +899,7 @@ png_build_grayscale_palette(int bit_depth, png_colorp palette)
 #endif
 
 #ifdef PNG_SET_UNKNOWN_CHUNKS_SUPPORTED
-int PNGAPI
+int
 png_handle_as_unknown(png_const_structrp png_ptr, png_const_bytep chunk_name)
 {
    /* Check chunk_name and return "keep" value if it's on the list, else 0 */
@@ -947,7 +947,7 @@ png_chunk_unknown_handling(png_const_structrp png_ptr, png_uint_32 chunk_name)
 
 #ifdef PNG_READ_SUPPORTED
 /* This function, added to libpng-1.0.6g, is untested. */
-int PNGAPI
+int
 png_reset_zstream(png_structrp png_ptr)
 {
    if (png_ptr == NULL)
@@ -959,7 +959,7 @@ png_reset_zstream(png_structrp png_ptr)
 #endif /* READ */
 
 /* This function was added to libpng-1.0.7 */
-png_uint_32 PNGAPI
+png_uint_32
 png_access_version_number(void)
 {
    /* Version of *.c files used when building libpng */
@@ -3738,7 +3738,7 @@ png_build_gamma_table(png_structrp png_ptr, int bit_depth)
 #endif /* READ_GAMMA */
 
 /* HARDWARE OR SOFTWARE OPTION SUPPORT */
-int PNGAPI
+int
 png_set_option(png_structrp png_ptr, int option, int onoff)
 {
    if (png_ptr != NULL && option >= 0 && option < PNG_OPTION_NEXT &&
@@ -3987,7 +3987,7 @@ png_image_free_function(png_voidp argument)
    return 1;
 }
 
-void PNGAPI
+void
 png_image_free(png_imagep image)
 {
    /* Safely call the real function, but only if doing so is safe at this point

--- a/png.c
+++ b/png.c
@@ -700,7 +700,7 @@ png_get_io_ptr(png_const_structrp png_ptr)
  * function of your own because "FILE *" isn't necessarily available.
  */
 void PNGAPI
-png_init_io(png_structrp png_ptr, png_FILE_p fp)
+png_init_io(png_structrp png_ptr, FILE *fp)
 {
    png_debug(1, "in png_init_io");
 

--- a/png.h
+++ b/png.h
@@ -838,7 +838,7 @@ typedef PNG_CALLBACK(int, *png_user_chunk_ptr, (png_structp,
  * your compiler.  This may be very difficult - try using a different compiler
  * to build the library!
  */
-PNG_FUNCTION(void, (PNGCAPI *png_longjmp_ptr), (jmp_buf, int), typedef);
+PNG_FUNCTION(void, (*png_longjmp_ptr), (jmp_buf, int), typedef);
 #endif
 
 /* Transform masks for the high-level interface */

--- a/png.h
+++ b/png.h
@@ -1551,7 +1551,7 @@ PNG_REMOVED(void, png_set_filter_heuristics_fixed,
 
 #ifdef PNG_STDIO_SUPPORTED
 /* Initialize the input/output for the PNG file to the default functions. */
-PNG_EXPORT(void, png_init_io, (png_structrp png_ptr, png_FILE_p fp));
+PNG_EXPORT(void, png_init_io, (png_structrp png_ptr, FILE *fp));
 #endif
 
 /* Replace the (error and abort), and warning functions with user

--- a/png.h
+++ b/png.h
@@ -3069,7 +3069,7 @@ PNG_EXPORT(int, png_image_begin_read_from_file, (png_imagep image,
     */
 
 PNG_EXPORT(int, png_image_begin_read_from_stdio, (png_imagep image,
-   FILE* file));
+   FILE *file));
    /* The PNG header is read from the stdio FILE object. */
 #endif /* STDIO */
 
@@ -3144,7 +3144,7 @@ PNG_EXPORT(int, png_image_write_to_file, (png_imagep image,
 PNG_EXPORT(int, png_image_write_to_stdio, (png_imagep image, FILE *file,
    int convert_to_8_bit, const void *buffer, png_int_32 row_stride,
    const void *colormap));
-   /* Write the image to the given (FILE*). */
+   /* Write the image to the given FILE object. */
 #endif /* SIMPLIFIED_WRITE_STDIO */
 
 /* With all write APIs if image is in one of the linear formats with 16-bit

--- a/png.h
+++ b/png.h
@@ -1036,7 +1036,7 @@ PNG_EXPORT(int, png_convert_to_rfc1123_buffer, (char out[29],
 
 /* Removed from libpng 1.7 onwards; use png_convert_to_rfc1123_buffer. */
 PNG_REMOVED(png_const_charp, png_convert_to_rfc1123, (png_structrp png_ptr,
-    png_const_timep ptime),PNG_DEPRECATED);
+    png_const_timep ptime),PNG_DEPRECATED)
 #endif
 
 #ifdef PNG_CONVERT_tIME_SUPPORTED
@@ -2011,9 +2011,9 @@ PNG_FIXED_EXPORT(void, png_set_cLLI_fixed, (png_const_structrp png_ptr,
 
 #ifdef PNG_eXIf_SUPPORTED
 PNG_REMOVED(png_uint_32, png_get_eXIf, (png_const_structrp png_ptr,
-    png_inforp info_ptr, png_bytep *exif),PNG_DEPRECATED);
+    png_inforp info_ptr, png_bytep *exif),PNG_DEPRECATED)
 PNG_REMOVED(void, png_set_eXIf, (png_const_structrp png_ptr,
-    png_inforp info_ptr, png_bytep exif),PNG_DEPRECATED);
+    png_inforp info_ptr, png_bytep exif),PNG_DEPRECATED)
 
 PNG_EXPORT(png_uint_32, png_get_eXIf_1, (png_const_structrp png_ptr,
     png_const_inforp info_ptr, png_uint_32 *num_exif, png_bytep *exif));

--- a/pngconf.h
+++ b/pngconf.h
@@ -222,22 +222,10 @@
 #     error "PNG_USER_PRIVATEBUILD must be defined if PNGAPI is changed"
 #  endif
 
-#  if (defined(_MSC_VER) && _MSC_VER < 800) ||\
-      (defined(__BORLANDC__) && __BORLANDC__ < 0x500)
-   /* older Borland and MSC
-    * compilers used '__export' and required this to be after
-    * the type.
-    */
-#    ifndef PNG_EXPORT_TYPE
-#      define PNG_EXPORT_TYPE(type) type PNG_IMPEXP
-#    endif
-#    define PNG_DLL_EXPORT __export
-#  else /* newer compiler */
-#    define PNG_DLL_EXPORT __declspec(dllexport)
-#    ifndef PNG_DLL_IMPORT
-#      define PNG_DLL_IMPORT __declspec(dllimport)
-#    endif
-#  endif /* compiler */
+#  define PNG_DLL_EXPORT __declspec(dllexport)
+#  ifndef PNG_DLL_IMPORT
+#    define PNG_DLL_IMPORT __declspec(dllimport)
+#  endif
 
 #else /* !Windows */
 #  if (defined(__IBMC__) || defined(__IBMCPP__)) && defined(__OS2__)
@@ -584,10 +572,6 @@ typedef const png_fixed_point * png_const_fixed_point_p;
 typedef size_t                * png_size_tp;
 typedef const size_t          * png_const_size_tp;
 
-#ifdef PNG_STDIO_SUPPORTED
-typedef FILE            * png_FILE_p;
-#endif
-
 #ifdef PNG_FLOATING_POINT_SUPPORTED
 typedef double       * png_doublep;
 typedef const double * png_const_doublep;
@@ -608,6 +592,15 @@ typedef double          * * png_doublepp;
 
 /* Pointers to pointers to pointers; i.e., pointer to array */
 typedef char            * * * png_charppp;
+
+#ifdef PNG_STDIO_SUPPORTED
+/* With PNG_STDIO_SUPPORTED it was possible to use I/O streams that were
+ * not necessarily stdio FILE streams, to allow building Windows applications
+ * before Win32 and Windows CE applications before WinCE 3.0, but that kind
+ * of support has long been discontinued.
+ */
+typedef FILE            * png_FILE_p; /* [Deprecated] */
+#endif
 
 #endif /* PNG_BUILDING_SYMBOL_TABLE */
 

--- a/pngerror.c
+++ b/pngerror.c
@@ -1,6 +1,6 @@
 /* pngerror.c - stub functions for i/o and memory allocation
  *
- * Copyright (c) 2018-2024 Cosmin Truta
+ * Copyright (c) 2018-2025 Cosmin Truta
  * Copyright (c) 1998-2002,2004,2006-2017 Glenn Randers-Pehrson
  * Copyright (c) 1996-1997 Andreas Dilger
  * Copyright (c) 1995-1996 Guy Eric Schalnat, Group 42, Inc.
@@ -35,7 +35,7 @@ png_default_warning(png_const_structrp png_ptr,
  * to replace the error function at run-time.
  */
 #ifdef PNG_ERROR_TEXT_SUPPORTED
-PNG_FUNCTION(void,PNGAPI
+PNG_FUNCTION(void,
 png_error,(png_const_structrp png_ptr, png_const_charp error_message),
     PNG_NORETURN)
 {
@@ -88,7 +88,7 @@ png_error,(png_const_structrp png_ptr, png_const_charp error_message),
    png_default_error(png_ptr, error_message);
 }
 #else
-PNG_FUNCTION(void,PNGAPI
+PNG_FUNCTION(void,
 png_err,(png_const_structrp png_ptr),PNG_NORETURN)
 {
    /* Prior to 1.5.2 the error_fn received a NULL pointer, expressed
@@ -212,7 +212,7 @@ png_format_number(png_const_charp start, png_charp end, int format,
  * you should supply a replacement warning function and use
  * png_set_error_fn() to replace the warning function at run-time.
  */
-void PNGAPI
+void
 png_warning(png_const_structrp png_ptr, png_const_charp warning_message)
 {
    int offset = 0;
@@ -358,7 +358,7 @@ png_formatted_warning(png_const_structrp png_ptr, png_warning_parameters p,
 #endif /* WARNINGS */
 
 #ifdef PNG_BENIGN_ERRORS_SUPPORTED
-void PNGAPI
+void
 png_benign_error(png_const_structrp png_ptr, png_const_charp error_message)
 {
    if ((png_ptr->flags & PNG_FLAG_BENIGN_ERRORS_WARN) != 0)
@@ -476,7 +476,7 @@ png_format_buffer(png_const_structrp png_ptr, png_charp buffer, png_const_charp
 #endif /* WARNINGS || ERROR_TEXT */
 
 #if defined(PNG_READ_SUPPORTED) && defined(PNG_ERROR_TEXT_SUPPORTED)
-PNG_FUNCTION(void,PNGAPI
+PNG_FUNCTION(void,
 png_chunk_error,(png_const_structrp png_ptr, png_const_charp error_message),
     PNG_NORETURN)
 {
@@ -493,7 +493,7 @@ png_chunk_error,(png_const_structrp png_ptr, png_const_charp error_message),
 #endif /* READ && ERROR_TEXT */
 
 #ifdef PNG_WARNINGS_SUPPORTED
-void PNGAPI
+void
 png_chunk_warning(png_const_structrp png_ptr, png_const_charp warning_message)
 {
    char msg[18+PNG_MAX_ERROR_TEXT];
@@ -510,7 +510,7 @@ png_chunk_warning(png_const_structrp png_ptr, png_const_charp warning_message)
 
 #ifdef PNG_READ_SUPPORTED
 #ifdef PNG_BENIGN_ERRORS_SUPPORTED
-void PNGAPI
+void
 png_chunk_benign_error(png_const_structrp png_ptr, png_const_charp
     error_message)
 {
@@ -593,7 +593,7 @@ png_fixed_error,(png_const_structrp png_ptr, png_const_charp name),PNG_NORETURN)
 /* This API only exists if ANSI-C style error handling is used,
  * otherwise it is necessary for png_default_error to be overridden.
  */
-jmp_buf* PNGAPI
+jmp_buf*
 png_set_longjmp_fn(png_structrp png_ptr, png_longjmp_ptr longjmp_fn,
     size_t jmp_buf_size)
 {
@@ -754,7 +754,7 @@ png_default_error,(png_const_structrp png_ptr, png_const_charp error_message),
    png_longjmp(png_ptr, 1);
 }
 
-PNG_FUNCTION(void,PNGAPI
+PNG_FUNCTION(void,
 png_longjmp,(png_const_structrp png_ptr, int val),PNG_NORETURN)
 {
 #ifdef PNG_SETJMP_SUPPORTED
@@ -831,7 +831,7 @@ png_default_warning(png_const_structrp png_ptr, png_const_charp warning_message)
  * return to the calling routine or serious problems will occur.  The return
  * method used in the default routine calls longjmp(png_ptr->jmp_buf_ptr, 1)
  */
-void PNGAPI
+void
 png_set_error_fn(png_structrp png_ptr, png_voidp error_ptr,
     png_error_ptr error_fn, png_error_ptr warning_fn)
 {
@@ -852,7 +852,7 @@ png_set_error_fn(png_structrp png_ptr, png_voidp error_ptr,
  * functions.  The application should free any memory associated with this
  * pointer before png_write_destroy and png_read_destroy are called.
  */
-png_voidp PNGAPI
+png_voidp
 png_get_error_ptr(png_const_structrp png_ptr)
 {
    if (png_ptr == NULL)
@@ -863,7 +863,7 @@ png_get_error_ptr(png_const_structrp png_ptr)
 
 
 #ifdef PNG_ERROR_NUMBERS_SUPPORTED
-void PNGAPI
+void
 png_set_strip_error_numbers(png_structrp png_ptr, png_uint_32 strip_mode)
 {
    if (png_ptr != NULL)
@@ -881,8 +881,8 @@ png_set_strip_error_numbers(png_structrp png_ptr, png_uint_32 strip_mode)
     * possible to implement without setjmp support just so long as there is some
     * way to handle the error return here:
     */
-PNG_FUNCTION(void /* PRIVATE */, (PNGCBAPI
-png_safe_error),(png_structp png_nonconst_ptr, png_const_charp error_message),
+PNG_FUNCTION(void /* PRIVATE */,
+png_safe_error,(png_structp png_nonconst_ptr, png_const_charp error_message),
     PNG_NORETURN)
 {
    png_const_structrp png_ptr = png_nonconst_ptr;
@@ -917,7 +917,7 @@ png_safe_error),(png_structp png_nonconst_ptr, png_const_charp error_message),
 }
 
 #ifdef PNG_WARNINGS_SUPPORTED
-void /* PRIVATE */ PNGCBAPI
+void /* PRIVATE */
 png_safe_warning(png_structp png_nonconst_ptr, png_const_charp warning_message)
 {
    png_const_structrp png_ptr = png_nonconst_ptr;

--- a/pngget.c
+++ b/pngget.c
@@ -1,6 +1,6 @@
 /* pngget.c - retrieval of values from info struct
  *
- * Copyright (c) 2018-2024 Cosmin Truta
+ * Copyright (c) 2018-2025 Cosmin Truta
  * Copyright (c) 1998-2002,2004,2006-2018 Glenn Randers-Pehrson
  * Copyright (c) 1996-1997 Andreas Dilger
  * Copyright (c) 1995-1996 Guy Eric Schalnat, Group 42, Inc.
@@ -15,7 +15,7 @@
 
 #if defined(PNG_READ_SUPPORTED) || defined(PNG_WRITE_SUPPORTED)
 
-png_uint_32 PNGAPI
+png_uint_32
 png_get_valid(png_const_structrp png_ptr, png_const_inforp info_ptr,
     png_uint_32 flag)
 {
@@ -36,7 +36,7 @@ png_get_valid(png_const_structrp png_ptr, png_const_inforp info_ptr,
    return 0;
 }
 
-size_t PNGAPI
+size_t
 png_get_rowbytes(png_const_structrp png_ptr, png_const_inforp info_ptr)
 {
    if (png_ptr != NULL && info_ptr != NULL)
@@ -46,7 +46,7 @@ png_get_rowbytes(png_const_structrp png_ptr, png_const_inforp info_ptr)
 }
 
 #ifdef PNG_INFO_IMAGE_SUPPORTED
-png_bytepp PNGAPI
+png_bytepp
 png_get_rows(png_const_structrp png_ptr, png_const_inforp info_ptr)
 {
    if (png_ptr != NULL && info_ptr != NULL)
@@ -58,7 +58,7 @@ png_get_rows(png_const_structrp png_ptr, png_const_inforp info_ptr)
 
 #ifdef PNG_EASY_ACCESS_SUPPORTED
 /* Easy access to info, added in libpng-0.99 */
-png_uint_32 PNGAPI
+png_uint_32
 png_get_image_width(png_const_structrp png_ptr, png_const_inforp info_ptr)
 {
    if (png_ptr != NULL && info_ptr != NULL)
@@ -67,7 +67,7 @@ png_get_image_width(png_const_structrp png_ptr, png_const_inforp info_ptr)
    return 0;
 }
 
-png_uint_32 PNGAPI
+png_uint_32
 png_get_image_height(png_const_structrp png_ptr, png_const_inforp info_ptr)
 {
    if (png_ptr != NULL && info_ptr != NULL)
@@ -76,7 +76,7 @@ png_get_image_height(png_const_structrp png_ptr, png_const_inforp info_ptr)
    return 0;
 }
 
-png_byte PNGAPI
+png_byte
 png_get_bit_depth(png_const_structrp png_ptr, png_const_inforp info_ptr)
 {
    if (png_ptr != NULL && info_ptr != NULL)
@@ -85,7 +85,7 @@ png_get_bit_depth(png_const_structrp png_ptr, png_const_inforp info_ptr)
    return 0;
 }
 
-png_byte PNGAPI
+png_byte
 png_get_color_type(png_const_structrp png_ptr, png_const_inforp info_ptr)
 {
    if (png_ptr != NULL && info_ptr != NULL)
@@ -94,7 +94,7 @@ png_get_color_type(png_const_structrp png_ptr, png_const_inforp info_ptr)
    return 0;
 }
 
-png_byte PNGAPI
+png_byte
 png_get_filter_type(png_const_structrp png_ptr, png_const_inforp info_ptr)
 {
    if (png_ptr != NULL && info_ptr != NULL)
@@ -103,7 +103,7 @@ png_get_filter_type(png_const_structrp png_ptr, png_const_inforp info_ptr)
    return 0;
 }
 
-png_byte PNGAPI
+png_byte
 png_get_interlace_type(png_const_structrp png_ptr, png_const_inforp info_ptr)
 {
    if (png_ptr != NULL && info_ptr != NULL)
@@ -112,7 +112,7 @@ png_get_interlace_type(png_const_structrp png_ptr, png_const_inforp info_ptr)
    return 0;
 }
 
-png_byte PNGAPI
+png_byte
 png_get_compression_type(png_const_structrp png_ptr, png_const_inforp info_ptr)
 {
    if (png_ptr != NULL && info_ptr != NULL)
@@ -121,7 +121,7 @@ png_get_compression_type(png_const_structrp png_ptr, png_const_inforp info_ptr)
    return 0;
 }
 
-png_uint_32 PNGAPI
+png_uint_32
 png_get_x_pixels_per_meter(png_const_structrp png_ptr, png_const_inforp
    info_ptr)
 {
@@ -142,7 +142,7 @@ png_get_x_pixels_per_meter(png_const_structrp png_ptr, png_const_inforp
    return 0;
 }
 
-png_uint_32 PNGAPI
+png_uint_32
 png_get_y_pixels_per_meter(png_const_structrp png_ptr, png_const_inforp
     info_ptr)
 {
@@ -163,7 +163,7 @@ png_get_y_pixels_per_meter(png_const_structrp png_ptr, png_const_inforp
    return 0;
 }
 
-png_uint_32 PNGAPI
+png_uint_32
 png_get_pixels_per_meter(png_const_structrp png_ptr, png_const_inforp info_ptr)
 {
 #ifdef PNG_pHYs_SUPPORTED
@@ -185,7 +185,7 @@ png_get_pixels_per_meter(png_const_structrp png_ptr, png_const_inforp info_ptr)
 }
 
 #ifdef PNG_FLOATING_POINT_SUPPORTED
-float PNGAPI
+float
 png_get_pixel_aspect_ratio(png_const_structrp png_ptr, png_const_inforp
    info_ptr)
 {
@@ -209,7 +209,7 @@ png_get_pixel_aspect_ratio(png_const_structrp png_ptr, png_const_inforp
 #endif
 
 #ifdef PNG_FIXED_POINT_SUPPORTED
-png_fixed_point PNGAPI
+png_fixed_point
 png_get_pixel_aspect_ratio_fixed(png_const_structrp png_ptr,
     png_const_inforp info_ptr)
 {
@@ -240,7 +240,7 @@ png_get_pixel_aspect_ratio_fixed(png_const_structrp png_ptr,
 }
 #endif
 
-png_int_32 PNGAPI
+png_int_32
 png_get_x_offset_microns(png_const_structrp png_ptr, png_const_inforp info_ptr)
 {
 #ifdef PNG_oFFs_SUPPORTED
@@ -260,7 +260,7 @@ png_get_x_offset_microns(png_const_structrp png_ptr, png_const_inforp info_ptr)
    return 0;
 }
 
-png_int_32 PNGAPI
+png_int_32
 png_get_y_offset_microns(png_const_structrp png_ptr, png_const_inforp info_ptr)
 {
 #ifdef PNG_oFFs_SUPPORTED
@@ -280,7 +280,7 @@ png_get_y_offset_microns(png_const_structrp png_ptr, png_const_inforp info_ptr)
    return 0;
 }
 
-png_int_32 PNGAPI
+png_int_32
 png_get_x_offset_pixels(png_const_structrp png_ptr, png_const_inforp info_ptr)
 {
 #ifdef PNG_oFFs_SUPPORTED
@@ -300,7 +300,7 @@ png_get_x_offset_pixels(png_const_structrp png_ptr, png_const_inforp info_ptr)
    return 0;
 }
 
-png_int_32 PNGAPI
+png_int_32
 png_get_y_offset_pixels(png_const_structrp png_ptr, png_const_inforp info_ptr)
 {
 #ifdef PNG_oFFs_SUPPORTED
@@ -353,19 +353,19 @@ ppi_from_ppm(png_uint_32 ppm)
 #endif
 }
 
-png_uint_32 PNGAPI
+png_uint_32
 png_get_pixels_per_inch(png_const_structrp png_ptr, png_const_inforp info_ptr)
 {
    return ppi_from_ppm(png_get_pixels_per_meter(png_ptr, info_ptr));
 }
 
-png_uint_32 PNGAPI
+png_uint_32
 png_get_x_pixels_per_inch(png_const_structrp png_ptr, png_const_inforp info_ptr)
 {
    return ppi_from_ppm(png_get_x_pixels_per_meter(png_ptr, info_ptr));
 }
 
-png_uint_32 PNGAPI
+png_uint_32
 png_get_y_pixels_per_inch(png_const_structrp png_ptr, png_const_inforp info_ptr)
 {
    return ppi_from_ppm(png_get_y_pixels_per_meter(png_ptr, info_ptr));
@@ -389,7 +389,7 @@ png_fixed_inches_from_microns(png_const_structrp png_ptr, png_int_32 microns)
    return 0;
 }
 
-png_fixed_point PNGAPI
+png_fixed_point
 png_get_x_offset_inches_fixed(png_const_structrp png_ptr,
     png_const_inforp info_ptr)
 {
@@ -399,7 +399,7 @@ png_get_x_offset_inches_fixed(png_const_structrp png_ptr,
 #endif /* FIXED_POINT */
 
 #ifdef PNG_FIXED_POINT_SUPPORTED
-png_fixed_point PNGAPI
+png_fixed_point
 png_get_y_offset_inches_fixed(png_const_structrp png_ptr,
     png_const_inforp info_ptr)
 {
@@ -409,7 +409,7 @@ png_get_y_offset_inches_fixed(png_const_structrp png_ptr,
 #endif
 
 #ifdef PNG_FLOATING_POINT_SUPPORTED
-float PNGAPI
+float
 png_get_x_offset_inches(png_const_structrp png_ptr, png_const_inforp info_ptr)
 {
    /* To avoid the overflow do the conversion directly in floating
@@ -420,7 +420,7 @@ png_get_x_offset_inches(png_const_structrp png_ptr, png_const_inforp info_ptr)
 #endif
 
 #ifdef PNG_FLOATING_POINT_SUPPORTED
-float PNGAPI
+float
 png_get_y_offset_inches(png_const_structrp png_ptr, png_const_inforp info_ptr)
 {
    /* To avoid the overflow do the conversion directly in floating
@@ -431,7 +431,7 @@ png_get_y_offset_inches(png_const_structrp png_ptr, png_const_inforp info_ptr)
 #endif
 
 #ifdef PNG_pHYs_SUPPORTED
-png_uint_32 PNGAPI
+png_uint_32
 png_get_pHYs_dpi(png_const_structrp png_ptr, png_const_inforp info_ptr,
     png_uint_32 *res_x, png_uint_32 *res_y, int *unit_type)
 {
@@ -477,7 +477,7 @@ png_get_pHYs_dpi(png_const_structrp png_ptr, png_const_inforp info_ptr,
 #endif /* EASY_ACCESS */
 
 
-png_byte PNGAPI
+png_byte
 png_get_channels(png_const_structrp png_ptr, png_const_inforp info_ptr)
 {
    if (png_ptr != NULL && info_ptr != NULL)
@@ -487,7 +487,7 @@ png_get_channels(png_const_structrp png_ptr, png_const_inforp info_ptr)
 }
 
 #ifdef PNG_READ_SUPPORTED
-png_const_bytep PNGAPI
+png_const_bytep
 png_get_signature(png_const_structrp png_ptr, png_const_inforp info_ptr)
 {
    if (png_ptr != NULL && info_ptr != NULL)
@@ -498,7 +498,7 @@ png_get_signature(png_const_structrp png_ptr, png_const_inforp info_ptr)
 #endif
 
 #ifdef PNG_bKGD_SUPPORTED
-png_uint_32 PNGAPI
+png_uint_32
 png_get_bKGD(png_const_structrp png_ptr, png_inforp info_ptr,
     png_color_16p *background)
 {
@@ -522,7 +522,7 @@ png_get_bKGD(png_const_structrp png_ptr, png_inforp info_ptr,
  * cHRM chunk in 1.5.4
  */
 #  ifdef PNG_FLOATING_POINT_SUPPORTED
-png_uint_32 PNGAPI
+png_uint_32
 png_get_cHRM(png_const_structrp png_ptr, png_const_inforp info_ptr,
     double *whitex, double *whitey, double *redx, double *redy,
     double *greenx, double *greeny, double *bluex, double *bluey)
@@ -555,7 +555,7 @@ png_get_cHRM(png_const_structrp png_ptr, png_const_inforp info_ptr,
    return 0;
 }
 
-png_uint_32 PNGAPI
+png_uint_32
 png_get_cHRM_XYZ(png_const_structrp png_ptr, png_const_inforp info_ptr,
     double *red_X, double *red_Y, double *red_Z, double *green_X,
     double *green_Y, double *green_Z, double *blue_X, double *blue_Y,
@@ -594,7 +594,7 @@ png_get_cHRM_XYZ(png_const_structrp png_ptr, png_const_inforp info_ptr,
 #  endif
 
 #  ifdef PNG_FIXED_POINT_SUPPORTED
-png_uint_32 PNGAPI
+png_uint_32
 png_get_cHRM_XYZ_fixed(png_const_structrp png_ptr, png_const_inforp info_ptr,
     png_fixed_point *int_red_X, png_fixed_point *int_red_Y,
     png_fixed_point *int_red_Z, png_fixed_point *int_green_X,
@@ -624,7 +624,7 @@ png_get_cHRM_XYZ_fixed(png_const_structrp png_ptr, png_const_inforp info_ptr,
    return 0;
 }
 
-png_uint_32 PNGAPI
+png_uint_32
 png_get_cHRM_fixed(png_const_structrp png_ptr, png_const_inforp info_ptr,
     png_fixed_point *whitex, png_fixed_point *whitey, png_fixed_point *redx,
     png_fixed_point *redy, png_fixed_point *greenx, png_fixed_point *greeny,
@@ -654,7 +654,7 @@ png_get_cHRM_fixed(png_const_structrp png_ptr, png_const_inforp info_ptr,
 
 #ifdef PNG_gAMA_SUPPORTED
 #  ifdef PNG_FIXED_POINT_SUPPORTED
-png_uint_32 PNGAPI
+png_uint_32
 png_get_gAMA_fixed(png_const_structrp png_ptr, png_const_inforp info_ptr,
     png_fixed_point *file_gamma)
 {
@@ -673,7 +673,7 @@ png_get_gAMA_fixed(png_const_structrp png_ptr, png_const_inforp info_ptr,
 #  endif
 
 #  ifdef PNG_FLOATING_POINT_SUPPORTED
-png_uint_32 PNGAPI
+png_uint_32
 png_get_gAMA(png_const_structrp png_ptr, png_const_inforp info_ptr,
     double *file_gamma)
 {
@@ -695,7 +695,7 @@ png_get_gAMA(png_const_structrp png_ptr, png_const_inforp info_ptr,
 #endif
 
 #ifdef PNG_sRGB_SUPPORTED
-png_uint_32 PNGAPI
+png_uint_32
 png_get_sRGB(png_const_structrp png_ptr, png_const_inforp info_ptr,
     int *file_srgb_intent)
 {
@@ -714,7 +714,7 @@ png_get_sRGB(png_const_structrp png_ptr, png_const_inforp info_ptr,
 #endif
 
 #ifdef PNG_iCCP_SUPPORTED
-png_uint_32 PNGAPI
+png_uint_32
 png_get_iCCP(png_const_structrp png_ptr, png_inforp info_ptr,
     png_charpp name, int *compression_type,
     png_bytepp profile, png_uint_32 *proflen)
@@ -742,7 +742,7 @@ png_get_iCCP(png_const_structrp png_ptr, png_inforp info_ptr,
 #endif
 
 #ifdef PNG_sPLT_SUPPORTED
-int PNGAPI
+int
 png_get_sPLT(png_const_structrp png_ptr, png_inforp info_ptr,
     png_sPLT_tpp spalettes)
 {
@@ -759,7 +759,7 @@ png_get_sPLT(png_const_structrp png_ptr, png_inforp info_ptr,
 #endif
 
 #ifdef PNG_cICP_SUPPORTED
-png_uint_32 PNGAPI
+png_uint_32
 png_get_cICP(png_const_structrp png_ptr,
              png_const_inforp info_ptr, png_bytep colour_primaries,
              png_bytep transfer_function, png_bytep matrix_coefficients,
@@ -785,7 +785,7 @@ png_get_cICP(png_const_structrp png_ptr,
 
 #ifdef PNG_cLLI_SUPPORTED
 #  ifdef PNG_FIXED_POINT_SUPPORTED
-png_uint_32 PNGAPI
+png_uint_32
 png_get_cLLI_fixed(png_const_structrp png_ptr, png_const_inforp info_ptr,
     png_uint_32p maxCLL,
     png_uint_32p maxFALL)
@@ -805,7 +805,7 @@ png_get_cLLI_fixed(png_const_structrp png_ptr, png_const_inforp info_ptr,
 #  endif
 
 #  ifdef PNG_FLOATING_POINT_SUPPORTED
-png_uint_32 PNGAPI
+png_uint_32
 png_get_cLLI(png_const_structrp png_ptr, png_const_inforp info_ptr,
       double *maxCLL, double *maxFALL)
 {
@@ -826,7 +826,7 @@ png_get_cLLI(png_const_structrp png_ptr, png_const_inforp info_ptr,
 
 #ifdef PNG_mDCV_SUPPORTED
 #  ifdef PNG_FIXED_POINT_SUPPORTED
-png_uint_32 PNGAPI
+png_uint_32
 png_get_mDCV_fixed(png_const_structrp png_ptr, png_const_inforp info_ptr,
     png_fixed_point *white_x, png_fixed_point *white_y,
     png_fixed_point *red_x, png_fixed_point *red_y,
@@ -857,7 +857,7 @@ png_get_mDCV_fixed(png_const_structrp png_ptr, png_const_inforp info_ptr,
 #  endif
 
 #  ifdef PNG_FLOATING_POINT_SUPPORTED
-png_uint_32 PNGAPI
+png_uint_32
 png_get_mDCV(png_const_structrp png_ptr, png_const_inforp info_ptr,
     double *white_x, double *white_y, double *red_x, double *red_y,
     double *green_x, double *green_y, double *blue_x, double *blue_y,
@@ -889,7 +889,7 @@ png_get_mDCV(png_const_structrp png_ptr, png_const_inforp info_ptr,
 #endif /* mDCV */
 
 #ifdef PNG_eXIf_SUPPORTED
-png_uint_32 PNGAPI
+png_uint_32
 png_get_eXIf_1(png_const_structrp png_ptr, png_const_inforp info_ptr,
     png_uint_32 *num_exif, png_bytep *exif)
 {
@@ -908,7 +908,7 @@ png_get_eXIf_1(png_const_structrp png_ptr, png_const_inforp info_ptr,
 #endif
 
 #ifdef PNG_hIST_SUPPORTED
-png_uint_32 PNGAPI
+png_uint_32
 png_get_hIST(png_const_structrp png_ptr, png_inforp info_ptr,
     png_uint_16p *hist)
 {
@@ -925,7 +925,7 @@ png_get_hIST(png_const_structrp png_ptr, png_inforp info_ptr,
 }
 #endif
 
-png_uint_32 PNGAPI
+png_uint_32
 png_get_IHDR(png_const_structrp png_ptr, png_const_inforp info_ptr,
     png_uint_32 *width, png_uint_32 *height, int *bit_depth,
     int *color_type, int *interlace_type, int *compression_type,
@@ -970,7 +970,7 @@ png_get_IHDR(png_const_structrp png_ptr, png_const_inforp info_ptr,
 }
 
 #ifdef PNG_oFFs_SUPPORTED
-png_uint_32 PNGAPI
+png_uint_32
 png_get_oFFs(png_const_structrp png_ptr, png_const_inforp info_ptr,
     png_int_32 *offset_x, png_int_32 *offset_y, int *unit_type)
 {
@@ -991,7 +991,7 @@ png_get_oFFs(png_const_structrp png_ptr, png_const_inforp info_ptr,
 #endif
 
 #ifdef PNG_pCAL_SUPPORTED
-png_uint_32 PNGAPI
+png_uint_32
 png_get_pCAL(png_const_structrp png_ptr, png_inforp info_ptr,
     png_charp *purpose, png_int_32 *X0, png_int_32 *X1, int *type, int *nparams,
     png_charp *units, png_charpp *params)
@@ -1021,7 +1021,7 @@ png_get_pCAL(png_const_structrp png_ptr, png_inforp info_ptr,
 #  ifdef PNG_FIXED_POINT_SUPPORTED
 #    if defined(PNG_FLOATING_ARITHMETIC_SUPPORTED) || \
          defined(PNG_FLOATING_POINT_SUPPORTED)
-png_uint_32 PNGAPI
+png_uint_32
 png_get_sCAL_fixed(png_const_structrp png_ptr, png_const_inforp info_ptr,
     int *unit, png_fixed_point *width, png_fixed_point *height)
 {
@@ -1046,7 +1046,7 @@ png_get_sCAL_fixed(png_const_structrp png_ptr, png_const_inforp info_ptr,
 #    endif /* FLOATING_ARITHMETIC */
 #  endif /* FIXED_POINT */
 #  ifdef PNG_FLOATING_POINT_SUPPORTED
-png_uint_32 PNGAPI
+png_uint_32
 png_get_sCAL(png_const_structrp png_ptr, png_const_inforp info_ptr,
     int *unit, double *width, double *height)
 {
@@ -1064,7 +1064,7 @@ png_get_sCAL(png_const_structrp png_ptr, png_const_inforp info_ptr,
    return 0;
 }
 #  endif /* FLOATING POINT */
-png_uint_32 PNGAPI
+png_uint_32
 png_get_sCAL_s(png_const_structrp png_ptr, png_const_inforp info_ptr,
     int *unit, png_charpp width, png_charpp height)
 {
@@ -1084,7 +1084,7 @@ png_get_sCAL_s(png_const_structrp png_ptr, png_const_inforp info_ptr,
 #endif /* sCAL */
 
 #ifdef PNG_pHYs_SUPPORTED
-png_uint_32 PNGAPI
+png_uint_32
 png_get_pHYs(png_const_structrp png_ptr, png_const_inforp info_ptr,
     png_uint_32 *res_x, png_uint_32 *res_y, int *unit_type)
 {
@@ -1118,7 +1118,7 @@ png_get_pHYs(png_const_structrp png_ptr, png_const_inforp info_ptr,
 }
 #endif /* pHYs */
 
-png_uint_32 PNGAPI
+png_uint_32
 png_get_PLTE(png_const_structrp png_ptr, png_inforp info_ptr,
     png_colorp *palette, int *num_palette)
 {
@@ -1137,7 +1137,7 @@ png_get_PLTE(png_const_structrp png_ptr, png_inforp info_ptr,
 }
 
 #ifdef PNG_sBIT_SUPPORTED
-png_uint_32 PNGAPI
+png_uint_32
 png_get_sBIT(png_const_structrp png_ptr, png_inforp info_ptr,
     png_color_8p *sig_bit)
 {
@@ -1155,7 +1155,7 @@ png_get_sBIT(png_const_structrp png_ptr, png_inforp info_ptr,
 #endif
 
 #ifdef PNG_TEXT_SUPPORTED
-int PNGAPI
+int
 png_get_text(png_const_structrp png_ptr, png_inforp info_ptr,
     png_textp *text_ptr, int *num_text)
 {
@@ -1181,7 +1181,7 @@ png_get_text(png_const_structrp png_ptr, png_inforp info_ptr,
 #endif
 
 #ifdef PNG_tIME_SUPPORTED
-png_uint_32 PNGAPI
+png_uint_32
 png_get_tIME(png_const_structrp png_ptr, png_inforp info_ptr,
     png_timep *mod_time)
 {
@@ -1199,7 +1199,7 @@ png_get_tIME(png_const_structrp png_ptr, png_inforp info_ptr,
 #endif
 
 #ifdef PNG_tRNS_SUPPORTED
-png_uint_32 PNGAPI
+png_uint_32
 png_get_tRNS(png_const_structrp png_ptr, png_inforp info_ptr,
     png_bytep *trans_alpha, int *num_trans, png_color_16p *trans_color)
 {
@@ -1246,7 +1246,7 @@ png_get_tRNS(png_const_structrp png_ptr, png_inforp info_ptr,
 #endif
 
 #ifdef PNG_STORE_UNKNOWN_CHUNKS_SUPPORTED
-int PNGAPI
+int
 png_get_unknown_chunks(png_const_structrp png_ptr, png_inforp info_ptr,
     png_unknown_chunkpp unknowns)
 {
@@ -1261,7 +1261,7 @@ png_get_unknown_chunks(png_const_structrp png_ptr, png_inforp info_ptr,
 #endif
 
 #ifdef PNG_READ_RGB_TO_GRAY_SUPPORTED
-png_byte PNGAPI
+png_byte
 png_get_rgb_to_gray_status(png_const_structrp png_ptr)
 {
    return (png_byte)(png_ptr ? png_ptr->rgb_to_gray_status : 0);
@@ -1269,14 +1269,14 @@ png_get_rgb_to_gray_status(png_const_structrp png_ptr)
 #endif
 
 #ifdef PNG_USER_CHUNKS_SUPPORTED
-png_voidp PNGAPI
+png_voidp
 png_get_user_chunk_ptr(png_const_structrp png_ptr)
 {
    return (png_ptr ? png_ptr->user_chunk_ptr : NULL);
 }
 #endif
 
-size_t PNGAPI
+size_t
 png_get_compression_buffer_size(png_const_structrp png_ptr)
 {
    if (png_ptr == NULL)
@@ -1302,27 +1302,27 @@ png_get_compression_buffer_size(png_const_structrp png_ptr)
 #ifdef PNG_SET_USER_LIMITS_SUPPORTED
 /* These functions were added to libpng 1.2.6 and were enabled
  * by default in libpng-1.4.0 */
-png_uint_32 PNGAPI
+png_uint_32
 png_get_user_width_max(png_const_structrp png_ptr)
 {
    return (png_ptr ? png_ptr->user_width_max : 0);
 }
 
-png_uint_32 PNGAPI
+png_uint_32
 png_get_user_height_max(png_const_structrp png_ptr)
 {
    return (png_ptr ? png_ptr->user_height_max : 0);
 }
 
 /* This function was added to libpng 1.4.0 */
-png_uint_32 PNGAPI
+png_uint_32
 png_get_chunk_cache_max(png_const_structrp png_ptr)
 {
    return (png_ptr ? png_ptr->user_chunk_cache_max : 0);
 }
 
 /* This function was added to libpng 1.4.1 */
-png_alloc_size_t PNGAPI
+png_alloc_size_t
 png_get_chunk_malloc_max(png_const_structrp png_ptr)
 {
    return (png_ptr ? png_ptr->user_chunk_malloc_max : 0);
@@ -1331,13 +1331,13 @@ png_get_chunk_malloc_max(png_const_structrp png_ptr)
 
 /* These functions were added to libpng 1.4.0 */
 #ifdef PNG_IO_STATE_SUPPORTED
-png_uint_32 PNGAPI
+png_uint_32
 png_get_io_state(png_const_structrp png_ptr)
 {
    return png_ptr->io_state;
 }
 
-png_uint_32 PNGAPI
+png_uint_32
 png_get_io_chunk_type(png_const_structrp png_ptr)
 {
    return png_ptr->chunk_name;
@@ -1346,7 +1346,7 @@ png_get_io_chunk_type(png_const_structrp png_ptr)
 
 #ifdef PNG_CHECK_FOR_INVALID_INDEX_SUPPORTED
 #  ifdef PNG_GET_PALETTE_MAX_SUPPORTED
-int PNGAPI
+int
 png_get_palette_max(png_const_structp png_ptr, png_const_infop info_ptr)
 {
    if (png_ptr != NULL && info_ptr != NULL)

--- a/pngmem.c
+++ b/pngmem.c
@@ -45,7 +45,7 @@ png_destroy_png_struct(png_structrp png_ptr)
  * need to allocate exactly 64K, so whatever you call here must
  * have the ability to do that.
  */
-PNG_FUNCTION(png_voidp,PNGAPI
+PNG_FUNCTION(png_voidp,
 png_calloc,(png_const_structrp png_ptr, png_alloc_size_t size),PNG_ALLOCATED)
 {
    png_voidp ret;
@@ -166,7 +166,7 @@ png_realloc_array,(png_const_structrp png_ptr, png_const_voidp old_array,
  * png_malloc always exists, but if PNG_USER_MEM_SUPPORTED is defined a separate
  * function png_malloc_default is also provided.
  */
-PNG_FUNCTION(png_voidp,PNGAPI
+PNG_FUNCTION(png_voidp,
 png_malloc,(png_const_structrp png_ptr, png_alloc_size_t size),PNG_ALLOCATED)
 {
    png_voidp ret;
@@ -183,7 +183,7 @@ png_malloc,(png_const_structrp png_ptr, png_alloc_size_t size),PNG_ALLOCATED)
 }
 
 #ifdef PNG_USER_MEM_SUPPORTED
-PNG_FUNCTION(png_voidp,PNGAPI
+PNG_FUNCTION(png_voidp,
 png_malloc_default,(png_const_structrp png_ptr, png_alloc_size_t size),
     PNG_ALLOCATED PNG_DEPRECATED)
 {
@@ -206,7 +206,7 @@ png_malloc_default,(png_const_structrp png_ptr, png_alloc_size_t size),
  * function will issue a png_warning and return NULL instead of issuing a
  * png_error, if it fails to allocate the requested memory.
  */
-PNG_FUNCTION(png_voidp,PNGAPI
+PNG_FUNCTION(png_voidp,
 png_malloc_warn,(png_const_structrp png_ptr, png_alloc_size_t size),
     PNG_ALLOCATED)
 {
@@ -226,7 +226,7 @@ png_malloc_warn,(png_const_structrp png_ptr, png_alloc_size_t size),
 /* Free a pointer allocated by png_malloc().  If ptr is NULL, return
  * without taking any action.
  */
-void PNGAPI
+void
 png_free(png_const_structrp png_ptr, png_voidp ptr)
 {
    if (png_ptr == NULL || ptr == NULL)
@@ -240,7 +240,7 @@ png_free(png_const_structrp png_ptr, png_voidp ptr)
       png_free_default(png_ptr, ptr);
 }
 
-PNG_FUNCTION(void,PNGAPI
+PNG_FUNCTION(void,
 png_free_default,(png_const_structrp png_ptr, png_voidp ptr),PNG_DEPRECATED)
 {
    if (png_ptr == NULL || ptr == NULL)
@@ -254,7 +254,7 @@ png_free_default,(png_const_structrp png_ptr, png_voidp ptr),PNG_DEPRECATED)
 /* This function is called when the application wants to use another method
  * of allocating and freeing memory.
  */
-void PNGAPI
+void
 png_set_mem_fn(png_structrp png_ptr, png_voidp mem_ptr, png_malloc_ptr
   malloc_fn, png_free_ptr free_fn)
 {
@@ -270,7 +270,7 @@ png_set_mem_fn(png_structrp png_ptr, png_voidp mem_ptr, png_malloc_ptr
  * functions.  The application should free any memory associated with this
  * pointer before png_write_destroy and png_read_destroy are called.
  */
-png_voidp PNGAPI
+png_voidp
 png_get_mem_ptr(png_const_structrp png_ptr)
 {
    if (png_ptr == NULL)

--- a/pngpread.c
+++ b/pngpread.c
@@ -1,6 +1,6 @@
 /* pngpread.c - read a png file in push mode
  *
- * Copyright (c) 2018-2024 Cosmin Truta
+ * Copyright (c) 2018-2025 Cosmin Truta
  * Copyright (c) 1998-2002,2004,2006-2018 Glenn Randers-Pehrson
  * Copyright (c) 1996-1997 Andreas Dilger
  * Copyright (c) 1995-1996 Guy Eric Schalnat, Group 42, Inc.
@@ -46,7 +46,7 @@ static const png_byte png_pass_yinc[7] = {8, 8, 8, 4, 4, 2, 2};
 /* TODO: Move these arrays to a common utility module to avoid duplication. */
 #endif
 
-void PNGAPI
+void
 png_process_data(png_structrp png_ptr, png_inforp info_ptr,
     png_bytep buffer, size_t buffer_size)
 {
@@ -61,7 +61,7 @@ png_process_data(png_structrp png_ptr, png_inforp info_ptr,
    }
 }
 
-size_t PNGAPI
+size_t
 png_process_data_pause(png_structrp png_ptr, int save)
 {
    if (png_ptr != NULL)
@@ -88,7 +88,7 @@ png_process_data_pause(png_structrp png_ptr, int save)
    return 0;
 }
 
-png_uint_32 PNGAPI
+png_uint_32
 png_process_data_skip(png_structrp png_ptr)
 {
 /* TODO: Deprecate and remove this API.
@@ -279,7 +279,7 @@ png_push_read_chunk(png_structrp png_ptr, png_inforp info_ptr)
    png_ptr->mode &= ~PNG_HAVE_CHUNK_HEADER;
 }
 
-void PNGCBAPI
+void
 png_push_fill_buffer(png_structp png_ptr, png_bytep buffer, size_t length)
 {
    png_bytep ptr;
@@ -895,7 +895,7 @@ png_push_have_row(png_structrp png_ptr, png_bytep row)
 }
 
 #ifdef PNG_READ_INTERLACING_SUPPORTED
-void PNGAPI
+void
 png_progressive_combine_row(png_const_structrp png_ptr, png_bytep old_row,
     png_const_bytep new_row)
 {
@@ -911,7 +911,7 @@ png_progressive_combine_row(png_const_structrp png_ptr, png_bytep old_row,
 }
 #endif /* READ_INTERLACING */
 
-void PNGAPI
+void
 png_set_progressive_read_fn(png_structrp png_ptr, png_voidp progressive_ptr,
     png_progressive_info_ptr info_fn, png_progressive_row_ptr row_fn,
     png_progressive_end_ptr end_fn)
@@ -926,7 +926,7 @@ png_set_progressive_read_fn(png_structrp png_ptr, png_voidp progressive_ptr,
    png_set_read_fn(png_ptr, progressive_ptr, png_push_fill_buffer);
 }
 
-png_voidp PNGAPI
+png_voidp
 png_get_progressive_ptr(png_const_structrp png_ptr)
 {
    if (png_ptr == NULL)

--- a/pngpriv.h
+++ b/pngpriv.h
@@ -170,7 +170,7 @@
 
 #ifndef PNG_INTERNAL_CALLBACK
 #  define PNG_INTERNAL_CALLBACK(type, name, args, attributes)\
-      PNG_LINKAGE_CALLBACK PNG_FUNCTION(type, (PNGCBAPI name), args,\
+      PNG_LINKAGE_CALLBACK PNG_FUNCTION(type, (name), args,\
          PNG_EMPTY attributes)
 #endif
 
@@ -280,16 +280,6 @@
 #endif
 #ifndef PNG_ERROR_TEXT_SUPPORTED
 #  define png_fixed_error(s1,s2) png_err(s1)
-#endif
-
-/* Some fixed point APIs are still required even if not exported because
- * they get used by the corresponding floating point APIs.  This magic
- * deals with this:
- */
-#ifdef PNG_FIXED_POINT_SUPPORTED
-#  define PNGFAPI PNGAPI
-#else
-#  define PNGFAPI /* PRIVATE */
 #endif
 
 #ifndef PNG_VERSION_INFO_ONLY
@@ -953,33 +943,31 @@ PNG_INTERNAL_FUNCTION(void,png_destroy_png_struct,(png_structrp png_ptr),
 /* Free an allocated jmp_buf (always succeeds) */
 PNG_INTERNAL_FUNCTION(void,png_free_jmpbuf,(png_structrp png_ptr),PNG_EMPTY);
 
-/* Function to allocate memory for zlib.  PNGAPI is disallowed. */
+/* Function to allocate memory for zlib. */
 PNG_INTERNAL_FUNCTION(voidpf,png_zalloc,(voidpf png_ptr, uInt items, uInt size),
    PNG_ALLOCATED);
 
-/* Function to free memory for zlib.  PNGAPI is disallowed. */
+/* Function to free memory for zlib. */
 PNG_INTERNAL_FUNCTION(void,png_zfree,(voidpf png_ptr, voidpf ptr),PNG_EMPTY);
 
-/* Next four functions are used internally as callbacks.  PNGCBAPI is required
- * but not PNG_EXPORT.  PNGAPI added at libpng version 1.2.3, changed to
- * PNGCBAPI at 1.5.0
- */
-
-PNG_INTERNAL_FUNCTION(void PNGCBAPI,png_default_read_data,(png_structp png_ptr,
+/* Internal callback. */
+PNG_INTERNAL_FUNCTION(void,png_default_read_data,(png_structp png_ptr,
     png_bytep data, size_t length),PNG_EMPTY);
 
 #ifdef PNG_PROGRESSIVE_READ_SUPPORTED
-PNG_INTERNAL_FUNCTION(void PNGCBAPI,png_push_fill_buffer,(png_structp png_ptr,
+/* Internal callback. */
+PNG_INTERNAL_FUNCTION(void,png_push_fill_buffer,(png_structp png_ptr,
     png_bytep buffer, size_t length),PNG_EMPTY);
 #endif
 
-PNG_INTERNAL_FUNCTION(void PNGCBAPI,png_default_write_data,(png_structp png_ptr,
+/* Internal callback. */
+PNG_INTERNAL_FUNCTION(void,png_default_write_data,(png_structp png_ptr,
     png_bytep data, size_t length),PNG_EMPTY);
 
 #ifdef PNG_WRITE_FLUSH_SUPPORTED
 #  ifdef PNG_STDIO_SUPPORTED
-PNG_INTERNAL_FUNCTION(void PNGCBAPI,png_default_flush,(png_structp png_ptr),
-   PNG_EMPTY);
+/* Internal callback. */
+PNG_INTERNAL_FUNCTION(void,png_default_flush,(png_structp png_ptr),PNG_EMPTY);
 #  endif
 #endif
 

--- a/pngread.c
+++ b/pngread.c
@@ -21,7 +21,7 @@
 #ifdef PNG_READ_SUPPORTED
 
 /* Create a PNG structure for reading, and allocate any memory needed. */
-PNG_FUNCTION(png_structp,PNGAPI
+PNG_FUNCTION(png_structp,
 png_create_read_struct,(png_const_charp user_png_ver, png_voidp error_ptr,
     png_error_ptr error_fn, png_error_ptr warn_fn),PNG_ALLOCATED)
 {
@@ -36,7 +36,7 @@ png_create_read_struct,(png_const_charp user_png_ver, png_voidp error_ptr,
 /* Alternate create PNG structure for reading, and allocate any memory
  * needed.
  */
-PNG_FUNCTION(png_structp,PNGAPI
+PNG_FUNCTION(png_structp,
 png_create_read_struct_2,(png_const_charp user_png_ver, png_voidp error_ptr,
     png_error_ptr error_fn, png_error_ptr warn_fn, png_voidp mem_ptr,
     png_malloc_ptr malloc_fn, png_free_ptr free_fn),PNG_ALLOCATED)
@@ -96,7 +96,7 @@ png_create_read_struct_2,(png_const_charp user_png_ver, png_voidp error_ptr,
  * here.  The application can then have access to the signature bytes we
  * read if it is determined that this isn't a valid PNG file.
  */
-void PNGAPI
+void
 png_read_info(png_structrp png_ptr, png_inforp info_ptr)
 {
 #ifdef PNG_HANDLE_AS_UNKNOWN_SUPPORTED
@@ -175,7 +175,7 @@ png_read_info(png_structrp png_ptr, png_inforp info_ptr)
 #endif /* SEQUENTIAL_READ */
 
 /* Optional call to update the users info_ptr structure */
-void PNGAPI
+void
 png_read_update_info(png_structrp png_ptr, png_inforp info_ptr)
 {
    png_debug(1, "in png_read_update_info");
@@ -206,7 +206,7 @@ png_read_update_info(png_structrp png_ptr, png_inforp info_ptr)
  * the user to obtain a gamma-corrected palette, for example.
  * If the user doesn't call this, we will do it ourselves.
  */
-void PNGAPI
+void
 png_start_read_image(png_structrp png_ptr)
 {
    png_debug(1, "in png_start_read_image");
@@ -291,7 +291,7 @@ png_do_read_intrapixel(png_row_infop row_info, png_bytep row)
 }
 #endif /* MNG_FEATURES */
 
-void PNGAPI
+void
 png_read_row(png_structrp png_ptr, png_bytep row, png_bytep dsp_row)
 {
    png_row_info row_info;
@@ -557,7 +557,7 @@ png_read_row(png_structrp png_ptr, png_bytep row, png_bytep dsp_row)
  * [*] png_handle_alpha() does not exist yet, as of this version of libpng
  */
 
-void PNGAPI
+void
 png_read_rows(png_structrp png_ptr, png_bytepp row,
     png_bytepp display_row, png_uint_32 num_rows)
 {
@@ -612,7 +612,7 @@ png_read_rows(png_structrp png_ptr, png_bytepp row,
  *
  * [*] png_handle_alpha() does not exist yet, as of this version of libpng
  */
-void PNGAPI
+void
 png_read_image(png_structrp png_ptr, png_bytepp image)
 {
    png_uint_32 i, image_height;
@@ -678,7 +678,7 @@ png_read_image(png_structrp png_ptr, png_bytepp image)
  * file, will verify the end is accurate, and will read any comments
  * or time information at the end of the file, if info is not NULL.
  */
-void PNGAPI
+void
 png_read_end(png_structrp png_ptr, png_inforp info_ptr)
 {
 #ifdef PNG_HANDLE_AS_UNKNOWN_SUPPORTED
@@ -830,7 +830,7 @@ png_read_destroy(png_structrp png_ptr)
 }
 
 /* Free all memory used by the read */
-void PNGAPI
+void
 png_destroy_read_struct(png_structpp png_ptr_ptr, png_infopp info_ptr_ptr,
     png_infopp end_info_ptr_ptr)
 {
@@ -856,7 +856,7 @@ png_destroy_read_struct(png_structpp png_ptr_ptr, png_infopp info_ptr_ptr,
    png_destroy_png_struct(png_ptr);
 }
 
-void PNGAPI
+void
 png_set_read_status_fn(png_structrp png_ptr, png_read_status_ptr read_row_fn)
 {
    if (png_ptr == NULL)
@@ -868,7 +868,7 @@ png_set_read_status_fn(png_structrp png_ptr, png_read_status_ptr read_row_fn)
 
 #ifdef PNG_SEQUENTIAL_READ_SUPPORTED
 #ifdef PNG_INFO_IMAGE_SUPPORTED
-void PNGAPI
+void
 png_read_png(png_structrp png_ptr, png_inforp info_ptr,
     int transforms, voidp params)
 {
@@ -1336,7 +1336,7 @@ png_image_read_header(png_voidp argument)
 }
 
 #ifdef PNG_STDIO_SUPPORTED
-int PNGAPI
+int
 png_image_begin_read_from_stdio(png_imagep image, FILE *file)
 {
    if (image != NULL && image->version == PNG_IMAGE_VERSION)
@@ -1366,7 +1366,7 @@ png_image_begin_read_from_stdio(png_imagep image, FILE *file)
    return 0;
 }
 
-int PNGAPI
+int
 png_image_begin_read_from_file(png_imagep image, const char *file_name)
 {
    if (image != NULL && image->version == PNG_IMAGE_VERSION)
@@ -1405,7 +1405,7 @@ png_image_begin_read_from_file(png_imagep image, const char *file_name)
 }
 #endif /* STDIO */
 
-static void PNGCBAPI
+static void
 png_image_memory_read(png_structp png_ptr, png_bytep out, size_t need)
 {
    if (png_ptr != NULL)
@@ -1435,7 +1435,7 @@ png_image_memory_read(png_structp png_ptr, png_bytep out, size_t need)
    }
 }
 
-int PNGAPI png_image_begin_read_from_memory(png_imagep image,
+int png_image_begin_read_from_memory(png_imagep image,
     png_const_voidp memory, size_t size)
 {
    if (image != NULL && image->version == PNG_IMAGE_VERSION)
@@ -3980,7 +3980,7 @@ png_image_read_direct(png_voidp argument)
    }
 }
 
-int PNGAPI
+int
 png_image_finish_read(png_imagep image, png_const_colorp background,
     void *buffer, png_int_32 row_stride, void *colormap)
 {

--- a/pngread.c
+++ b/pngread.c
@@ -1337,7 +1337,7 @@ png_image_read_header(png_voidp argument)
 
 #ifdef PNG_STDIO_SUPPORTED
 int PNGAPI
-png_image_begin_read_from_stdio(png_imagep image, FILE* file)
+png_image_begin_read_from_stdio(png_imagep image, FILE *file)
 {
    if (image != NULL && image->version == PNG_IMAGE_VERSION)
    {

--- a/pngrio.c
+++ b/pngrio.c
@@ -1,6 +1,6 @@
 /* pngrio.c - functions for data input
  *
- * Copyright (c) 2018 Cosmin Truta
+ * Copyright (c) 2018-2025 Cosmin Truta
  * Copyright (c) 1998-2002,2004,2006-2016,2018 Glenn Randers-Pehrson
  * Copyright (c) 1996-1997 Andreas Dilger
  * Copyright (c) 1995-1996 Guy Eric Schalnat, Group 42, Inc.
@@ -56,7 +56,7 @@ png_default_read_data(png_structp png_ptr, png_bytep data, size_t length)
    /* fread() returns 0 on error, so it is OK to store this in a size_t
     * instead of an int, which is what fread() actually returns.
     */
-   check = fread(data, 1, length, png_voidcast(png_FILE_p, png_ptr->io_ptr));
+   check = fread(data, 1, length, png_voidcast(FILE *, png_ptr->io_ptr));
 
    if (check != length)
       png_error(png_ptr, "Read Error");

--- a/pngrio.c
+++ b/pngrio.c
@@ -45,7 +45,7 @@ png_read_data(png_structrp png_ptr, png_bytep data, size_t length)
  * read_data function and use it at run time with png_set_read_fn(), rather
  * than changing the library.
  */
-void PNGCBAPI
+void
 png_default_read_data(png_structp png_ptr, png_bytep data, size_t length)
 {
    size_t check;
@@ -82,7 +82,7 @@ png_default_read_data(png_structp png_ptr, png_bytep data, size_t length)
  *                May be NULL, in which case libpng's default function will
  *                be used.
  */
-void PNGAPI
+void
 png_set_read_fn(png_structrp png_ptr, png_voidp io_ptr,
     png_rw_ptr read_data_fn)
 {

--- a/pngrtran.c
+++ b/pngrtran.c
@@ -1,6 +1,6 @@
 /* pngrtran.c - transforms the data in a row for PNG readers
  *
- * Copyright (c) 2018-2024 Cosmin Truta
+ * Copyright (c) 2018-2025 Cosmin Truta
  * Copyright (c) 1998-2002,2004,2006-2018 Glenn Randers-Pehrson
  * Copyright (c) 1996-1997 Andreas Dilger
  * Copyright (c) 1995-1996 Guy Eric Schalnat, Group 42, Inc.
@@ -20,7 +20,7 @@
 #ifdef PNG_READ_SUPPORTED
 
 /* Set the action on getting a CRC error for an ancillary or critical chunk. */
-void PNGAPI
+void
 png_set_crc_action(png_structrp png_ptr, int crit_action, int ancil_action)
 {
    png_debug(1, "in png_set_crc_action");
@@ -121,7 +121,7 @@ png_rtran_ok(png_structrp png_ptr, int need_IHDR)
 
 #ifdef PNG_READ_BACKGROUND_SUPPORTED
 /* Handle alpha and tRNS via a background color */
-void PNGFAPI
+void
 png_set_background_fixed(png_structrp png_ptr,
     png_const_color_16p background_color, int background_gamma_code,
     int need_expand, png_fixed_point background_gamma)
@@ -151,7 +151,7 @@ png_set_background_fixed(png_structrp png_ptr,
 }
 
 #  ifdef PNG_FLOATING_POINT_SUPPORTED
-void PNGAPI
+void
 png_set_background(png_structrp png_ptr,
     png_const_color_16p background_color, int background_gamma_code,
     int need_expand, double background_gamma)
@@ -167,7 +167,7 @@ png_set_background(png_structrp png_ptr,
  * TRANSFORM and API behavior to be somewhat consistent, and it's simpler.
  */
 #ifdef PNG_READ_SCALE_16_TO_8_SUPPORTED
-void PNGAPI
+void
 png_set_scale_16(png_structrp png_ptr)
 {
    png_debug(1, "in png_set_scale_16");
@@ -181,7 +181,7 @@ png_set_scale_16(png_structrp png_ptr)
 
 #ifdef PNG_READ_STRIP_16_TO_8_SUPPORTED
 /* Chop 16-bit depth files to 8-bit depth */
-void PNGAPI
+void
 png_set_strip_16(png_structrp png_ptr)
 {
    png_debug(1, "in png_set_strip_16");
@@ -194,7 +194,7 @@ png_set_strip_16(png_structrp png_ptr)
 #endif
 
 #ifdef PNG_READ_STRIP_ALPHA_SUPPORTED
-void PNGAPI
+void
 png_set_strip_alpha(png_structrp png_ptr)
 {
    png_debug(1, "in png_set_strip_alpha");
@@ -340,7 +340,7 @@ unsupported_gamma(png_structrp png_ptr, png_fixed_point gamma, int warn)
 #endif /* READ_ALPHA_MODE || READ_GAMMA */
 
 #ifdef PNG_READ_ALPHA_MODE_SUPPORTED
-void PNGFAPI
+void
 png_set_alpha_mode_fixed(png_structrp png_ptr, int mode,
     png_fixed_point output_gamma)
 {
@@ -440,7 +440,7 @@ png_set_alpha_mode_fixed(png_structrp png_ptr, int mode,
 }
 
 #  ifdef PNG_FLOATING_POINT_SUPPORTED
-void PNGAPI
+void
 png_set_alpha_mode(png_structrp png_ptr, int mode, double output_gamma)
 {
    png_set_alpha_mode_fixed(png_ptr, mode, convert_gamma_value(png_ptr,
@@ -468,7 +468,7 @@ typedef struct png_dsort_struct
 typedef png_dsort *   png_dsortp;
 typedef png_dsort * * png_dsortpp;
 
-void PNGAPI
+void
 png_set_quantize(png_structrp png_ptr, png_colorp palette,
     int num_palette, int maximum_colors, png_const_uint_16p histogram,
     int full_quantize)
@@ -855,7 +855,7 @@ png_set_quantize(png_structrp png_ptr, png_colorp palette,
 #endif /* READ_QUANTIZE */
 
 #ifdef PNG_READ_GAMMA_SUPPORTED
-void PNGFAPI
+void
 png_set_gamma_fixed(png_structrp png_ptr, png_fixed_point scrn_gamma,
     png_fixed_point file_gamma)
 {
@@ -897,7 +897,7 @@ png_set_gamma_fixed(png_structrp png_ptr, png_fixed_point scrn_gamma,
 }
 
 #  ifdef PNG_FLOATING_POINT_SUPPORTED
-void PNGAPI
+void
 png_set_gamma(png_structrp png_ptr, double scrn_gamma, double file_gamma)
 {
    png_set_gamma_fixed(png_ptr, convert_gamma_value(png_ptr, scrn_gamma),
@@ -911,7 +911,7 @@ png_set_gamma(png_structrp png_ptr, double scrn_gamma, double file_gamma)
  * less than 8-bit depth to 8-bit depth, and expand tRNS chunks
  * to alpha channels.
  */
-void PNGAPI
+void
 png_set_expand(png_structrp png_ptr)
 {
    png_debug(1, "in png_set_expand");
@@ -941,7 +941,7 @@ png_set_expand(png_structrp png_ptr)
  */
 
 /* Expand paletted images to RGB. */
-void PNGAPI
+void
 png_set_palette_to_rgb(png_structrp png_ptr)
 {
    png_debug(1, "in png_set_palette_to_rgb");
@@ -953,7 +953,7 @@ png_set_palette_to_rgb(png_structrp png_ptr)
 }
 
 /* Expand grayscale images of less than 8-bit depth to 8 bits. */
-void PNGAPI
+void
 png_set_expand_gray_1_2_4_to_8(png_structrp png_ptr)
 {
    png_debug(1, "in png_set_expand_gray_1_2_4_to_8");
@@ -965,7 +965,7 @@ png_set_expand_gray_1_2_4_to_8(png_structrp png_ptr)
 }
 
 /* Expand tRNS chunks to alpha channels. */
-void PNGAPI
+void
 png_set_tRNS_to_alpha(png_structrp png_ptr)
 {
    png_debug(1, "in png_set_tRNS_to_alpha");
@@ -981,7 +981,7 @@ png_set_tRNS_to_alpha(png_structrp png_ptr)
 /* Expand to 16-bit channels, expand the tRNS chunk too (because otherwise
  * it may not work correctly.)
  */
-void PNGAPI
+void
 png_set_expand_16(png_structrp png_ptr)
 {
    png_debug(1, "in png_set_expand_16");
@@ -994,7 +994,7 @@ png_set_expand_16(png_structrp png_ptr)
 #endif
 
 #ifdef PNG_READ_GRAY_TO_RGB_SUPPORTED
-void PNGAPI
+void
 png_set_gray_to_rgb(png_structrp png_ptr)
 {
    png_debug(1, "in png_set_gray_to_rgb");
@@ -1009,7 +1009,7 @@ png_set_gray_to_rgb(png_structrp png_ptr)
 #endif
 
 #ifdef PNG_READ_RGB_TO_GRAY_SUPPORTED
-void PNGFAPI
+void
 png_set_rgb_to_gray_fixed(png_structrp png_ptr, int error_action,
     png_fixed_point red, png_fixed_point green)
 {
@@ -1081,7 +1081,7 @@ png_set_rgb_to_gray_fixed(png_structrp png_ptr, int error_action,
  * for example, to convert a 24 bpp RGB image into an 8 bpp grayscale image.
  */
 
-void PNGAPI
+void
 png_set_rgb_to_gray(png_structrp png_ptr, int error_action, double red,
     double green)
 {
@@ -1095,7 +1095,7 @@ png_set_rgb_to_gray(png_structrp png_ptr, int error_action, double red,
 
 #if defined(PNG_READ_USER_TRANSFORM_SUPPORTED) || \
     defined(PNG_WRITE_USER_TRANSFORM_SUPPORTED)
-void PNGAPI
+void
 png_set_read_user_transform_fn(png_structrp png_ptr, png_user_transform_ptr
     read_user_transform_fn)
 {

--- a/pngrutil.c
+++ b/pngrutil.c
@@ -1,6 +1,6 @@
 /* pngrutil.c - utilities to read a PNG file
  *
- * Copyright (c) 2018-2024 Cosmin Truta
+ * Copyright (c) 2018-2025 Cosmin Truta
  * Copyright (c) 1998-2002,2004,2006-2018 Glenn Randers-Pehrson
  * Copyright (c) 1996-1997 Andreas Dilger
  * Copyright (c) 1995-1996 Guy Eric Schalnat, Group 42, Inc.
@@ -37,7 +37,7 @@ static const png_byte png_pass_yinc[7] = {8, 8, 8, 4, 4, 2, 2};
 /* TODO: Move these arrays to a common utility module to avoid duplication. */
 #endif
 
-png_uint_32 PNGAPI
+png_uint_32
 png_get_uint_31(png_const_structrp png_ptr, png_const_bytep buf)
 {
    png_uint_32 uval = png_get_uint_32(buf);
@@ -53,14 +53,14 @@ png_get_uint_31(png_const_structrp png_ptr, png_const_bytep buf)
  * PNG_USE_READ_MACROS is set the library will not use them internally,
  * but the APIs will still be available externally.
  *
- * The parentheses around "PNGAPI function_name" in the following three
- * functions are necessary because they allow the macros to co-exist with
- * these (unused but exported) functions.
+ * The parentheses around function names in the following three functions
+ * are necessary, because they allow the macros to co-exist with these
+ * (unused but exported) functions.
  */
 
 /* Grab an unsigned 32-bit integer from a buffer in big-endian format. */
-png_uint_32 (PNGAPI
-png_get_uint_32)(png_const_bytep buf)
+png_uint_32
+(png_get_uint_32)(png_const_bytep buf)
 {
    png_uint_32 uval =
        ((png_uint_32)(*(buf    )) << 24) +
@@ -76,8 +76,8 @@ png_get_uint_32)(png_const_bytep buf)
  * is no guarantee that a 'png_int_32' is exactly 32 bits, therefore
  * the following code does a two's complement to native conversion.
  */
-png_int_32 (PNGAPI
-png_get_int_32)(png_const_bytep buf)
+png_int_32
+(png_get_int_32)(png_const_bytep buf)
 {
    png_uint_32 uval = png_get_uint_32(buf);
    if ((uval & 0x80000000) == 0) /* non-negative */
@@ -94,8 +94,8 @@ png_get_int_32)(png_const_bytep buf)
 }
 
 /* Grab an unsigned 16-bit integer from a buffer in big-endian format. */
-png_uint_16 (PNGAPI
-png_get_uint_16)(png_const_bytep buf)
+png_uint_16
+(png_get_uint_16)(png_const_bytep buf)
 {
    /* ANSI-C requires an int value to accommodate at least 16 bits so this
     * works and allows the compiler not to worry about possible narrowing

--- a/pngset.c
+++ b/pngset.c
@@ -20,7 +20,7 @@
 #if defined(PNG_READ_SUPPORTED) || defined(PNG_WRITE_SUPPORTED)
 
 #ifdef PNG_bKGD_SUPPORTED
-void PNGAPI
+void
 png_set_bKGD(png_const_structrp png_ptr, png_inforp info_ptr,
     png_const_color_16p background)
 {
@@ -35,7 +35,7 @@ png_set_bKGD(png_const_structrp png_ptr, png_inforp info_ptr,
 #endif
 
 #ifdef PNG_cHRM_SUPPORTED
-void PNGFAPI
+void
 png_set_cHRM_fixed(png_const_structrp png_ptr, png_inforp info_ptr,
     png_fixed_point white_x, png_fixed_point white_y, png_fixed_point red_x,
     png_fixed_point red_y, png_fixed_point green_x, png_fixed_point green_y,
@@ -58,7 +58,7 @@ png_set_cHRM_fixed(png_const_structrp png_ptr, png_inforp info_ptr,
    info_ptr->valid |= PNG_INFO_cHRM;
 }
 
-void PNGFAPI
+void
 png_set_cHRM_XYZ_fixed(png_const_structrp png_ptr, png_inforp info_ptr,
     png_fixed_point int_red_X, png_fixed_point int_red_Y,
     png_fixed_point int_red_Z, png_fixed_point int_green_X,
@@ -95,7 +95,7 @@ png_set_cHRM_XYZ_fixed(png_const_structrp png_ptr, png_inforp info_ptr,
 }
 
 #  ifdef PNG_FLOATING_POINT_SUPPORTED
-void PNGAPI
+void
 png_set_cHRM(png_const_structrp png_ptr, png_inforp info_ptr,
     double white_x, double white_y, double red_x, double red_y,
     double green_x, double green_y, double blue_x, double blue_y)
@@ -111,7 +111,7 @@ png_set_cHRM(png_const_structrp png_ptr, png_inforp info_ptr,
        png_fixed(png_ptr, blue_y, "cHRM Blue Y"));
 }
 
-void PNGAPI
+void
 png_set_cHRM_XYZ(png_const_structrp png_ptr, png_inforp info_ptr, double red_X,
     double red_Y, double red_Z, double green_X, double green_Y, double green_Z,
     double blue_X, double blue_Y, double blue_Z)
@@ -132,7 +132,7 @@ png_set_cHRM_XYZ(png_const_structrp png_ptr, png_inforp info_ptr, double red_X,
 #endif /* cHRM */
 
 #ifdef PNG_cICP_SUPPORTED
-void PNGAPI
+void
 png_set_cICP(png_const_structrp png_ptr, png_inforp info_ptr,
              png_byte colour_primaries, png_byte transfer_function,
              png_byte matrix_coefficients, png_byte video_full_range_flag)
@@ -158,7 +158,7 @@ png_set_cICP(png_const_structrp png_ptr, png_inforp info_ptr,
 #endif /* cICP */
 
 #ifdef PNG_cLLI_SUPPORTED
-void PNGFAPI
+void
 png_set_cLLI_fixed(png_const_structrp png_ptr, png_inforp info_ptr,
     /* The values below are in cd/m2 (nits) and are scaled by 10,000; not
      * 100,000 as in the case of png_fixed_point.
@@ -190,7 +190,7 @@ png_set_cLLI_fixed(png_const_structrp png_ptr, png_inforp info_ptr,
 }
 
 #  ifdef PNG_FLOATING_POINT_SUPPORTED
-void PNGAPI
+void
 png_set_cLLI(png_const_structrp png_ptr, png_inforp info_ptr,
    double maxCLL, double maxFALL)
 {
@@ -221,7 +221,7 @@ png_ITU_fixed_16(int *error, png_fixed_point v)
    return (png_uint_16)/*SAFE*/v;
 }
 
-void PNGAPI
+void
 png_set_mDCV_fixed(png_const_structrp png_ptr, png_inforp info_ptr,
     png_fixed_point white_x, png_fixed_point white_y,
     png_fixed_point red_x, png_fixed_point red_y,
@@ -293,7 +293,7 @@ png_set_mDCV_fixed(png_const_structrp png_ptr, png_inforp info_ptr,
 }
 
 #  ifdef PNG_FLOATING_POINT_SUPPORTED
-void PNGAPI
+void
 png_set_mDCV(png_const_structrp png_ptr, png_inforp info_ptr,
     double white_x, double white_y, double red_x, double red_y, double green_x,
     double green_y, double blue_x, double blue_y,
@@ -318,7 +318,7 @@ png_set_mDCV(png_const_structrp png_ptr, png_inforp info_ptr,
 #endif /* mDCV */
 
 #ifdef PNG_eXIf_SUPPORTED
-void PNGAPI
+void
 png_set_eXIf_1(png_const_structrp png_ptr, png_inforp info_ptr,
     png_uint_32 num_exif, png_bytep exif)
 {
@@ -350,7 +350,7 @@ png_set_eXIf_1(png_const_structrp png_ptr, png_inforp info_ptr,
 #endif /* eXIf */
 
 #ifdef PNG_gAMA_SUPPORTED
-void PNGFAPI
+void
 png_set_gAMA_fixed(png_const_structrp png_ptr, png_inforp info_ptr,
     png_fixed_point file_gamma)
 {
@@ -364,7 +364,7 @@ png_set_gAMA_fixed(png_const_structrp png_ptr, png_inforp info_ptr,
 }
 
 #  ifdef PNG_FLOATING_POINT_SUPPORTED
-void PNGAPI
+void
 png_set_gAMA(png_const_structrp png_ptr, png_inforp info_ptr, double file_gamma)
 {
    png_set_gAMA_fixed(png_ptr, info_ptr, png_fixed(png_ptr, file_gamma,
@@ -374,7 +374,7 @@ png_set_gAMA(png_const_structrp png_ptr, png_inforp info_ptr, double file_gamma)
 #endif
 
 #ifdef PNG_hIST_SUPPORTED
-void PNGAPI
+void
 png_set_hIST(png_const_structrp png_ptr, png_inforp info_ptr,
     png_const_uint_16p hist)
 {
@@ -416,7 +416,7 @@ png_set_hIST(png_const_structrp png_ptr, png_inforp info_ptr,
 }
 #endif
 
-void PNGAPI
+void
 png_set_IHDR(png_const_structrp png_ptr, png_inforp info_ptr,
     png_uint_32 width, png_uint_32 height, int bit_depth,
     int color_type, int interlace_type, int compression_type,
@@ -457,7 +457,7 @@ png_set_IHDR(png_const_structrp png_ptr, png_inforp info_ptr,
 }
 
 #ifdef PNG_oFFs_SUPPORTED
-void PNGAPI
+void
 png_set_oFFs(png_const_structrp png_ptr, png_inforp info_ptr,
     png_int_32 offset_x, png_int_32 offset_y, int unit_type)
 {
@@ -474,7 +474,7 @@ png_set_oFFs(png_const_structrp png_ptr, png_inforp info_ptr,
 #endif
 
 #ifdef PNG_pCAL_SUPPORTED
-void PNGAPI
+void
 png_set_pCAL(png_const_structrp png_ptr, png_inforp info_ptr,
     png_const_charp purpose, png_int_32 X0, png_int_32 X1, int type,
     int nparams, png_const_charp units, png_charpp params)
@@ -590,7 +590,7 @@ png_set_pCAL(png_const_structrp png_ptr, png_inforp info_ptr,
 #endif
 
 #ifdef PNG_sCAL_SUPPORTED
-void PNGAPI
+void
 png_set_sCAL_s(png_const_structrp png_ptr, png_inforp info_ptr,
     int unit, png_const_charp swidth, png_const_charp sheight)
 {
@@ -656,7 +656,7 @@ png_set_sCAL_s(png_const_structrp png_ptr, png_inforp info_ptr,
 }
 
 #  ifdef PNG_FLOATING_POINT_SUPPORTED
-void PNGAPI
+void
 png_set_sCAL(png_const_structrp png_ptr, png_inforp info_ptr, int unit,
     double width, double height)
 {
@@ -686,7 +686,7 @@ png_set_sCAL(png_const_structrp png_ptr, png_inforp info_ptr, int unit,
 #  endif
 
 #  ifdef PNG_FIXED_POINT_SUPPORTED
-void PNGAPI
+void
 png_set_sCAL_fixed(png_const_structrp png_ptr, png_inforp info_ptr, int unit,
     png_fixed_point width, png_fixed_point height)
 {
@@ -715,7 +715,7 @@ png_set_sCAL_fixed(png_const_structrp png_ptr, png_inforp info_ptr, int unit,
 #endif
 
 #ifdef PNG_pHYs_SUPPORTED
-void PNGAPI
+void
 png_set_pHYs(png_const_structrp png_ptr, png_inforp info_ptr,
     png_uint_32 res_x, png_uint_32 res_y, int unit_type)
 {
@@ -731,7 +731,7 @@ png_set_pHYs(png_const_structrp png_ptr, png_inforp info_ptr,
 }
 #endif
 
-void PNGAPI
+void
 png_set_PLTE(png_structrp png_ptr, png_inforp info_ptr,
     png_const_colorp palette, int num_palette)
 {
@@ -796,7 +796,7 @@ png_set_PLTE(png_structrp png_ptr, png_inforp info_ptr,
 }
 
 #ifdef PNG_sBIT_SUPPORTED
-void PNGAPI
+void
 png_set_sBIT(png_const_structrp png_ptr, png_inforp info_ptr,
     png_const_color_8p sig_bit)
 {
@@ -811,7 +811,7 @@ png_set_sBIT(png_const_structrp png_ptr, png_inforp info_ptr,
 #endif
 
 #ifdef PNG_sRGB_SUPPORTED
-void PNGAPI
+void
 png_set_sRGB(png_const_structrp png_ptr, png_inforp info_ptr, int srgb_intent)
 {
    png_debug1(1, "in %s storage function", "sRGB");
@@ -823,7 +823,7 @@ png_set_sRGB(png_const_structrp png_ptr, png_inforp info_ptr, int srgb_intent)
    info_ptr->valid |= PNG_INFO_sRGB;
 }
 
-void PNGAPI
+void
 png_set_sRGB_gAMA_and_cHRM(png_const_structrp png_ptr, png_inforp info_ptr,
     int srgb_intent)
 {
@@ -851,7 +851,7 @@ png_set_sRGB_gAMA_and_cHRM(png_const_structrp png_ptr, png_inforp info_ptr,
 
 
 #ifdef PNG_iCCP_SUPPORTED
-void PNGAPI
+void
 png_set_iCCP(png_const_structrp png_ptr, png_inforp info_ptr,
     png_const_charp name, int compression_type,
     png_const_bytep profile, png_uint_32 proflen)
@@ -904,7 +904,7 @@ png_set_iCCP(png_const_structrp png_ptr, png_inforp info_ptr,
 #endif
 
 #ifdef PNG_TEXT_SUPPORTED
-void PNGAPI
+void
 png_set_text(png_const_structrp png_ptr, png_inforp info_ptr,
     png_const_textp text_ptr, int num_text)
 {
@@ -1110,7 +1110,7 @@ png_set_text_2(png_const_structrp png_ptr, png_inforp info_ptr,
 #endif
 
 #ifdef PNG_tIME_SUPPORTED
-void PNGAPI
+void
 png_set_tIME(png_const_structrp png_ptr, png_inforp info_ptr,
     png_const_timep mod_time)
 {
@@ -1136,7 +1136,7 @@ png_set_tIME(png_const_structrp png_ptr, png_inforp info_ptr,
 #endif
 
 #ifdef PNG_tRNS_SUPPORTED
-void PNGAPI
+void
 png_set_tRNS(png_structrp png_ptr, png_inforp info_ptr,
     png_const_bytep trans_alpha, int num_trans, png_const_color_16p trans_color)
 {
@@ -1207,7 +1207,7 @@ png_set_tRNS(png_structrp png_ptr, png_inforp info_ptr,
 #endif
 
 #ifdef PNG_sPLT_SUPPORTED
-void PNGAPI
+void
 png_set_sPLT(png_const_structrp png_ptr,
     png_inforp info_ptr, png_const_sPLT_tp entries, int nentries)
 /*
@@ -1347,7 +1347,7 @@ check_location(png_const_structrp png_ptr, int location)
    return (png_byte)location;
 }
 
-void PNGAPI
+void
 png_set_unknown_chunks(png_const_structrp png_ptr,
     png_inforp info_ptr, png_const_unknown_chunkp unknowns, int num_unknowns)
 {
@@ -1446,7 +1446,7 @@ png_set_unknown_chunks(png_const_structrp png_ptr,
    }
 }
 
-void PNGAPI
+void
 png_set_unknown_chunk_location(png_const_structrp png_ptr, png_inforp info_ptr,
     int chunk, int location)
 {
@@ -1476,7 +1476,7 @@ png_set_unknown_chunk_location(png_const_structrp png_ptr, png_inforp info_ptr,
 #endif /* STORE_UNKNOWN_CHUNKS */
 
 #ifdef PNG_MNG_FEATURES_SUPPORTED
-png_uint_32 PNGAPI
+png_uint_32
 png_permit_mng_features(png_structrp png_ptr, png_uint_32 mng_features)
 {
    png_debug(1, "in png_permit_mng_features");
@@ -1519,7 +1519,7 @@ add_one_chunk(png_bytep list, unsigned int count, png_const_bytep add, int keep)
    return count;
 }
 
-void PNGAPI
+void
 png_set_keep_unknown_chunks(png_structrp png_ptr, int keep,
     png_const_bytep chunk_list, int num_chunks_in)
 {
@@ -1681,7 +1681,7 @@ png_set_keep_unknown_chunks(png_structrp png_ptr, int keep,
 #endif
 
 #ifdef PNG_READ_USER_CHUNKS_SUPPORTED
-void PNGAPI
+void
 png_set_read_user_chunk_fn(png_structrp png_ptr, png_voidp user_chunk_ptr,
     png_user_chunk_ptr read_user_chunk_fn)
 {
@@ -1696,7 +1696,7 @@ png_set_read_user_chunk_fn(png_structrp png_ptr, png_voidp user_chunk_ptr,
 #endif
 
 #ifdef PNG_INFO_IMAGE_SUPPORTED
-void PNGAPI
+void
 png_set_rows(png_const_structrp png_ptr, png_inforp info_ptr,
     png_bytepp row_pointers)
 {
@@ -1716,7 +1716,7 @@ png_set_rows(png_const_structrp png_ptr, png_inforp info_ptr,
 }
 #endif
 
-void PNGAPI
+void
 png_set_compression_buffer_size(png_structrp png_ptr, size_t size)
 {
    png_debug(1, "in png_set_compression_buffer_size");
@@ -1778,7 +1778,7 @@ png_set_compression_buffer_size(png_structrp png_ptr, size_t size)
 #  endif
 }
 
-void PNGAPI
+void
 png_set_invalid(png_const_structrp png_ptr, png_inforp info_ptr, int mask)
 {
    if (png_ptr != NULL && info_ptr != NULL)
@@ -1788,7 +1788,7 @@ png_set_invalid(png_const_structrp png_ptr, png_inforp info_ptr, int mask)
 
 #ifdef PNG_SET_USER_LIMITS_SUPPORTED
 /* This function was added to libpng 1.2.6 */
-void PNGAPI
+void
 png_set_user_limits(png_structrp png_ptr, png_uint_32 user_width_max,
     png_uint_32 user_height_max)
 {
@@ -1806,7 +1806,7 @@ png_set_user_limits(png_structrp png_ptr, png_uint_32 user_width_max,
 }
 
 /* This function was added to libpng 1.4.0 */
-void PNGAPI
+void
 png_set_chunk_cache_max(png_structrp png_ptr, png_uint_32 user_chunk_cache_max)
 {
    png_debug(1, "in png_set_chunk_cache_max");
@@ -1816,7 +1816,7 @@ png_set_chunk_cache_max(png_structrp png_ptr, png_uint_32 user_chunk_cache_max)
 }
 
 /* This function was added to libpng 1.4.1 */
-void PNGAPI
+void
 png_set_chunk_malloc_max(png_structrp png_ptr,
     png_alloc_size_t user_chunk_malloc_max)
 {
@@ -1845,7 +1845,7 @@ png_set_chunk_malloc_max(png_structrp png_ptr,
 
 
 #ifdef PNG_BENIGN_ERRORS_SUPPORTED
-void PNGAPI
+void
 png_set_benign_errors(png_structrp png_ptr, int allowed)
 {
    png_debug(1, "in png_set_benign_errors");
@@ -1875,7 +1875,7 @@ png_set_benign_errors(png_structrp png_ptr, int allowed)
     * (opaque black).  By default, when this occurs libpng will issue
     * a benign error.  This API can be used to override that behavior.
     */
-void PNGAPI
+void
 png_set_check_for_invalid_index(png_structrp png_ptr, int allowed)
 {
    png_debug(1, "in png_set_check_for_invalid_index");

--- a/pngtest.c
+++ b/pngtest.c
@@ -154,7 +154,7 @@ static int status_pass = 1;
 static int status_dots_requested = 0;
 static int status_dots = 1;
 
-static void PNGCBAPI
+static void
 read_row_callback(png_structp png_ptr, png_uint_32 row_number, int pass)
 {
    /* The callback should always receive correct parameters. */
@@ -184,7 +184,7 @@ read_row_callback(png_structp png_ptr, png_uint_32 row_number, int pass)
 }
 
 #ifdef PNG_WRITE_SUPPORTED
-static void PNGCBAPI
+static void
 write_row_callback(png_structp png_ptr, png_uint_32 row_number, int pass)
 {
    /* The callback should always receive correct parameters. */
@@ -203,7 +203,7 @@ write_row_callback(png_structp png_ptr, png_uint_32 row_number, int pass)
 #ifdef PNG_READ_USER_TRANSFORM_SUPPORTED
 /* Example of using a user transform callback (doesn't do anything at present).
  */
-static void PNGCBAPI
+static void
 read_user_callback(png_structp png_ptr, png_row_infop row_info, png_bytep data)
 {
    /* The callback should always receive correct parameters. */
@@ -223,7 +223,7 @@ read_user_callback(png_structp png_ptr, png_row_infop row_info, png_bytep data)
 
 static png_uint_32 zero_samples;
 
-static void PNGCBAPI
+static void
 count_zero_samples(png_structp png_ptr, png_row_infop row_info, png_bytep data)
 {
    png_bytep dp = data;
@@ -386,7 +386,7 @@ pngtest_check_io_state(png_structp png_ptr, size_t data_length,
 }
 #endif
 
-static void PNGCBAPI
+static void
 pngtest_read_data(png_structp png_ptr, png_bytep data, size_t length)
 {
    size_t check = 0;
@@ -411,7 +411,7 @@ pngtest_read_data(png_structp png_ptr, png_bytep data, size_t length)
 }
 
 #ifdef PNG_WRITE_FLUSH_SUPPORTED
-static void PNGCBAPI
+static void
 pngtest_flush(png_structp png_ptr)
 {
    if (png_ptr == NULL)
@@ -426,7 +426,7 @@ pngtest_flush(png_structp png_ptr)
  * write_data function and use it at run time with png_set_write_fn(), rather
  * than changing the library.
  */
-static void PNGCBAPI
+static void
 pngtest_write_data(png_structp png_ptr, png_bytep data, size_t length)
 {
    size_t check;
@@ -455,7 +455,7 @@ typedef struct
    const char *file_name;
 }  pngtest_error_parameters;
 
-static void PNGCBAPI
+static void
 pngtest_warning(png_structp png_ptr, png_const_charp message)
 {
    const char *name = "UNKNOWN (ERROR!)";
@@ -475,7 +475,7 @@ pngtest_warning(png_structp png_ptr, png_const_charp message)
  * function is used by default, or if the program supplies NULL for the
  * error function pointer in png_set_error_fn().
  */
-static void PNGCBAPI
+static void
 pngtest_error(png_structp png_ptr, png_const_charp message)
 {
    ++error_count;
@@ -514,14 +514,13 @@ static int maximum_allocation = 0;
 static int total_allocation = 0;
 static int num_allocations = 0;
 
-png_voidp PNGCBAPI png_debug_malloc(png_structp png_ptr,
+png_voidp png_debug_malloc(png_structp png_ptr,
     png_alloc_size_t size);
-void PNGCBAPI png_debug_free(png_structp png_ptr, png_voidp ptr);
+void png_debug_free(png_structp png_ptr, png_voidp ptr);
 
 png_voidp
-PNGCBAPI png_debug_malloc(png_structp png_ptr, png_alloc_size_t size)
+png_debug_malloc(png_structp png_ptr, png_alloc_size_t size)
 {
-
    /* png_malloc has already tested for NULL; png_create_struct calls
     * png_debug_malloc directly, with png_ptr == NULL which is OK
     */
@@ -573,7 +572,7 @@ PNGCBAPI png_debug_malloc(png_structp png_ptr, png_alloc_size_t size)
 }
 
 /* Free a pointer.  It is removed from the list at the same time. */
-void PNGCBAPI
+void
 png_debug_free(png_structp png_ptr, png_voidp ptr)
 {
    if (png_ptr == NULL)
@@ -691,7 +690,7 @@ set_chunk_location(png_structp png_ptr, user_chunk_info *chunk_data, int what)
    return 1; /* handled */
 }
 
-static int PNGCBAPI
+static int
 read_user_chunk_callback(png_struct *png_ptr, png_unknown_chunkp chunk)
 {
    user_chunk_info *my_user_chunk_data =

--- a/pngtest.c
+++ b/pngtest.c
@@ -104,10 +104,6 @@ typedef png_libpng_version_1_8_0_git Your_png_h_is_not_version_1_8_0_git;
 #  define PNG_ZBUF_SIZE 8192
 #endif
 
-#ifndef PNG_STDIO_SUPPORTED
-typedef FILE * png_FILE_p;
-#endif
-
 #ifndef PNG_DEBUG
 #  define PNG_DEBUG 0
 #endif
@@ -404,7 +400,7 @@ pngtest_read_data(png_structp png_ptr, png_bytep data, size_t length)
     */
    io_ptr = png_get_io_ptr(png_ptr);
    if (io_ptr != NULL)
-      check = fread(data, 1, length, (png_FILE_p)io_ptr);
+      check = fread(data, 1, length, (FILE *)io_ptr);
 
    if (check != length)
       png_error(png_ptr, "Read Error");
@@ -438,7 +434,7 @@ pngtest_write_data(png_structp png_ptr, png_bytep data, size_t length)
    if (png_ptr == NULL)
       png_error(png_ptr, "pngtest_write_data: bad png_ptr");
 
-   check = fwrite(data, 1, length, (png_FILE_p)png_get_io_ptr(png_ptr));
+   check = fwrite(data, 1, length, (FILE *)png_get_io_ptr(png_ptr));
 
    if (check != length)
       png_error(png_ptr, "Write Error");
@@ -859,8 +855,8 @@ pngtest_check_text_support(png_structp png_ptr, png_textp text_ptr,
 static int
 test_one_file(const char *inname, const char *outname)
 {
-   static png_FILE_p fpin;
-   static png_FILE_p fpout;  /* "static" prevents setjmp corruption */
+   static FILE *fpin;
+   static FILE *fpout;  /* "static" prevents setjmp corruption */
    pngtest_error_parameters error_parameters;
    png_structp read_ptr;
    png_infop read_info_ptr, end_info_ptr;

--- a/pngtrans.c
+++ b/pngtrans.c
@@ -1,6 +1,6 @@
 /* pngtrans.c - transforms the data in a row (used by both readers and writers)
  *
- * Copyright (c) 2018-2024 Cosmin Truta
+ * Copyright (c) 2018-2025 Cosmin Truta
  * Copyright (c) 1998-2002,2004,2006-2018 Glenn Randers-Pehrson
  * Copyright (c) 1996-1997 Andreas Dilger
  * Copyright (c) 1995-1996 Guy Eric Schalnat, Group 42, Inc.
@@ -16,7 +16,7 @@
 
 #if defined(PNG_READ_BGR_SUPPORTED) || defined(PNG_WRITE_BGR_SUPPORTED)
 /* Turn on BGR-to-RGB mapping */
-void PNGAPI
+void
 png_set_bgr(png_structrp png_ptr)
 {
    png_debug(1, "in png_set_bgr");
@@ -30,7 +30,7 @@ png_set_bgr(png_structrp png_ptr)
 
 #if defined(PNG_READ_SWAP_SUPPORTED) || defined(PNG_WRITE_SWAP_SUPPORTED)
 /* Turn on 16-bit byte swapping */
-void PNGAPI
+void
 png_set_swap(png_structrp png_ptr)
 {
    png_debug(1, "in png_set_swap");
@@ -45,7 +45,7 @@ png_set_swap(png_structrp png_ptr)
 
 #if defined(PNG_READ_PACK_SUPPORTED) || defined(PNG_WRITE_PACK_SUPPORTED)
 /* Turn on pixel packing */
-void PNGAPI
+void
 png_set_packing(png_structrp png_ptr)
 {
    png_debug(1, "in png_set_packing");
@@ -65,7 +65,7 @@ png_set_packing(png_structrp png_ptr)
 
 #if defined(PNG_READ_PACKSWAP_SUPPORTED)||defined(PNG_WRITE_PACKSWAP_SUPPORTED)
 /* Turn on packed pixel swapping */
-void PNGAPI
+void
 png_set_packswap(png_structrp png_ptr)
 {
    png_debug(1, "in png_set_packswap");
@@ -79,7 +79,7 @@ png_set_packswap(png_structrp png_ptr)
 #endif
 
 #if defined(PNG_READ_SHIFT_SUPPORTED) || defined(PNG_WRITE_SHIFT_SUPPORTED)
-void PNGAPI
+void
 png_set_shift(png_structrp png_ptr, png_const_color_8p true_bits)
 {
    png_debug(1, "in png_set_shift");
@@ -94,7 +94,7 @@ png_set_shift(png_structrp png_ptr, png_const_color_8p true_bits)
 
 #if defined(PNG_READ_INTERLACING_SUPPORTED) || \
     defined(PNG_WRITE_INTERLACING_SUPPORTED)
-int PNGAPI
+int
 png_set_interlace_handling(png_structrp png_ptr)
 {
    png_debug(1, "in png_set_interlace handling");
@@ -115,7 +115,7 @@ png_set_interlace_handling(png_structrp png_ptr)
  * for 48-bit input data, as well as to avoid problems with some compilers
  * that don't like bytes as parameters.
  */
-void PNGAPI
+void
 png_set_filler(png_structrp png_ptr, png_uint_32 filler, int filler_loc)
 {
    png_debug(1, "in png_set_filler");
@@ -200,7 +200,7 @@ png_set_filler(png_structrp png_ptr, png_uint_32 filler, int filler_loc)
 }
 
 /* Added to libpng-1.2.7 */
-void PNGAPI
+void
 png_set_add_alpha(png_structrp png_ptr, png_uint_32 filler, int filler_loc)
 {
    png_debug(1, "in png_set_add_alpha");
@@ -218,7 +218,7 @@ png_set_add_alpha(png_structrp png_ptr, png_uint_32 filler, int filler_loc)
 
 #if defined(PNG_READ_SWAP_ALPHA_SUPPORTED) || \
     defined(PNG_WRITE_SWAP_ALPHA_SUPPORTED)
-void PNGAPI
+void
 png_set_swap_alpha(png_structrp png_ptr)
 {
    png_debug(1, "in png_set_swap_alpha");
@@ -232,7 +232,7 @@ png_set_swap_alpha(png_structrp png_ptr)
 
 #if defined(PNG_READ_INVERT_ALPHA_SUPPORTED) || \
     defined(PNG_WRITE_INVERT_ALPHA_SUPPORTED)
-void PNGAPI
+void
 png_set_invert_alpha(png_structrp png_ptr)
 {
    png_debug(1, "in png_set_invert_alpha");
@@ -245,7 +245,7 @@ png_set_invert_alpha(png_structrp png_ptr)
 #endif
 
 #if defined(PNG_READ_INVERT_SUPPORTED) || defined(PNG_WRITE_INVERT_SUPPORTED)
-void PNGAPI
+void
 png_set_invert_mono(png_structrp png_ptr)
 {
    png_debug(1, "in png_set_invert_mono");
@@ -801,7 +801,7 @@ png_do_check_palette_indexes(png_structrp png_ptr, png_row_infop row_info)
 #if defined(PNG_READ_USER_TRANSFORM_SUPPORTED) || \
     defined(PNG_WRITE_USER_TRANSFORM_SUPPORTED)
 #ifdef PNG_USER_TRANSFORM_PTR_SUPPORTED
-void PNGAPI
+void
 png_set_user_transform_info(png_structrp png_ptr, png_voidp
    user_transform_ptr, int user_transform_depth, int user_transform_channels)
 {
@@ -832,7 +832,7 @@ png_set_user_transform_info(png_structrp png_ptr, png_voidp
  * are called.
  */
 #ifdef PNG_USER_TRANSFORM_PTR_SUPPORTED
-png_voidp PNGAPI
+png_voidp
 png_get_user_transform_ptr(png_const_structrp png_ptr)
 {
    if (png_ptr == NULL)
@@ -843,7 +843,7 @@ png_get_user_transform_ptr(png_const_structrp png_ptr)
 #endif
 
 #ifdef PNG_USER_TRANSFORM_INFO_SUPPORTED
-png_uint_32 PNGAPI
+png_uint_32
 png_get_current_row_number(png_const_structrp png_ptr)
 {
    /* See the comments in png.h - this is the sub-image row when reading an
@@ -855,7 +855,7 @@ png_get_current_row_number(png_const_structrp png_ptr)
    return PNG_UINT_32_MAX; /* help the app not to fail silently */
 }
 
-png_byte PNGAPI
+png_byte
 png_get_current_pass_number(png_const_structrp png_ptr)
 {
    if (png_ptr != NULL)

--- a/pngwio.c
+++ b/pngwio.c
@@ -1,6 +1,6 @@
 /* pngwio.c - functions for data output
  *
- * Copyright (c) 2018 Cosmin Truta
+ * Copyright (c) 2018-2025 Cosmin Truta
  * Copyright (c) 1998-2002,2004,2006-2014,2016,2018 Glenn Randers-Pehrson
  * Copyright (c) 1996-1997 Andreas Dilger
  * Copyright (c) 1995-1996 Guy Eric Schalnat, Group 42, Inc.
@@ -54,7 +54,7 @@ png_default_write_data(png_structp png_ptr, png_bytep data, size_t length)
    if (png_ptr == NULL)
       return;
 
-   check = fwrite(data, 1, length, (png_FILE_p)(png_ptr->io_ptr));
+   check = fwrite(data, 1, length, (FILE *)png_ptr->io_ptr);
 
    if (check != length)
       png_error(png_ptr, "Write Error");
@@ -77,12 +77,12 @@ png_flush(png_structrp png_ptr)
 void PNGCBAPI
 png_default_flush(png_structp png_ptr)
 {
-   png_FILE_p io_ptr;
+   FILE *io_ptr;
 
    if (png_ptr == NULL)
       return;
 
-   io_ptr = png_voidcast(png_FILE_p, (png_ptr->io_ptr));
+   io_ptr = png_voidcast(FILE *, png_ptr->io_ptr);
    fflush(io_ptr);
 }
 #  endif

--- a/pngwio.c
+++ b/pngwio.c
@@ -46,7 +46,7 @@ png_write_data(png_structrp png_ptr, png_const_bytep data, size_t length)
  * write_data function and use it at run time with png_set_write_fn(), rather
  * than changing the library.
  */
-void PNGCBAPI
+void
 png_default_write_data(png_structp png_ptr, png_bytep data, size_t length)
 {
    size_t check;
@@ -74,7 +74,7 @@ png_flush(png_structrp png_ptr)
 }
 
 #  ifdef PNG_STDIO_SUPPORTED
-void PNGCBAPI
+void
 png_default_flush(png_structp png_ptr)
 {
    FILE *io_ptr;
@@ -117,7 +117,7 @@ png_default_flush(png_structp png_ptr)
  *                 a good idea if io_ptr does not point to a standard
  *                 *FILE structure.
  */
-void PNGAPI
+void
 png_set_write_fn(png_structrp png_ptr, png_voidp io_ptr,
     png_rw_ptr write_data_fn, png_flush_ptr output_flush_fn)
 {

--- a/pngwrite.c
+++ b/pngwrite.c
@@ -79,7 +79,7 @@ write_unknown_chunks(png_structrp png_ptr, png_const_inforp info_ptr,
  * to just write a plain PNG file.  If you have long comments, I suggest
  * writing them in png_write_end(), and compressing them.
  */
-void PNGAPI
+void
 png_write_info_before_PLTE(png_structrp png_ptr, png_const_inforp info_ptr)
 {
    png_debug(1, "in png_write_info_before_PLTE");
@@ -219,7 +219,7 @@ png_write_info_before_PLTE(png_structrp png_ptr, png_const_inforp info_ptr)
    }
 }
 
-void PNGAPI
+void
 png_write_info(png_structrp png_ptr, png_const_inforp info_ptr)
 {
 #if defined(PNG_WRITE_TEXT_SUPPORTED) || defined(PNG_WRITE_sPLT_SUPPORTED)
@@ -388,7 +388,7 @@ png_write_info(png_structrp png_ptr, png_const_inforp info_ptr)
  * in png_write_info(), do not write them again here.  If you have long
  * comments, I suggest writing them here, and compressing them.
  */
-void PNGAPI
+void
 png_write_end(png_structrp png_ptr, png_inforp info_ptr)
 {
    png_debug(1, "in png_write_end");
@@ -504,7 +504,7 @@ png_write_end(png_structrp png_ptr, png_inforp info_ptr)
 }
 
 #ifdef PNG_CONVERT_tIME_SUPPORTED
-void PNGAPI
+void
 png_convert_from_struct_tm(png_timep ptime, const struct tm * ttime)
 {
    png_debug(1, "in png_convert_from_struct_tm");
@@ -517,7 +517,7 @@ png_convert_from_struct_tm(png_timep ptime, const struct tm * ttime)
    ptime->second = (png_byte)ttime->tm_sec;
 }
 
-void PNGAPI
+void
 png_convert_from_time_t(png_timep ptime, time_t ttime)
 {
    struct tm *tbuf;
@@ -540,7 +540,7 @@ png_convert_from_time_t(png_timep ptime, time_t ttime)
 #endif
 
 /* Initialize png_ptr structure, and allocate any memory needed */
-PNG_FUNCTION(png_structp,PNGAPI
+PNG_FUNCTION(png_structp,
 png_create_write_struct,(png_const_charp user_png_ver, png_voidp error_ptr,
     png_error_ptr error_fn, png_error_ptr warn_fn),PNG_ALLOCATED)
 {
@@ -553,7 +553,7 @@ png_create_write_struct,(png_const_charp user_png_ver, png_voidp error_ptr,
 }
 
 /* Alternate initialize png_ptr structure, and allocate any memory needed */
-PNG_FUNCTION(png_structp,PNGAPI
+PNG_FUNCTION(png_structp,
 png_create_write_struct_2,(png_const_charp user_png_ver, png_voidp error_ptr,
     png_error_ptr error_fn, png_error_ptr warn_fn, png_voidp mem_ptr,
     png_malloc_ptr malloc_fn, png_free_ptr free_fn),PNG_ALLOCATED)
@@ -621,7 +621,7 @@ png_create_write_struct_2,(png_const_charp user_png_ver, png_voidp error_ptr,
  * have called png_set_interlace_handling(), you will have to
  * "write" the image seven times.
  */
-void PNGAPI
+void
 png_write_rows(png_structrp png_ptr, png_bytepp row,
     png_uint_32 num_rows)
 {
@@ -643,7 +643,7 @@ png_write_rows(png_structrp png_ptr, png_bytepp row,
 /* Write the image.  You only need to call this function once, even
  * if you are writing an interlaced image.
  */
-void PNGAPI
+void
 png_write_image(png_structrp png_ptr, png_bytepp image)
 {
    png_uint_32 i; /* row index */
@@ -740,7 +740,7 @@ png_do_write_intrapixel(png_row_infop row_info, png_bytep row)
 #endif /* MNG_FEATURES */
 
 /* Called by user to write a row of image data */
-void PNGAPI
+void
 png_write_row(png_structrp png_ptr, png_const_bytep row)
 {
    /* 1.5.6: moved from png_struct to be a local structure: */
@@ -950,7 +950,7 @@ png_write_row(png_structrp png_ptr, png_const_bytep row)
 
 #ifdef PNG_WRITE_FLUSH_SUPPORTED
 /* Set the automatic flush interval or 0 to turn flushing off */
-void PNGAPI
+void
 png_set_flush(png_structrp png_ptr, int nrows)
 {
    png_debug(1, "in png_set_flush");
@@ -962,7 +962,7 @@ png_set_flush(png_structrp png_ptr, int nrows)
 }
 
 /* Flush the current output buffers now */
-void PNGAPI
+void
 png_write_flush(png_structrp png_ptr)
 {
    png_debug(1, "in png_write_flush");
@@ -1021,7 +1021,7 @@ png_write_destroy(png_structrp png_ptr)
  * inside them.  In 1.6.0 it quietly does nothing (it has to be quiet because it
  * has no png_ptr.)
  */
-void PNGAPI
+void
 png_destroy_write_struct(png_structpp png_ptr_ptr, png_infopp info_ptr_ptr)
 {
    png_debug(1, "in png_destroy_write_struct");
@@ -1042,7 +1042,7 @@ png_destroy_write_struct(png_structpp png_ptr_ptr, png_infopp info_ptr_ptr)
 }
 
 /* Allow the application to select one or more row filters to use. */
-void PNGAPI
+void
 png_set_filter(png_structrp png_ptr, int method, int filters)
 {
    png_debug(1, "in png_set_filter");
@@ -1169,7 +1169,7 @@ png_set_filter(png_structrp png_ptr, int method, int filters)
 }
 
 #ifdef PNG_WRITE_CUSTOMIZE_COMPRESSION_SUPPORTED
-void PNGAPI
+void
 png_set_compression_level(png_structrp png_ptr, int level)
 {
    png_debug(1, "in png_set_compression_level");
@@ -1180,7 +1180,7 @@ png_set_compression_level(png_structrp png_ptr, int level)
    png_ptr->zlib_level = level;
 }
 
-void PNGAPI
+void
 png_set_compression_mem_level(png_structrp png_ptr, int mem_level)
 {
    png_debug(1, "in png_set_compression_mem_level");
@@ -1191,7 +1191,7 @@ png_set_compression_mem_level(png_structrp png_ptr, int mem_level)
    png_ptr->zlib_mem_level = mem_level;
 }
 
-void PNGAPI
+void
 png_set_compression_strategy(png_structrp png_ptr, int strategy)
 {
    png_debug(1, "in png_set_compression_strategy");
@@ -1208,7 +1208,7 @@ png_set_compression_strategy(png_structrp png_ptr, int strategy)
 /* If PNG_WRITE_OPTIMIZE_CMF_SUPPORTED is defined, libpng will use a
  * smaller value of window_bits if it can do so safely.
  */
-void PNGAPI
+void
 png_set_compression_window_bits(png_structrp png_ptr, int window_bits)
 {
    png_debug(1, "in png_set_compression_window_bits");
@@ -1237,7 +1237,7 @@ png_set_compression_window_bits(png_structrp png_ptr, int window_bits)
    png_ptr->zlib_window_bits = window_bits;
 }
 
-void PNGAPI
+void
 png_set_compression_method(png_structrp png_ptr, int method)
 {
    png_debug(1, "in png_set_compression_method");
@@ -1257,7 +1257,7 @@ png_set_compression_method(png_structrp png_ptr, int method)
 
 /* The following were added to libpng-1.5.4 */
 #ifdef PNG_WRITE_CUSTOMIZE_ZTXT_COMPRESSION_SUPPORTED
-void PNGAPI
+void
 png_set_text_compression_level(png_structrp png_ptr, int level)
 {
    png_debug(1, "in png_set_text_compression_level");
@@ -1268,7 +1268,7 @@ png_set_text_compression_level(png_structrp png_ptr, int level)
    png_ptr->zlib_text_level = level;
 }
 
-void PNGAPI
+void
 png_set_text_compression_mem_level(png_structrp png_ptr, int mem_level)
 {
    png_debug(1, "in png_set_text_compression_mem_level");
@@ -1279,7 +1279,7 @@ png_set_text_compression_mem_level(png_structrp png_ptr, int mem_level)
    png_ptr->zlib_text_mem_level = mem_level;
 }
 
-void PNGAPI
+void
 png_set_text_compression_strategy(png_structrp png_ptr, int strategy)
 {
    png_debug(1, "in png_set_text_compression_strategy");
@@ -1293,7 +1293,7 @@ png_set_text_compression_strategy(png_structrp png_ptr, int strategy)
 /* If PNG_WRITE_OPTIMIZE_CMF_SUPPORTED is defined, libpng will use a
  * smaller value of window_bits if it can do so safely.
  */
-void PNGAPI
+void
 png_set_text_compression_window_bits(png_structrp png_ptr, int window_bits)
 {
    png_debug(1, "in png_set_text_compression_window_bits");
@@ -1316,7 +1316,7 @@ png_set_text_compression_window_bits(png_structrp png_ptr, int window_bits)
    png_ptr->zlib_text_window_bits = window_bits;
 }
 
-void PNGAPI
+void
 png_set_text_compression_method(png_structrp png_ptr, int method)
 {
    png_debug(1, "in png_set_text_compression_method");
@@ -1332,7 +1332,7 @@ png_set_text_compression_method(png_structrp png_ptr, int method)
 #endif /* WRITE_CUSTOMIZE_ZTXT_COMPRESSION */
 /* end of API added to libpng-1.5.4 */
 
-void PNGAPI
+void
 png_set_write_status_fn(png_structrp png_ptr, png_write_status_ptr write_row_fn)
 {
    png_debug(1, "in png_set_write_status_fn");
@@ -1344,7 +1344,7 @@ png_set_write_status_fn(png_structrp png_ptr, png_write_status_ptr write_row_fn)
 }
 
 #ifdef PNG_WRITE_USER_TRANSFORM_SUPPORTED
-void PNGAPI
+void
 png_set_write_user_transform_fn(png_structrp png_ptr, png_user_transform_ptr
     write_user_transform_fn)
 {
@@ -1360,7 +1360,7 @@ png_set_write_user_transform_fn(png_structrp png_ptr, png_user_transform_ptr
 
 
 #ifdef PNG_INFO_IMAGE_SUPPORTED
-void PNGAPI
+void
 png_write_png(png_structrp png_ptr, png_inforp info_ptr,
     int transforms, voidp params)
 {
@@ -2183,9 +2183,8 @@ png_image_write_main(png_voidp argument)
    return 1;
 }
 
-
-static void (PNGCBAPI
-image_memory_write)(png_structp png_ptr, png_bytep/*const*/ data, size_t size)
+static void
+image_memory_write(png_structp png_ptr, png_bytep/*const*/ data, size_t size)
 {
    png_image_write_control *display = png_voidcast(png_image_write_control*,
        png_ptr->io_ptr/*backdoor: png_get_io_ptr(png_ptr)*/);
@@ -2209,8 +2208,8 @@ image_memory_write)(png_structp png_ptr, png_bytep/*const*/ data, size_t size)
       png_error(png_ptr, "png_image_write_to_memory: PNG too big");
 }
 
-static void (PNGCBAPI
-image_memory_flush)(png_structp png_ptr)
+static void
+image_memory_flush(png_structp png_ptr)
 {
    PNG_UNUSED(png_ptr)
 }
@@ -2231,7 +2230,7 @@ png_image_write_memory(png_voidp argument)
    return png_image_write_main(display);
 }
 
-int PNGAPI
+int
 png_image_write_to_memory(png_imagep image, void *memory,
     png_alloc_size_t * PNG_RESTRICT memory_bytes, int convert_to_8bit,
     const void *buffer, png_int_32 row_stride, const void *colormap)
@@ -2298,7 +2297,7 @@ png_image_write_to_memory(png_imagep image, void *memory,
 }
 
 #ifdef PNG_SIMPLIFIED_WRITE_STDIO_SUPPORTED
-int PNGAPI
+int
 png_image_write_to_stdio(png_imagep image, FILE *file, int convert_to_8bit,
     const void *buffer, png_int_32 row_stride, const void *colormap)
 {
@@ -2347,7 +2346,7 @@ png_image_write_to_stdio(png_imagep image, FILE *file, int convert_to_8bit,
       return 0;
 }
 
-int PNGAPI
+int
 png_image_write_to_file(png_imagep image, const char *file_name,
     int convert_to_8bit, const void *buffer, png_int_32 row_stride,
     const void *colormap)

--- a/pngwrite.c
+++ b/pngwrite.c
@@ -2302,7 +2302,7 @@ int PNGAPI
 png_image_write_to_stdio(png_imagep image, FILE *file, int convert_to_8bit,
     const void *buffer, png_int_32 row_stride, const void *colormap)
 {
-   /* Write the image to the given (FILE*). */
+   /* Write the image to the given FILE object. */
    if (image != NULL && image->version == PNG_IMAGE_VERSION)
    {
       if (file != NULL && buffer != NULL)

--- a/pngwutil.c
+++ b/pngwutil.c
@@ -1,6 +1,6 @@
 /* pngwutil.c - utilities to write a PNG file
  *
- * Copyright (c) 2018-2024 Cosmin Truta
+ * Copyright (c) 2018-2025 Cosmin Truta
  * Copyright (c) 1998-2002,2004,2006-2018 Glenn Randers-Pehrson
  * Copyright (c) 1996-1997 Andreas Dilger
  * Copyright (c) 1995-1996 Guy Eric Schalnat, Group 42, Inc.
@@ -37,7 +37,7 @@ static const png_byte png_pass_yinc[7] = {8, 8, 8, 4, 4, 2, 2};
  * with unsigned numbers for convenience, although one supported
  * ancillary chunk uses signed (two's complement) numbers.
  */
-void PNGAPI
+void
 png_save_uint_32(png_bytep buf, png_uint_32 i)
 {
    buf[0] = (png_byte)((i >> 24) & 0xffU);
@@ -50,7 +50,7 @@ png_save_uint_32(png_bytep buf, png_uint_32 i)
  * The parameter is declared unsigned int, not png_uint_16,
  * just to avoid potential problems on pre-ANSI C compilers.
  */
-void PNGAPI
+void
 png_save_uint_16(png_bytep buf, unsigned int i)
 {
    buf[0] = (png_byte)((i >> 8) & 0xffU);
@@ -64,7 +64,7 @@ png_save_uint_16(png_bytep buf, unsigned int i)
  * we should call png_set_sig_bytes() to tell libpng how many of the
  * bytes have already been written.
  */
-void PNGAPI
+void
 png_write_sig(png_structrp png_ptr)
 {
    png_byte png_signature[8] = {137, 80, 78, 71, 13, 10, 26, 10};
@@ -128,7 +128,7 @@ png_write_chunk_header(png_structrp png_ptr, png_uint_32 chunk_name,
 #endif
 }
 
-void PNGAPI
+void
 png_write_chunk_start(png_structrp png_ptr, png_const_bytep chunk_string,
     png_uint_32 length)
 {
@@ -140,7 +140,7 @@ png_write_chunk_start(png_structrp png_ptr, png_const_bytep chunk_string,
  * sum of the lengths from these calls *must* add up to the total_length
  * given to png_write_chunk_header().
  */
-void PNGAPI
+void
 png_write_chunk_data(png_structrp png_ptr, png_const_bytep data, size_t length)
 {
    /* Write the data, and run the CRC over it */
@@ -159,7 +159,7 @@ png_write_chunk_data(png_structrp png_ptr, png_const_bytep data, size_t length)
 }
 
 /* Finish a chunk started with png_write_chunk_header(). */
-void PNGAPI
+void
 png_write_chunk_end(png_structrp png_ptr)
 {
    png_byte buf[4];
@@ -205,7 +205,7 @@ png_write_complete_chunk(png_structrp png_ptr, png_uint_32 chunk_name,
 }
 
 /* This is the API that calls the internal function above. */
-void PNGAPI
+void
 png_write_chunk(png_structrp png_ptr, png_const_bytep chunk_string,
     png_const_bytep data, size_t length)
 {


### PR DESCRIPTION
Here are three honking commits for your viewing and reviewing pleasure.

FYI, projects/owatcom and scripts/makefile.intel are about to go, because they depend on what I'm about to remove in this PR. And I could fix those but I ain't gonna. And CMake should be able to do their job, anyway. I haven't tested Open Watcom recently, but last time I did give it a try, about two years ago, its IDE died a horrible death when I attempted to do stuff with projects/owatcom on my Windows 10 laptop.

Also about Watcom: fun fact: I used to live and work in Waterloo, Ontario for aboot a decade, and two former Watcom compiler engineers used to be in my team at BlackBerry for a while. Because, you know... Waterloo... compiler... wink-wink 😉