### PR TITLE
SECURITY: discourage application backdoors

### DIFF
--- a/pnginfo.h
+++ b/pnginfo.h
@@ -10,43 +10,24 @@
  * and license in png.h
  */
 
- /* png_info is a structure that holds the information in a PNG file so
- * that the application can find out the characteristics of the image.
- * If you are reading the file, this structure will tell you what is
- * in the PNG file.  If you are writing the file, fill in the information
- * you want to put into the PNG file, using png_set_*() functions, then
- * call png_write_info().
+#ifndef PNGPRIV_H
+/* PRIVATE INTERNAL HEADER FILE
  *
- * The names chosen should be very close to the PNG specification, so
- * consult that document for information about the meaning of each field.
+ * This file may not be included directly.
+ */
+#  error "PRIVATE HEADER INCLUDED: pnginfo.h is an internal libpng file."
+#endif
+
+/* INTERNAL, PRIVATE definition of a PNG.
  *
- * With libpng < 0.95, it was only possible to directly set and read the
- * the values in the png_info_struct, which meant that the contents and
- * order of the values had to remain fixed.  With libpng 0.95 and later,
- * however, there are now functions that abstract the contents of
- * png_info_struct from the application, so this makes it easier to use
- * libpng with dynamic libraries, and even makes it possible to use
- * libraries that don't have all of the libpng ancillary chunk-handing
- * functionality.  In libpng-1.5.0 this was moved into a separate private
- * file that is not visible to applications.
+ * png_info is a modifiable stateless description of a PNG.  Fields in png_info
+ * are accessed through png_get_<CHUNK>() functions and set using
+ * png_set_<CHUNK>() functions.
  *
- * The following members may have allocated storage attached that should be
- * cleaned up before the structure is discarded: palette, trans, text,
- * pcal_purpose, pcal_units, pcal_params, hist, iccp_name, iccp_profile,
- * splt_palettes, scal_unit, row_pointers, and unknowns.   By default, these
- * are automatically freed when the info structure is deallocated, if they were
- * allocated internally by libpng.  This behavior can be changed by means
- * of the png_data_freer() function.
- *
- * More allocation details: all the chunk-reading functions that
- * change these members go through the corresponding png_set_*
- * functions.  A function to clear these members is available: see
- * png_free_data().  The png_set_* functions do not depend on being
- * able to point info structure members to any of the storage they are
- * passed (they make their own copies), EXCEPT that the png_set_text
- * functions use the same storage passed to them in the text_ptr or
- * itxt_ptr structure argument, and the png_set_rows and png_set_unknowns
- * functions do not make their own copies.
+ * Some functions in libpng do directly access png_info::members, however this
+ * should be avoided.  png_struct contains members which hold caches, sometimes
+ * optimised, of the values from png_info and png_info is not passed to the
+ * functions which read and write image data.
  */
 #ifndef PNGINFO_H
 #define PNGINFO_H

--- a/pnginfo.h
+++ b/pnginfo.h
@@ -15,7 +15,7 @@
  *
  * This file may not be included directly.
  */
-#  error "PRIVATE HEADER INCLUDED: pnginfo.h is an internal libpng file."
+#  error "Do not include pnginfo.h.  Include png.h for the libpng API."
 #endif
 
 /* INTERNAL, PRIVATE definition of a PNG.

--- a/pngpriv.h
+++ b/pngpriv.h
@@ -28,14 +28,14 @@
  *
  *    #include "pngpriv.h"
  */
-#  error "PRIVATE HEADER: pngpriv.h may only be used by libpng .c files"
+#  error "Include png.h not pngpriv.h for the supported libpng API."
 #endif /* PNG_H || PNGLCONF_H */
 
 #ifdef PNGPRIV_H /* duplicate include of png.h */
 /* If you get the error below check where **this** file has been included, it
  * must be the first include in one of the libpng .c files!
  */
-#  error "PRIVATE HEADER: pngpriv.h may only be used by libpng .c files"
+#  error "Include png.h not pngpriv.h for the supported libpng API."
 #else
 #define PNGPRIV_H
 

--- a/pngpriv.h
+++ b/pngpriv.h
@@ -19,7 +19,24 @@
  * they should be well aware of the issues that may arise from doing so.
  */
 
-#ifndef PNGPRIV_H
+#if (defined PNG_H) || (defined PNGLCONF_H) /* pngpriv.h must be first */
+/* PRIVATE INTERNAL HEADER FILE */
+
+/* This file may only be incldued by libpng source files and it must be the
+ * first header file included.  It may only be included once right at the
+ * start of the .c file:
+ *
+ *    #include "pngpriv.h"
+ */
+#  error "PRIVATE HEADER: pngpriv.h may only be used by libpng .c files"
+#endif /* PNG_H || PNGLCONF_H */
+
+#ifdef PNGPRIV_H /* duplicate include of png.h */
+/* If you get the error below check where **this** file has been included, it
+ * must be the first include in one of the libpng .c files!
+ */
+#  error "PRIVATE HEADER: pngpriv.h may only be used by libpng .c files"
+#else
 #define PNGPRIV_H
 
 /* Feature Test Macros.  The following are defined here to ensure that correctly
@@ -67,9 +84,7 @@
  * are not internal definitions may be required.  This is handled below just
  * before png.h is included, but load the configuration now if it is available.
  */
-#ifndef PNGLCONF_H
-#  include "pnglibconf.h"
-#endif
+#include "pnglibconf.h"
 
 /* Local renames may change non-exported API functions from png.h */
 #if defined(PNG_PREFIX) && !defined(PNGPREFIX_H)

--- a/pngstruct.h
+++ b/pngstruct.h
@@ -15,7 +15,7 @@
  *
  * This file may not be included directly.
  */
-#  error "PRIVATE HEADER INCLUDED: pngstruct.h is an internal libpng file."
+#  error "Do not include pngstruct.h.  Include png.h for the libpng API."
 #endif
 
 #ifndef PNGSTRUCT_H

--- a/pngstruct.h
+++ b/pngstruct.h
@@ -10,11 +10,13 @@
  * and license in png.h
  */
 
-/* The structure that holds the information to read and write PNG files.
- * The only people who need to care about what is inside of this are the
- * people who will be modifying the library for their own special needs.
- * It should NOT be accessed directly by an application.
+#ifndef PNGPRIV_H
+/* PRIVATE INTERNAL HEADER FILE
+ *
+ * This file may not be included directly.
  */
+#  error "PRIVATE HEADER INCLUDED: pngstruct.h is an internal libpng file."
+#endif
 
 #ifndef PNGSTRUCT_H
 #define PNGSTRUCT_H


### PR DESCRIPTION
Add extra checking to the private libpng header files to attempt to
detect inclusion from application code.  Including any of these three
header files in application code raises the possibility of application
crashes as a result of internal changes to the png_struct and png_info
structures.

Signed-off-by: John Bowler <jbowler@acm.org>
