### PR TITLE
Fix syntax error in configure.ac and update build files. (Issue 678)

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -124,18 +124,17 @@ host_triplet = @host@
 @PNG_POWERPC_VSX_TRUE@am__append_7 = powerpc/powerpc_init.c\
 @PNG_POWERPC_VSX_TRUE@        powerpc/filter_vsx_intrinsics.c
 
-
-#   Versioned symbols and restricted exports
-@HAVE_LD_VERSION_SCRIPT_TRUE@@HAVE_SOLARIS_LD_TRUE@am__append_8 = -Wl,-M -Wl,libpng.vers
-@HAVE_LD_VERSION_SCRIPT_TRUE@@HAVE_SOLARIS_LD_FALSE@am__append_9 = -Wl,--version-script=libpng.vers
-#   Only restricted exports when possible
-@HAVE_LD_VERSION_SCRIPT_FALSE@am__append_10 = -export-symbols libpng.sym
-@PNG_LOONGARCH_LSX_TRUE@am__append_11 = libpng@PNGLIB_MAJOR@@PNGLIB_MINOR@lsx.la
-@DO_PNG_PREFIX_TRUE@am__append_12 = -DPNG_PREFIX='@PNG_PREFIX@'
-
-@PNG_RISCV_RVV_TRUE@am__append_13 = riscv/riscv_init.c\
+@PNG_RISCV_RVV_TRUE@am__append_8 = riscv/riscv_init.c\
 @PNG_RISCV_RVV_TRUE@        riscv/filter_rvv_intrinsics.c
 
+
+#   Versioned symbols and restricted exports
+@HAVE_LD_VERSION_SCRIPT_TRUE@@HAVE_SOLARIS_LD_TRUE@am__append_9 = -Wl,-M -Wl,libpng.vers
+@HAVE_LD_VERSION_SCRIPT_TRUE@@HAVE_SOLARIS_LD_FALSE@am__append_10 = -Wl,--version-script=libpng.vers
+#   Only restricted exports when possible
+@HAVE_LD_VERSION_SCRIPT_FALSE@am__append_11 = -export-symbols libpng.sym
+@PNG_LOONGARCH_LSX_TRUE@am__append_12 = libpng@PNGLIB_MAJOR@@PNGLIB_MINOR@lsx.la
+@DO_PNG_PREFIX_TRUE@am__append_13 = -DPNG_PREFIX='@PNG_PREFIX@'
 subdir = .
 ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
 am__aclocal_m4_deps = $(top_srcdir)/scripts/autoconf/libtool.m4 \
@@ -834,7 +833,7 @@ libpng@PNGLIB_MAJOR@@PNGLIB_MINOR@_la_SOURCES = png.c pngerror.c \
 	pngwutil.c png.h pngconf.h pngdebug.h pnginfo.h pngpriv.h \
 	pngstruct.h pngusr.dfa $(am__append_2) $(am__append_3) \
 	$(am__append_4) $(am__append_5) $(am__append_6) \
-	$(am__append_7) $(am__append_13)
+	$(am__append_7) $(am__append_8)
 @PNG_LOONGARCH_LSX_TRUE@noinst_LTLIBRARIES = libpng@PNGLIB_MAJOR@@PNGLIB_MINOR@lsx.la
 @PNG_LOONGARCH_LSX_TRUE@libpng@PNGLIB_MAJOR@@PNGLIB_MINOR@lsx_la_SOURCES = loongarch/loongarch_lsx_init.c\
 @PNG_LOONGARCH_LSX_TRUE@	loongarch/filter_lsx_intrinsics.c
@@ -846,11 +845,11 @@ nodist_libpng@PNGLIB_MAJOR@@PNGLIB_MINOR@_la_SOURCES = pnglibconf.h
 libpng@PNGLIB_MAJOR@@PNGLIB_MINOR@_la_LDFLAGS = -no-undefined \
 	-export-dynamic -version-number \
 	@PNGLIB_MAJOR@@PNGLIB_MINOR@:@PNGLIB_RELEASE@:0 \
-	$(am__append_8) $(am__append_9) $(am__append_10)
+	$(am__append_9) $(am__append_10) $(am__append_11)
 @HAVE_LD_VERSION_SCRIPT_FALSE@libpng@PNGLIB_MAJOR@@PNGLIB_MINOR@_la_DEPENDENCIES =  \
-@HAVE_LD_VERSION_SCRIPT_FALSE@	libpng.sym $(am__append_11)
+@HAVE_LD_VERSION_SCRIPT_FALSE@	libpng.sym $(am__append_12)
 @HAVE_LD_VERSION_SCRIPT_TRUE@libpng@PNGLIB_MAJOR@@PNGLIB_MINOR@_la_DEPENDENCIES =  \
-@HAVE_LD_VERSION_SCRIPT_TRUE@	libpng.vers $(am__append_11)
+@HAVE_LD_VERSION_SCRIPT_TRUE@	libpng.vers $(am__append_12)
 pkginclude_HEADERS = png.h pngconf.h
 nodist_pkginclude_HEADERS = pnglibconf.h
 pkgconfig_DATA = libpng@PNGLIB_MAJOR@@PNGLIB_MINOR@.pc
@@ -884,7 +883,7 @@ SUFFIXES = .chk .out
 SYMBOL_CFLAGS = -DPNGLIB_LIBNAME='PNG@PNGLIB_MAJOR@@PNGLIB_MINOR@_0' \
 	-DPNGLIB_VERSION='@PNGLIB_VERSION@' \
 	-DSYMBOL_PREFIX='$(SYMBOL_PREFIX)' -DPNG_NO_USE_READ_MACROS \
-	-DPNG_BUILDING_SYMBOL_TABLE $(am__append_12)
+	-DPNG_BUILDING_SYMBOL_TABLE $(am__append_13)
 
 # EXT_LIST is a list of the possibly library directory extensions, this exists
 # because we can't find a good way of discovering the file extensions that are
@@ -1082,10 +1081,10 @@ powerpc/filter_vsx_intrinsics.lo: powerpc/$(am__dirstamp) \
 	powerpc/$(DEPDIR)/$(am__dirstamp)
 riscv/$(am__dirstamp):
 	@$(MKDIR_P) riscv
-	@: > riscv/$(am__dirstamp)
+	@: >>riscv/$(am__dirstamp)
 riscv/$(DEPDIR)/$(am__dirstamp):
 	@$(MKDIR_P) riscv/$(DEPDIR)
-	@: > riscv/$(DEPDIR)/$(am__dirstamp)
+	@: >>riscv/$(DEPDIR)/$(am__dirstamp)
 riscv/riscv_init.lo: riscv/$(am__dirstamp) \
 	riscv/$(DEPDIR)/$(am__dirstamp)
 riscv/filter_rvv_intrinsics.lo: riscv/$(am__dirstamp) \
@@ -1263,6 +1262,8 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@mips/$(DEPDIR)/mips_init.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@powerpc/$(DEPDIR)/filter_vsx_intrinsics.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@powerpc/$(DEPDIR)/powerpc_init.Plo@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@riscv/$(DEPDIR)/filter_rvv_intrinsics.Plo@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@riscv/$(DEPDIR)/riscv_init.Plo@am__quote@ # am--include-marker
 
 $(am__depfiles_remade):
 	@$(MKDIR_P) $(@D)
@@ -2170,6 +2171,8 @@ distclean-generic:
 	-$(am__rm_f) mips/$(am__dirstamp)
 	-$(am__rm_f) powerpc/$(DEPDIR)/$(am__dirstamp)
 	-$(am__rm_f) powerpc/$(am__dirstamp)
+	-$(am__rm_f) riscv/$(DEPDIR)/$(am__dirstamp)
+	-$(am__rm_f) riscv/$(am__dirstamp)
 
 maintainer-clean-generic:
 	@echo "This command is intended for maintainers to use"

--- a/config.h.in
+++ b/config.h.in
@@ -117,7 +117,7 @@
 /* Enable RISC-V Vector optimizations */
 #undef PNG_RISCV_RVV_OPT
 
-/* Define to 1 if all of the C90 standard headers exist (not just the ones
+/* Define to 1 if all of the C89 standard headers exist (not just the ones
    required in a freestanding environment). This macro is provided for
    backward compatibility; new code need not use it. */
 #undef STDC_HEADERS

--- a/configure
+++ b/configure
@@ -1593,11 +1593,12 @@ Optional Features:
                           no/off: disable the optimizations; yes/on: turn on
                           unconditionally. If not specified: determined by the
                           compiler.
-  --enable-riscv-rvv
-                          Enable RISC-V Vector optimizations: =no/off, yes/on:
-                          no/off: disable the optimizations; yes/on: turn on
-                          unconditionally. If not specified: determined by the
-                          compiler.
+  --enable-riscv-rvv    Enable RISC-V Vector optimizations: =no/off, check,
+                          api, yes/on: no/off: disable the optimizations;
+                          check: use internal checking code api: disable by
+                          default, enable by a call to png_set_option yes/on:
+                          turn on unconditionally. If not specified:
+                          determined by the compiler.
 
 Optional Packages:
   --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
@@ -15209,7 +15210,8 @@ printf "%s\n" "#define PNG_LOONGARCH_LSX_OPT 1" >>confdefs.h
             riscv*)
               enable_riscv_rvv=yes
 
-printf "%s\n" "#define PNG_RISCV_RVV_OPT 1" >>confdefs.h
+printf "%s\n" "#define PNG_RISCV_RVV_OPT 2" >>confdefs.h
+
               ;;
          esac
          ;;
@@ -15566,24 +15568,31 @@ else
   PNG_LOONGARCH_LSX_FALSE=
 fi
 
-# RISC-V RVV
-# =============
+
+# RISC-V
+# ======
+#
+# RISC-V Vector support.
 
 # Check whether --enable-riscv-rvv was given.
 if test ${enable_riscv_rvv+y}
 then :
   enableval=$enable_riscv_rvv; case "$enableval" in
       no|off)
-         # disable the default enabling on __RVV__ systems:
+         # disable the default enabling on __riscv systems:
 
 printf "%s\n" "#define PNG_RISCV_RVV_OPT 0" >>confdefs.h
 
-         # Prevent inclusion of the assembler files below:
+         # Prevent inclusion of the platform-specific files below:
          enable_riscv_rvv=no ;;
       check)
 
 printf "%s\n" "#define PNG_RISCV_RVV_CHECK_SUPPORTED /**/" >>confdefs.h
-;;
+
+         { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: --enable-riscv-rvv Please check contrib/riscv-vector/README file
+            for the list of supported OSes." >&5
+printf "%s\n" "$as_me: WARNING: --enable-riscv-rvv Please check contrib/riscv-vector/README file
+            for the list of supported OSes." >&2;};;
       api)
 
 printf "%s\n" "#define PNG_RISCV_RVV_API_SUPPORTED /**/" >>confdefs.h
@@ -15592,27 +15601,25 @@ printf "%s\n" "#define PNG_RISCV_RVV_API_SUPPORTED /**/" >>confdefs.h
 
 printf "%s\n" "#define PNG_RISCV_RVV_OPT 2" >>confdefs.h
 
-         { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: --enable-riscv-rvv: please specify 'check' or 'api';
-            if you want the optimizations unconditionally,
-            pass '-march=rv64gv1p0' or '-march=rv64gcv1p0' to the compiler." >&5
-printf "%s\n" "$as_me: WARNING: --enable-riscv-rvv: please specify 'check' or 'api';
-            if you want the optimizations unconditionally,
-            pass '-march=rv64gv1p0' or '-march=rv64gcv1p0' to the compiler." >&2;};;
+         { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: --enable-riscv-rvv: please specify 'check' or 'api', if
+            you want the optimizations unconditionally pass e.g. '-march=rv64gcv'
+            to the compiler." >&5
+printf "%s\n" "$as_me: WARNING: --enable-riscv-rvv: please specify 'check' or 'api', if
+            you want the optimizations unconditionally pass e.g. '-march=rv64gcv'
+            to the compiler." >&2;};;
       *)
-         as_fn_error $? "--enable-riscv-rvv=${enable_riscv_rvv}:
-                      invalid argument" "$LINENO" 5
+         as_fn_error $? "--enable-riscv-rvv=${enable_riscv_rvv}: invalid value" "$LINENO" 5
    esac
 fi
 
 
-# Add RISCV-specific files to all builds where $host_cpu is RISC-V ('riscv64') or
-# where RISCV optimizations were explicitly requested. (This allows a fallback
+# Add RISC-V-specific files to all builds where $host_cpu is RISC-V ('riscv64') or
+# where RISC-V optimizations were explicitly requested (this allows a fallback
 # if a future host CPU does not match 'riscv64'.)
 
  if test "$enable_riscv_rvv" != 'no' &&
     case "$host_cpu" in
-      riscv64) : ;;
-      *)    test "$enable_riscv_rvv" != '' ;;
+      riscv*) : ;;
     esac; then
   PNG_RISCV_RVV_TRUE=
   PNG_RISCV_RVV_FALSE='#'

--- a/configure.ac
+++ b/configure.ac
@@ -377,6 +377,7 @@ AC_ARG_ENABLE([hardware-optimizations],
               enable_loongarch_lsx=yes
               AC_DEFINE([PNG_LOONGARCH_LSX_OPT], [1],
                 [Enable LOONGARCH_LSX optimizations])
+              ;;
             riscv*)
               enable_riscv_rvv=yes
               AC_DEFINE([PNG_RISCV_RVV_OPT], [2],
@@ -673,7 +674,7 @@ AM_CONDITIONAL([PNG_LOONGARCH_LSX],
 #
 # RISC-V Vector support.
 
-AC_ARG_ENABLE([riscv-vector],
+AC_ARG_ENABLE([riscv-rvv],
 AS_HELP_STRING([[[--enable-riscv-rvv]]],
       [Enable RISC-V Vector optimizations: =no/off, check, api, yes/on:]
       [no/off: disable the optimizations; check: use internal checking code]
@@ -705,9 +706,9 @@ AS_HELP_STRING([[[--enable-riscv-rvv]]],
          AC_MSG_ERROR([--enable-riscv-rvv=${enable_riscv_rvv}: invalid value])
    esac])
 
-# Add RISC-V-specific files to all builds where $host_cpu is riscv ('riscv*')
-# or where RISC-V optimizations were explicitly requested (this allows a fallback
-# if a future host CPU does not match 'riscv*')
+# Add RISC-V-specific files to all builds where $host_cpu is RISC-V ('riscv64') or
+# where RISC-V optimizations were explicitly requested (this allows a fallback
+# if a future host CPU does not match 'riscv64'.)
 
 AM_CONDITIONAL([PNG_RISCV_RVV],
    [test "$enable_riscv_rvv" != 'no' &&


### PR DESCRIPTION
This changeset fixes the syntax error in configure.ac, reconciles differences noticed due to configure being edited rather than configure.ac, and regenerates Autotools based on Autoconf 2.72, Automake 1.17, and libtool 2.5.4.  This is a proposed alternative to pull request #685 by @jbowler.

I do not have any knowledge of RISCV, or a compilation environment for it, but it seems best to preserve contributed work as much as possible until RISCV experts pay attention again.