### PR TITLE
refactor: Remove PNG_STRING_NEWLINE

### DIFF
--- a/png.c
+++ b/png.c
@@ -793,14 +793,12 @@ png_get_copyright(png_const_structrp png_ptr)
 #ifdef PNG_STRING_COPYRIGHT
    return PNG_STRING_COPYRIGHT
 #else
-   return PNG_STRING_NEWLINE \
-      "libpng version 1.8.0.git" PNG_STRING_NEWLINE \
-      "Copyright (c) 2018-2025 Cosmin Truta" PNG_STRING_NEWLINE \
-      "Copyright (c) 1998-2002,2004,2006-2018 Glenn Randers-Pehrson" \
-      PNG_STRING_NEWLINE \
-      "Copyright (c) 1996-1997 Andreas Dilger" PNG_STRING_NEWLINE \
-      "Copyright (c) 1995-1996 Guy Eric Schalnat, Group 42, Inc." \
-      PNG_STRING_NEWLINE;
+   return "\n"
+      "libpng version 1.8.0.git\n"
+      "Copyright (c) 2018-2025 Cosmin Truta\n"
+      "Copyright (c) 1998-2002,2004,2006-2018 Glenn Randers-Pehrson\n"
+      "Copyright (c) 1996-1997 Andreas Dilger\n"
+      "Copyright (c) 1995-1996 Guy Eric Schalnat, Group 42, Inc.\n";
 #endif
 }
 
@@ -837,7 +835,7 @@ png_get_header_version(png_const_structrp png_ptr)
 #  ifndef PNG_READ_SUPPORTED
       " (NO READ SUPPORT)"
 #  endif
-      PNG_STRING_NEWLINE;
+      "\n";
 #else
    return PNG_HEADER_VERSION_STRING;
 #endif

--- a/pngdebug.h
+++ b/pngdebug.h
@@ -37,10 +37,6 @@
 #ifndef PNGDEBUG_H
 #define PNGDEBUG_H
 
-#ifndef PNG_STRING_NEWLINE
-#  define PNG_STRING_NEWLINE "\n"
-#endif
-
 #ifdef PNG_DEBUG
 #  if (PNG_DEBUG > 0)
 #    if !defined(PNG_DEBUG_FILE) && defined(_MSC_VER)
@@ -50,14 +46,14 @@
 #          define _DEBUG
 #        endif
 #        ifndef png_debug
-#          define png_debug(l,m)  _RPT0(_CRT_WARN,m PNG_STRING_NEWLINE)
+#          define png_debug(l,m)  _RPT0(_CRT_WARN,m "\n")
 #        endif
 #        ifndef png_debug1
-#          define png_debug1(l,m,p1)  _RPT1(_CRT_WARN,m PNG_STRING_NEWLINE,p1)
+#          define png_debug1(l,m,p1)  _RPT1(_CRT_WARN,m "\n",p1)
 #        endif
 #        ifndef png_debug2
 #          define png_debug2(l,m,p1,p2) \
-             _RPT2(_CRT_WARN,m PNG_STRING_NEWLINE,p1,p2)
+             _RPT2(_CRT_WARN,m "\n",p1,p2)
 #        endif
 #      endif
 #    else /* PNG_DEBUG_FILE || !_MSC_VER */
@@ -74,7 +70,7 @@
 #            define png_debug(l,m) \
        do { \
        int num_tabs=l; \
-       fprintf(PNG_DEBUG_FILE,"%s" m PNG_STRING_NEWLINE,(num_tabs==1 ? "   " : \
+       fprintf(PNG_DEBUG_FILE,"%s" m "\n",(num_tabs==1 ? "   " : \
          (num_tabs==2 ? "      " : (num_tabs>2 ? "         " : "")))); \
        } while (0)
 #          endif
@@ -82,7 +78,7 @@
 #            define png_debug1(l,m,p1) \
        do { \
        int num_tabs=l; \
-       fprintf(PNG_DEBUG_FILE,"%s" m PNG_STRING_NEWLINE,(num_tabs==1 ? "   " : \
+       fprintf(PNG_DEBUG_FILE,"%s" m "\n",(num_tabs==1 ? "   " : \
          (num_tabs==2 ? "      " : (num_tabs>2 ? "         " : ""))),p1); \
        } while (0)
 #          endif
@@ -90,7 +86,7 @@
 #            define png_debug2(l,m,p1,p2) \
        do { \
        int num_tabs=l; \
-       fprintf(PNG_DEBUG_FILE,"%s" m PNG_STRING_NEWLINE,(num_tabs==1 ? "   " : \
+       fprintf(PNG_DEBUG_FILE,"%s" m "\n",(num_tabs==1 ? "   " : \
          (num_tabs==2 ? "      " : (num_tabs>2 ? "         " : ""))),p1,p2);\
        } while (0)
 #          endif
@@ -100,9 +96,9 @@
        do { \
        int num_tabs=l; \
        char format[256]; \
-       snprintf(format,256,"%s%s%s",(num_tabs==1 ? "\t" : \
+       snprintf(format,256,"%s%s\n",(num_tabs==1 ? "\t" : \
          (num_tabs==2 ? "\t\t":(num_tabs>2 ? "\t\t\t":""))), \
-         m,PNG_STRING_NEWLINE); \
+         m); \
        fprintf(PNG_DEBUG_FILE,format); \
        } while (0)
 #          endif
@@ -111,9 +107,9 @@
        do { \
        int num_tabs=l; \
        char format[256]; \
-       snprintf(format,256,"%s%s%s",(num_tabs==1 ? "\t" : \
+       snprintf(format,256,"%s%s\n",(num_tabs==1 ? "\t" : \
          (num_tabs==2 ? "\t\t":(num_tabs>2 ? "\t\t\t":""))), \
-         m,PNG_STRING_NEWLINE); \
+         m); \
        fprintf(PNG_DEBUG_FILE,format,p1); \
        } while (0)
 #          endif
@@ -122,9 +118,9 @@
        do { \
        int num_tabs=l; \
        char format[256]; \
-       snprintf(format,256,"%s%s%s",(num_tabs==1 ? "\t" : \
+       snprintf(format,256,"%s%s\n",(num_tabs==1 ? "\t" : \
          (num_tabs==2 ? "\t\t":(num_tabs>2 ? "\t\t\t":""))), \
-         m,PNG_STRING_NEWLINE); \
+         m); \
        fprintf(PNG_DEBUG_FILE,format,p1,p2); \
        } while (0)
 #          endif

--- a/pngerror.c
+++ b/pngerror.c
@@ -657,9 +657,8 @@ png_default_error,(png_const_structrp png_ptr, png_const_charp error_message),
     PNG_NORETURN)
 {
 #ifdef PNG_CONSOLE_IO_SUPPORTED
-   fprintf(stderr, "libpng error: %s", error_message ? error_message :
+   fprintf(stderr, "libpng error: %s\n", error_message ? error_message :
       "undefined");
-   fprintf(stderr, PNG_STRING_NEWLINE);
 #else
    PNG_UNUSED(error_message) /* Make compiler happy */
 #endif
@@ -697,8 +696,7 @@ static void /* PRIVATE */
 png_default_warning(png_const_structrp png_ptr, png_const_charp warning_message)
 {
 #ifdef PNG_CONSOLE_IO_SUPPORTED
-   fprintf(stderr, "libpng warning: %s", warning_message);
-   fprintf(stderr, PNG_STRING_NEWLINE);
+   fprintf(stderr, "libpng warning: %s\n", warning_message);
 #else
    PNG_UNUSED(warning_message) /* Make compiler happy */
 #endif

--- a/pngerror.c
+++ b/pngerror.c
@@ -657,11 +657,9 @@ png_default_error,(png_const_structrp png_ptr, png_const_charp error_message),
     PNG_NORETURN)
 {
 #ifdef PNG_CONSOLE_IO_SUPPORTED
-   {
-      fprintf(stderr, "libpng error: %s", error_message ? error_message :
-         "undefined");
-      fprintf(stderr, PNG_STRING_NEWLINE);
-   }
+   fprintf(stderr, "libpng error: %s", error_message ? error_message :
+      "undefined");
+   fprintf(stderr, PNG_STRING_NEWLINE);
 #else
    PNG_UNUSED(error_message) /* Make compiler happy */
 #endif


### PR DESCRIPTION
Remove PNG_STRING_NEWLINE, which is supposed to be always \n.

Also, with removal of ERROR_NUMBERS feature, this block, which was a preprocessor conditional if-block, can be removed.

Call the fprintf functions directly instead.