### PR TITLE
Hardening ci_expr Against Potential Shell Injection

### DIFF
--- a/ci/lib/ci.lib.sh
+++ b/ci/lib/ci.lib.sh
@@ -54,18 +54,16 @@ function ci_err_internal {
 }
 
 function ci_expr {
-    if [[ ${*:-0} == [0-9] ]]
-    then
-        # This is the same as in the else-branch below, albeit much faster
-        # for our intended use cases.
+    if [[ ${*:-0} == [0-9] ]]; then
         return $((!$1))
     else
-        # The funny-looking compound command "... && return $? || return $?"
-        # allows the execution to continue uninterrupted under "set -e".
+        # Sanitize input: allow only numbers, arithmetic/logical operators, parens, and space
+        if [[ "$*" =~ [^0-9[:space:]+\-*/%()&|<>=!] ]]; then
+            ci_err "invalid characters in expression: $*"
+        fi
         expr >/dev/null "$@" && return $? || return $?
     fi
 }
-
 function ci_spawn {
     printf >&2 "%s: executing:" "$CI_SCRIPT_NAME"
     printf >&2 " %q" "$@"


### PR DESCRIPTION
This patch introduces a minimal input validation check in the ci_expr function in ci.lib.sh to ensure only safe characters are passed to expr.

While current usage may be safe, this adds a security layer to help guard against misuse or future changes where inputs may not be tightly controlled.

This change is backward-compatible and does not affect valid mathematical expressions.

