### PR TITLE
Prevent out-of-bounds read in png_handle_sPLT when scanning for null-…

### DIFF
--- a/pngrutil.c
+++ b/pngrutil.c
@@ -1613,9 +1613,20 @@ png_handle_sPLT(png_structrp png_ptr, png_inforp info_ptr, png_uint_32 length)
 
    buffer[length] = 0;
 
-   for (entry_start = buffer; *entry_start; entry_start++)
-      /* Empty loop to find end of name */ ;
+for (entry_start = buffer; entry_start < buffer + length && *entry_start;
+       entry_start++)
+ /* Empty loop to find end of name */ ;
 
+   if (entry_start >= buffer + length)
+   {
+      png_warning(png_ptr, "malformed sPLT chunk");
+      return handled_error;
+   }
+   if (*entry_start != 0)
+   {
+       png_warning(png_ptr, "malformed sPLT chunk");
+       return handled_error;
+   }
    ++entry_start;
 
    /* A sample depth should follow the separator, and we should be on it  */


### PR DESCRIPTION
##Prevent out-of-bounds read in png_handle_sPLT when scanning for null-terminator

This patch adds bounds checking to the loop that scans the sPLT chunk name for a null-terminator. If the null-terminator is missing, the function now emits a warning and gracefully exits instead of reading past the buffer boundary.

This mitigates a possible memory-safety issue from malformed PNG input.

##IMPACT
Impact
	•	Memory Safety: Prevents undefined behavior from out-of-bounds memory access.
	•	Denial-of-Service Risk: Avoids crashing the application on malformed PNGs.
	•	Robust Parsing: Ensures only correctly formatted sPLT chunks are processed.
	•	Standards Compliance: Enforces the PNG spec requirement for null-terminated chunk names.