### PR TITLE
png_read_reinit: info_rowbytes correction

### DIFF
--- a/pngrutil.c
+++ b/pngrutil.c
@@ -4928,7 +4928,7 @@ png_read_reinit(png_structp png_ptr, png_infop info_ptr)
    png_ptr->height = info_ptr->next_frame_height;
    png_ptr->rowbytes = PNG_ROWBYTES(png_ptr->pixel_depth,png_ptr->width);
    if (png_ptr->info_rowbytes != 0)
-      png_ptr->info_rowbytes =
+      png_ptr->info_rowbytes = info_ptr->rowbytes =
          PNG_ROWBYTES(info_ptr->pixel_depth, png_ptr->width);
    if (png_ptr->prev_row)
       memset(png_ptr->prev_row, 0, png_ptr->rowbytes + 1);


### PR DESCRIPTION
In the case where the application has not called png_read_update_info
png_ptr->info_rowbytes is 0 and should not be updated (fix from
MaartenBent).

In the case where the application has called png_read_update_info the
value of info_ptr->rowbytes needs to be updated as well has
png_ptr->info_rowbytes so that png_get_rowbytes works correctly.

Signed-off-by: John Bowler <jbowler@acm.org>
