### PR TITLE
Improve documentation in pngerror.c

### DIFF
--- a/pngerror.c
+++ b/pngerror.c
@@ -1,4 +1,4 @@
-/* pngerror.c - stub functions for i/o and memory allocation
+/* pngerror.c - functions for warnings and error handling
  *
  * Copyright (c) 2018-2025 Cosmin Truta
  * Copyright (c) 1998-2002,2004,2006-2017 Glenn Randers-Pehrson
@@ -237,11 +237,10 @@ png_formatted_warning(png_const_structrp png_ptr, png_warning_parameters p,
    size_t i = 0; /* Index in the msg[] buffer: */
    char msg[192];
 
-   /* Each iteration through the following loop writes at most one character
-    * to msg[i++] then returns here to validate that there is still space for
-    * the trailing '\0'.  It may (in the case of a parameter) read more than
-    * one character from message[]; it must check for '\0' and continue to the
-    * test if it finds the end of string.
+   /* Iterate through characters in message and resolve encountered
+    * parameters, which consist of @ followed by parameter number. Either
+    * add the resolved parameter or the raw character at msg[i]. Always check
+    * that there is still space for the trailing '\0'.
     */
    while (i<(sizeof msg)-1 && *message != '\0')
    {

--- a/pngerror.c
+++ b/pngerror.c
@@ -65,7 +65,7 @@ png_err,(png_const_structrp png_ptr),PNG_NORETURN)
 }
 #endif /* ERROR_TEXT */
 
-/* Utility to safely appends strings to a buffer.  This never errors out so
+/* Utility to safely append strings to a buffer.  This never errors out so
  * error checking is not required in the caller.
  */
 size_t
@@ -86,7 +86,7 @@ png_safecat(png_charp buffer, size_t bufsize, size_t pos,
 
 #if defined(PNG_WARNINGS_SUPPORTED) || defined(PNG_TIME_RFC1123_SUPPORTED)
 /* Utility to dump an unsigned value into a buffer, given a start pointer and
- * and end pointer (which should point just *beyond* the end of the buffer!)
+ * an end pointer (which should point just *beyond* the end of the buffer!).
  * Returns the pointer to the start of the formatted string.
  */
 png_charp
@@ -707,7 +707,7 @@ png_default_warning(png_const_structrp png_ptr, png_const_charp warning_message)
 /* This function is called when the application wants to use another method
  * of handling errors and warnings.  Note that the error function MUST NOT
  * return to the calling routine or serious problems will occur.  The return
- * method used in the default routine calls longjmp(png_ptr->jmp_buf_ptr, 1)
+ * method used in the default routine calls longjmp(png_ptr->jmp_buf_ptr, 1).
  */
 void
 png_set_error_fn(png_structrp png_ptr, png_voidp error_ptr,

--- a/pngpriv.h
+++ b/pngpriv.h
@@ -1514,7 +1514,7 @@ PNG_INTERNAL_FUNCTION(size_t,png_safecat,(png_charp buffer, size_t bufsize,
  */
 #if defined(PNG_WARNINGS_SUPPORTED) || defined(PNG_TIME_RFC1123_SUPPORTED)
 /* Utility to dump an unsigned value into a buffer, given a start pointer and
- * and end pointer (which should point just *beyond* the end of the buffer!)
+ * an end pointer (which should point just *beyond* the end of the buffer!).
  * Returns the pointer to the start of the formatted string.  This utility only
  * does unsigned values.
  */


### PR DESCRIPTION
Fixes a few typos and properly describes what kind of functions are located in pngerror.c.

Also, the implementation of a while loop in `png_formatted_warning` changed so much that the descriptive comment didn't fit anymore. Adjusted the comment.