### PR TITLE
Fix double fclose by ensuring fp is not NULL before closing

### DIFF
--- a/contrib/examples/iccfrompng.c
+++ b/contrib/examples/iccfrompng.c
@@ -161,6 +161,9 @@ extract_one_file(const char *filename)
    else
       fprintf(stderr, "%s: could not open file\n", filename);
 
+    if (fp != NULL)
+        fclose(fp);
+
    return result;
 }
 


### PR DESCRIPTION
@ctruta Hello again, I loved your support and help, which gave me a good understanding of how the world of code works. Thanks for that.

This is a minimalist, clean fix to avoid a potential double fclose() call in iccfrompng.c.
We now ensure the file pointer fp is closed exactly once, only if it was opened.
No other logic or formatting is changed.