### PR TITLE
Write only configurations: remove unused function

### DIFF
--- a/contrib/conftest/read-full.dfa
+++ b/contrib/conftest/read-full.dfa
@@ -1,0 +1,13 @@
+# read-full.dfa
+#  Build time configuration of libpng
+#
+# Author: John Bowler
+# Copyright: (c) John Bowler, 2025
+# Usage rights:
+#  To the extent possible under law, the author has waived all copyright and
+#  related or neighboring rights to this work.  This work is published from:
+#  United States.
+#
+# Build libpng with no write support and full read support.
+#
+option WRITE off

--- a/contrib/conftest/write-full.dfa
+++ b/contrib/conftest/write-full.dfa
@@ -1,0 +1,13 @@
+# write-full.dfa
+#  Build time configuration of libpng
+#
+# Author: John Bowler
+# Copyright: (c) John Bowler, 2025
+# Usage rights:
+#  To the extent possible under law, the author has waived all copyright and
+#  related or neighboring rights to this work.  This work is published from:
+#  United States.
+#
+# Build libpng with no read support and full write support.
+#
+option READ off

--- a/png.c
+++ b/png.c
@@ -1491,7 +1491,7 @@ png_XYZ_from_xy(png_XYZ *XYZ, const png_xy *xy)
 }
 #endif /* COLORSPACE */
 
-#ifdef PNG_iCCP_SUPPORTED
+#ifdef PNG_READ_iCCP_SUPPORTED
 /* Error message generation */
 static char
 png_icc_tag_char(png_uint_32 byte)
@@ -1567,9 +1567,7 @@ png_icc_profile_error(png_const_structrp png_ptr, png_const_charp name,
 
    return 0;
 }
-#endif /* iCCP */
 
-#ifdef PNG_READ_iCCP_SUPPORTED
 /* Encoded value of D50 as an ICC XYZNumber.  From the ICC 2010 spec the value
  * is XYZ(0.9642,1.0,0.8249), which scales to:
  *


### PR DESCRIPTION
png_icc_profile_error is no longer used when writing iCCP chunks
but was still compiled when PNG read is disabled.

The change includes two `minconfig` files to test read-only and
write-only "full" configurations to supplement the existing tests for
"minimal" configurations.

Signed-off-by: John Bowler <jbowler@acm.org>
