### PR TITLE
Fix: prevent NULL dereference in png_handle_PLTE() for zero-length PLTE chunk (CVE-2013-6954)

### DIFF
--- a/pngrutil.c
+++ b/pngrutil.c
@@ -999,11 +999,9 @@ png_handle_PLTE(png_structrp png_ptr, png_inforp info_ptr, png_uint_32 length)
       errmsg = "ignored in grayscale PNG";
 
    else if (length > 3*PNG_MAX_PALETTE_LENGTH || (length % 3) != 0)
-      errmsg = "invalid";
-   
-   else if (length == 0)
+      errmsg = "invalid"
+else if (length == 0)
        errmsg = "zero length";
-
    /* This drops PLTE in favour of tRNS or bKGD because both of those chunks
     * can have an effect on the rendering of the image whereas PLTE only matters
     * in the case of an 8-bit display with a decoder which controls the palette.

--- a/pngrutil.c
+++ b/pngrutil.c
@@ -1000,6 +1000,9 @@ png_handle_PLTE(png_structrp png_ptr, png_inforp info_ptr, png_uint_32 length)
 
    else if (length > 3*PNG_MAX_PALETTE_LENGTH || (length % 3) != 0)
       errmsg = "invalid";
+   
+   else if (length == 0)
+       errmsg = "zero length";
 
    /* This drops PLTE in favour of tRNS or bKGD because both of those chunks
     * can have an effect on the rendering of the image whereas PLTE only matters


### PR DESCRIPTION
### Summary

This patch fixes a potential NULL pointer dereference when processing PNG files with a zero-length PLTE chunk, which previously led to application crashes (denial of service). The issue corresponds to CVE-2013-6954.

### Vulnerability Details

- The function `png_handle_PLTE()` did not correctly handle the case where a PLTE chunk had a length of 0.
- As a result, `png_ptr->palette` remained unallocated.
- Later, `png_do_expand_palette()` accessed `png_ptr->palette`, causing a NULL pointer dereference and crash.

### Fix

A check has been added to `png_handle_PLTE()` to detect a 0-length PLTE chunk and gracefully abort processing with a relevant error message:
```c
else if (length == 0)
   errmsg = "zero length";
   
 ###Impact
 	•	Prevents a denial-of-service vulnerability caused by malformed PNGs.
	•	Improves robustness of the PNG decoder against malformed input.  