### PR TITLE
testing: update pngtest FP and fixed API checks

### DIFF
--- a/contrib/conftest/float.dfa
+++ b/contrib/conftest/float.dfa
@@ -1,0 +1,17 @@
+# float.dfa
+#  Build time configuration of libpng
+#
+# Author: John Bowler
+# Copyright: (c) John Bowler, 2025
+# Usage rights:
+#  To the extent possible under law, the author has waived all copyright and
+#  related or neighboring rights to this work.  This work is published from:
+#  United States.
+#
+# Test the standard libpng configuration without fixed point (the internal
+# floating point implementations are used instead).  This does not turn off all
+# fixed point; in some cases the only implementation is fixed point, however it
+# does make those implementations private to libpng forcing use of the floating
+# point variants.
+#
+option FIXED_POINT off

--- a/pngtest.c
+++ b/pngtest.c
@@ -1116,7 +1116,7 @@ test_one_file(const char *inname, const char *outname)
       else
          png_error(read_ptr, "png_get_IHDR failed");
    }
-#ifdef PNG_FIXED_POINT_SUPPORTED
+#ifndef PNG_FLOATING_POINT_SUPPORTED
 #ifdef PNG_cHRM_SUPPORTED
    {
       png_fixed_point white_x, white_y, red_x, red_y, green_x, green_y, blue_x,


### PR DESCRIPTION
pngtest.c is changed to check the floating point APIs by default as
these are likely to be the most used and in a number of cases they still
use the fixed point APIs.

contrib/conftest/float.dfa is added to turn off the fixed-point APIs and
these force use of the available floating point APIs in all test
programs when used as the build configuration.

Signed-off-by: John Bowler <jbowler@acm.org>
