### PR TITLE
Recover from errors in ancillary chunks

### DIFF
--- a/pngrutil.c
+++ b/pngrutil.c
@@ -211,8 +211,12 @@ png_read_chunk_header(png_structrp png_ptr)
       png_chunk_error(png_ptr, "bad header (invalid length)");
 
    /* Check to see if chunk name is valid. */
-   if (!check_chunk_name(chunk_name))
-      png_chunk_error(png_ptr, "bad header (invalid type)");
+   if (!check_chunk_name(chunk_name)) {
+      if (PNG_CHUNK_ANCILLARY(png_ptr->chunk_name) == 0)
+         png_chunk_error(png_ptr, "bad header (invalid type)");
+      else
+         png_chunk_benign_error(png_ptr, "bad header (invalid type)");
+   }
 
 #ifdef PNG_IO_STATE_SUPPORTED
    png_ptr->io_state = PNG_IO_READING | PNG_IO_CHUNK_DATA;


### PR DESCRIPTION
As per the third edition of the spec, decoders should recover from errors in ancillary chunks.

In section 13.1 Error handling [1]:
> Anomalous situations other than syntax errors shall be treated as
> follows:
>  1. Encountering an unknown ancillary chunk is never an error. The
>     chunk can simply be ignored.

More specifically, in this commit, if a chunk that is detected as ancillary, does not pass the `check_chunk_name()` function. Only a warning is issued, instead of an error.

This allows libpng to fully decode images like [2] and [3]. It has been tested by passing them to both pngtest and Gnome's image viewer. Note that invalid-unknown-ancillary-after-IDAT.png could already be displayed but not fully decoded.

[1] https://w3c.github.io/png/#13Decoders.Errors
[2] https://github.com/web-platform-tests/wpt/blob/master/png/errors/support/invalid-unknown-ancillary.png
[3] https://github.com/web-platform-tests/wpt/blob/master/png/errors/support/invalid-unknown-ancillary-after-IDAT.png