### PR TITLE
Simplify pngerror.c functions

### DIFF
--- a/pngerror.c
+++ b/pngerror.c
@@ -380,13 +380,12 @@ png_format_buffer(png_const_structrp png_ptr, png_charp buffer, png_const_charp
     error_message)
 {
    png_uint_32 chunk_name = png_ptr->chunk_name;
-   int iout = 0, ishift = 24;
+   int iout = 0, ishift;
 
-   while (ishift >= 0)
+   for (ishift = 24; ishift >= 0; ishift -= 8)
    {
       int c = (int)(chunk_name >> ishift) & 0xff;
 
-      ishift -= 8;
       if (isnonalpha(c) != 0)
       {
          buffer[iout++] = '[';

--- a/pngerror.c
+++ b/pngerror.c
@@ -175,12 +175,11 @@ png_format_number(png_const_charp start, png_charp end, int format,
 void
 png_warning(png_const_structrp png_ptr, png_const_charp warning_message)
 {
-   int offset = 0;
    if (png_ptr != NULL && png_ptr->warning_fn != NULL)
       (*(png_ptr->warning_fn))(png_constcast(png_structrp,png_ptr),
-          warning_message + offset);
+          warning_message);
    else
-      png_default_warning(png_ptr, warning_message + offset);
+      png_default_warning(png_ptr, warning_message);
 }
 
 /* These functions support 'formatted' warning messages with up to


### PR DESCRIPTION
Remove unneeded `offset` variable in `png_warning` and turn a `while` loop into a `for` loop in `png_format_buffer.

The `offset` is always 0 and the `while` loop is used a `for` loop.