### PR TITLE
FIX: unknown IDAT causes out-of-place IEND

### DIFF
--- a/pngpread.c
+++ b/pngpread.c
@@ -229,6 +229,15 @@ png_push_read_chunk(png_structrp png_ptr, png_inforp info_ptr)
          png_benign_error(png_ptr, "Too many IDATs found");
    }
 
+   else if ((png_ptr->mode & PNG_HAVE_IDAT) != 0)
+   {
+      /* This used to be done in some but not all of the specific
+       * chunk handlers.  That's the wrong place; it needs to happen reliably on
+       * any non-IDAT chunk before that chunk is processed.
+       */
+      png_ptr->mode |= PNG_HAVE_CHUNK_AFTER_IDAT | PNG_AFTER_IDAT;
+   }
+
    if (chunk_name == png_IHDR)
    {
       if (png_ptr->push_length != 13)

--- a/pngread.c
+++ b/pngread.c
@@ -702,7 +702,13 @@ png_read_end(png_structrp png_ptr, png_inforp info_ptr)
       png_uint_32 chunk_name = png_ptr->chunk_name;
 
       if (chunk_name != png_IDAT)
-         png_ptr->mode |= PNG_HAVE_CHUNK_AFTER_IDAT;
+      {
+         /* Some of the chunk handlers for non-IDAT used to do this if
+          * PNG_HAVE_IDAT was set.  It needs to happen consistently including
+          * for 'unknown' chunks.
+          */
+         png_ptr->mode |= PNG_HAVE_CHUNK_AFTER_IDAT | PNG_AFTER_IDAT;
+      }
 
       if (chunk_name == png_IEND)
          png_handle_chunk(png_ptr, info_ptr, length);

--- a/pngrutil.c
+++ b/pngrutil.c
@@ -2412,10 +2412,6 @@ png_handle_tEXt(png_structrp png_ptr, png_inforp info_ptr, png_uint_32 length)
    }
 #endif
 
-   /* TODO: this doesn't work and shouldn't be necessary. */
-   if ((png_ptr->mode & PNG_HAVE_IDAT) != 0)
-      png_ptr->mode |= PNG_AFTER_IDAT;
-
    buffer = png_read_buffer(png_ptr, length+1);
 
    if (buffer == NULL)
@@ -2485,10 +2481,6 @@ png_handle_zTXt(png_structrp png_ptr, png_inforp info_ptr, png_uint_32 length)
       }
    }
 #endif
-
-   /* TODO: should not be necessary. */
-   if ((png_ptr->mode & PNG_HAVE_IDAT) != 0)
-      png_ptr->mode |= PNG_AFTER_IDAT;
 
    /* Note, "length" is sufficient here; we won't be adding
     * a null terminator later.  The limit check in png_handle_chunk should be
@@ -2605,10 +2597,6 @@ png_handle_iTXt(png_structrp png_ptr, png_inforp info_ptr, png_uint_32 length)
       }
    }
 #endif
-
-   /* TODO: should not be necessary. */
-   if ((png_ptr->mode & PNG_HAVE_IDAT) != 0)
-      png_ptr->mode |= PNG_AFTER_IDAT;
 
    buffer = png_read_buffer(png_ptr, length+1);
 


### PR DESCRIPTION
PNG_AFTER_IDAT was not set by the IDAT read code if unknown handling for IDAT was turned on.  This was hidden in the current tests by checks within the text handling chunks (the test file, pngtest.png, has a zTXt after IDAT).

This change modifies both the sequential and progressive reader to reliably set PNG_AFTER_IDAT when the first non-IDAT chunk is seen and before that chunk is processed.

The change is minimalist; PNG_HAVE_CHUNK_AFTER_IDAT can probably be removed and replaced with PNG_AFTER_IDAT with this change.  This change is apparently not necessary so is deferred until libpng2.