### PR TITLE
riscv: fix autodetection of rvv support

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -135,8 +135,11 @@ libpng@PNGLIB_MAJOR@@PNGLIB_MINOR@_la_SOURCES += powerpc/powerpc_init.c\
 endif
 
 if PNG_RISCV_RVV
-libpng@PNGLIB_MAJOR@@PNGLIB_MINOR@_la_SOURCES += riscv/riscv_init.c\
+noinst_LTLIBRARIES= libpng@PNGLIB_MAJOR@@PNGLIB_MINOR@rvv.la
+libpng@PNGLIB_MAJOR@@PNGLIB_MINOR@rvv_la_SOURCES = riscv/riscv_init.c\
         riscv/filter_rvv_intrinsics.c
+libpng@PNGLIB_MAJOR@@PNGLIB_MINOR@rvv_la_CFLAGS = -march=rv64gv
+libpng@PNGLIB_MAJOR@@PNGLIB_MINOR@_la_LIBADD = libpng@PNGLIB_MAJOR@@PNGLIB_MINOR@rvv.la
 endif
 
 if PNG_LOONGARCH_LSX
@@ -145,7 +148,6 @@ libpng@PNGLIB_MAJOR@@PNGLIB_MINOR@lsx_la_SOURCES = loongarch/loongarch_lsx_init.
 	loongarch/filter_lsx_intrinsics.c
 libpng@PNGLIB_MAJOR@@PNGLIB_MINOR@lsx_la_CFLAGS = -mlsx
 libpng@PNGLIB_MAJOR@@PNGLIB_MINOR@_la_LIBADD = libpng@PNGLIB_MAJOR@@PNGLIB_MINOR@lsx.la
-# libpng@PNGLIB_MAJOR@@PNGLIB_MINOR@_la_DEPENDENCIES = libpng@PNGLIB_MAJOR@@PNGLIB_MINOR@lsx.la
 endif
 
 nodist_libpng@PNGLIB_MAJOR@@PNGLIB_MINOR@_la_SOURCES = pnglibconf.h
@@ -166,6 +168,10 @@ else
 #   Only restricted exports when possible
   libpng@PNGLIB_MAJOR@@PNGLIB_MINOR@_la_LDFLAGS += -export-symbols libpng.sym
   libpng@PNGLIB_MAJOR@@PNGLIB_MINOR@_la_DEPENDENCIES = libpng.sym
+endif
+
+if PNG_RISCV_RVV
+  libpng@PNGLIB_MAJOR@@PNGLIB_MINOR@_la_DEPENDENCIES += libpng@PNGLIB_MAJOR@@PNGLIB_MINOR@rvv.la
 endif
 
 if PNG_LOONGARCH_LSX

--- a/configure.ac
+++ b/configure.ac
@@ -714,6 +714,9 @@ if test "$enable_riscv_rvv" != "no" &&
 then
    compiler_support_riscv_rvv=no
    AC_MSG_CHECKING(whether to use RISC-V RVV intrinsics)
+
+   save_CFLAGS=$CFLAGS
+   CFLAGS="$CFLAGS -march=rv64gv"
    AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
 #include <riscv_vector.h>
 int main(){
@@ -726,6 +729,7 @@ int main(){
    else
       AC_MSG_WARN([Compiler does not support riscv rvv.])
    fi
+   CFLAGS=$save_CFLAGS
 fi
 
 # Add RISC-V-specific files to all builds where $host_cpu is riscv ('riscv64')


### PR DESCRIPTION
Issue: https://github.com/pnggroup/libpng/issues/698

What has been done:
- When checking for RVV build time support we compile a mini program. This compilation went wrong if the march was not explicitly stated (which is the case for default ci builds and other builds as well)
- Pushed only configuarion.ac and makefile.am


