### PR TITLE
RISC-V RVV extension

### DIFF
--- a/configure
+++ b/configure
@@ -15605,9 +15605,9 @@ printf "%s\n" "$as_me: WARNING: --enable-riscv-rvv: please specify 'check' or 'a
 fi
 
 
-# Add RISCV-specific files to all builds where $host_cpu is arm ('riscv64*') or
+# Add RISCV-specific files to all builds where $host_cpu is RISC-V ('riscv64') or
 # where RISCV optimizations were explicitly requested. (This allows a fallback
-# if a future host CPU does not match 'riscv64*'.)
+# if a future host CPU does not match 'riscv64'.)
 
  if test "$enable_riscv_rvv" != 'no' &&
     case "$host_cpu" in

--- a/contrib/riscv-rvv/README
+++ b/contrib/riscv-rvv/README
@@ -1,4 +1,4 @@
-OPERATING SYSTEM SPECIFIC ARM NEON DETECTION
+OPERATING SYSTEM SPECIFIC RISC-V RVV DETECTION
 --------------------------------------------
 
 Detection of the ability to execute RISC-V Vector on a RISC-V processor

--- a/riscv/riscv_init.c
+++ b/riscv/riscv_init.c
@@ -1,4 +1,4 @@
-/* arm_init.c - RISC-V Vector optimized filter functions
+/* riscv_init.c - RISC-V Vector optimized filter functions
  *
  * Copyright (c) 2023 Google LLC
  * Written by Dragoș Tiselice <dtiselice@google.com>, May 2023.
@@ -53,16 +53,11 @@ static int png_have_rvv(png_structp png_ptr);
 void
 png_init_filter_functions_rvv(png_structp pp, unsigned int bpp)
 {
-   /* The switch statement is compiled in for RISCV_rvv_API, the call to
-    * png_have_rvv is compiled in for RISCV_rvv_CHECK.  If both are
+   /* The switch statement is compiled in for RISCV_RVV_API, the call to
+    * png_have_rvv is compiled in for RISCV_RVV_CHECK.  If both are
     * defined the check is only performed if the API has not set the VECTOR
     * option on or off explicitly.  In this case the check controls what
     * happens.
-    *
-    * If the CHECK is not compiled in and the option is UNSET the behavior prior
-    * to 1.6.7 was to use the NEON code - this was a bug caused by having the
-    * wrong order of the 'ON' and 'default' cases.  UNSET now defaults to OFF,
-    * as documented in png.h
     */
    png_debug(1, "in png_init_filter_functions_rvv");
 #ifdef PNG_RISCV_RVV_API_SUPPORTED
@@ -98,7 +93,7 @@ png_init_filter_functions_rvv(png_structp pp, unsigned int bpp)
          /* Option turned on */
          break;
    }
-#endif
+#endif /* PNG_RISCV_RVV_API_SUPPORTED */
 
    /* IMPORTANT: any new external functions used here must be declared using
     * PNG_INTERNAL_FUNCTION in ../pngpriv.h.  This is required so that the


### PR DESCRIPTION
Updating and testing autotools build and CMake build
Renaming riscv-vector to riscv-rvv
Changes implementation of few functions because they do not compile for RVV 1.0 via gcc 14.0.1 20240412
Corrected and added few flag names and definitions
Solved merge conflicts
