### PR TITLE
Add optional compile flag for global allocator override

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6279,6 +6279,10 @@ Version 1.6.50 [July 1, 2025]
   Fixed the CMake file for cross-platform builds that require `libm`.
 
 Version 1.6.51 [TODO]
+  Add option PNG_USER_GLOBAL_MEM_SUPPORTED to allow using png_set_mem_fn
+    with a NULL png_ptr to set a common malloc/free to use, overriding
+    the default `malloc()` and `free()`, if not
+    set on a specific png_ptr.
 
 Send comments/corrections/commendations to png-mng-implement at lists.sf.net.
 Subscription is required; visit


### PR DESCRIPTION
Add compile option `PNG_USER_GLOBAL_MEM_SUPPORTED`

which allows specifying  `png_set_mem_fn(NULL,...);` to specify functions to use for malloc/free, the additional data pointer passed is NULL (it could be a per-png data parameter, but being global, it'd unlikely the current PNG's data parameter would be useful anyway.  The first parameter `NULL` in this case is normally a `png_struct*`, and NULL was previously equivalent to doing nothing.