### PR TITLE
riscv: autotools update

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -136,7 +136,7 @@ Your directory structure should look like this:
              depcomp, install-sh, mkinstalldirs, test-pngtest.sh, etc.
           contrib
              arm-neon, conftest, examples, gregbook, libtests, pngminim,
-             pngminus, pngsuite, tools, visupng, riscv-vector
+             pngminus, pngsuite, tools, visupng, riscv-rvv
           projects
              owatcom, visualc71, vstudio
           scripts

--- a/README
+++ b/README
@@ -163,7 +163,7 @@ Files included in this distribution
                           programs demonstrating the use of pngusr.dfa
         pngminus/     =>  Simple pnm2png and png2pnm programs
         pngsuite/     =>  Test images
-        riscv-vector/ =>  Optimized code for the RISC-V Vector platform
+        riscv-rvv/    =>  Optimized code for the RISC-V Vector platform
         testpngs/     =>  Test images
         tools/        =>  Various tools
         visupng/      =>  VisualPng, a Windows viewer for PNG images

--- a/configure.ac
+++ b/configure.ac
@@ -377,7 +377,8 @@ AC_ARG_ENABLE([hardware-optimizations],
               enable_loongarch_lsx=yes
               AC_DEFINE([PNG_LOONGARCH_LSX_OPT], [1],
                 [Enable LOONGARCH_LSX optimizations])
-            riscv*)
+              ;;
+            riscv64)
               enable_riscv_rvv=yes
               AC_DEFINE([PNG_RISCV_RVV_OPT], [2],
                 [Enable RISC-V Vector optimizations])
@@ -673,7 +674,7 @@ AM_CONDITIONAL([PNG_LOONGARCH_LSX],
 #
 # RISC-V Vector support.
 
-AC_ARG_ENABLE([riscv-vector],
+AC_ARG_ENABLE([riscv-rvv],
 AS_HELP_STRING([[[--enable-riscv-rvv]]],
       [Enable RISC-V Vector optimizations: =no/off, check, api, yes/on:]
       [no/off: disable the optimizations; check: use internal checking code]
@@ -690,7 +691,7 @@ AS_HELP_STRING([[[--enable-riscv-rvv]]],
       check)
          AC_DEFINE([PNG_RISCV_RVV_CHECK_SUPPORTED], [],
                    [Check for RISC-V Vector support at run-time])
-         AC_MSG_WARN([--enable-riscv-rvv Please check contrib/riscv-vector/README file]
+         AC_MSG_WARN([--enable-riscv-rvv Please check contrib/riscv-rvv/README file]
             [for the list of supported OSes.]);;
       api)
          AC_DEFINE([PNG_RISCV_RVV_API_SUPPORTED], [],
@@ -699,20 +700,44 @@ AS_HELP_STRING([[[--enable-riscv-rvv]]],
          AC_DEFINE([PNG_RISCV_RVV_OPT], [2],
                    [Enable RISC-V Vector optimizations])
          AC_MSG_WARN([--enable-riscv-rvv: please specify 'check' or 'api', if]
-            [you want the optimizations unconditionally pass e.g. '-march=rv64gcv']
+            [you want the optimizations unconditionally pass e.g. '-march=rv64gv']
             [to the compiler.]);;
       *)
          AC_MSG_ERROR([--enable-riscv-rvv=${enable_riscv_rvv}: invalid value])
    esac])
 
-# Add RISC-V-specific files to all builds where $host_cpu is riscv ('riscv*')
+if test "$enable_riscv_rvv" != "no" &&
+   case "$host_cpu" in
+      riscv64) : ;;
+      *)    test "$enable_riscv_rvv" != '' ;;
+   esac
+then
+   compiler_support_riscv_rvv=no
+   AC_MSG_CHECKING(whether to use RISC-V RVV intrinsics)
+   AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
+#include <riscv_vector.h>
+int main(){
+   return 0;
+}]])],compiler_support_riscv_rvv=yes)
+   AC_MSG_RESULT($compiler_support_riscv_rvv)
+   if test "$compiler_support_riscv_rvv" = "yes"; then
+      AC_DEFINE([PNG_RISCV_RVV_OPT], [1],
+                [Enable RISCV RVV optimizations])
+   else
+      AC_MSG_WARN([Compiler does not support riscv rvv.])
+   fi
+fi
+
+# Add RISC-V-specific files to all builds where $host_cpu is riscv ('riscv64')
 # or where RISC-V optimizations were explicitly requested (this allows a fallback
-# if a future host CPU does not match 'riscv*')
+# if a future host CPU does not match 'riscv64')
 
 AM_CONDITIONAL([PNG_RISCV_RVV],
-   [test "$enable_riscv_rvv" != 'no' &&
+   [test "$enable_riscv_rvv" != "no" &&
+    test "$compiler_support_riscv_rvv" = "yes" &&
     case "$host_cpu" in
-      riscv*) : ;;
+      riscv64) : ;;
+      *)    test "$compiler_support_riscv_rvv" != '' ;;
     esac])
 
 AC_MSG_NOTICE([[Extra options for compiler: $PNG_COPTS]])


### PR DESCRIPTION
I updated the configure.ac with necessary checks and confirmed that following autotools calls work as intended.
Considering such a build command:

`
./autogen.sh --maintainer && ./configure CFLAGS="-march=rv64gcv1p0" --enable-riscv-rvv=<on/yes/off/no/check/api> && make -j4
`

The only way to compile the rvv code is to define the march in c flags the v extension. For example:
`CFLAGS="-march=rv64gcv1p0" ` 
then any of the options will work:
`
--enable-riscv-rvv=on/yes/off/no/check/api
`

the default behaviour is: yes/on (as above: only if v extension is available in march in C_FLAGS)

if the test mini program fails to compile (one in AC_COMPILE_IFELSE ), then the files will not be included in compilation and passing --enable-riscv-rvv=on/yes/off/no/check always results in off/no.

I did not upload the generated files, but i can say that when I generated it, it worked as described above.
namely:
`
	modified:   Makefile.in
	modified:   aclocal.m4
	modified:   compile
	modified:   config.guess
	modified:   config.h.in
	modified:   config.sub
	modified:   configure
	modified:   depcomp
	modified:   install-sh
	modified:   ltmain.sh
	modified:   missing
	modified:   scripts/autoconf/libtool.m4
	modified:   scripts/autoconf/ltoptions.m4
	modified:   scripts/autoconf/ltsugar.m4
	modified:   scripts/autoconf/ltversion.m4
	modified:   scripts/autoconf/lt~obsolete.m4
	modified:   test-driver
`

The only thing i did not test is the **--enable-riscv-rvv=api**.
I can tell that it is included/excluded as expected (in regard to compilation).
I will focus on this as the next step. 