### PR TITLE
Reduce compiled library size with pngerror.o reduction

### DIFF
--- a/pngerror.c
+++ b/pngerror.c
@@ -250,20 +250,13 @@ png_formatted_warning(png_const_structrp png_ptr, png_warning_parameters p,
        */
       if (p != NULL && *message == '@' && message[1] != '\0')
       {
-         int parameter_char = *++message; /* Consume the '@' */
-         static const char valid_parameters[] = "123456789";
-         int parameter = 0;
-
-         /* Search for the parameter digit, the index in the string is the
-          * parameter to use.
-          */
-         while (valid_parameters[parameter] != parameter_char &&
-            valid_parameters[parameter] != '\0')
-            ++parameter;
+         const int parameter_char = *++message; /* Consume the '@' */
 
          /* If the parameter digit is out of range it will just get printed. */
-         if (parameter < PNG_WARNING_PARAMETER_COUNT)
+         if (parameter_char >= '1' && parameter_char <= '9')
          {
+            const int parameter = parameter_char - '1';
+
             /* Append this parameter */
             png_const_charp parm = p[parameter];
             png_const_charp pend = p[parameter] + (sizeof p[parameter]);

--- a/pngerror.c
+++ b/pngerror.c
@@ -370,10 +370,7 @@ png_app_error(png_const_structrp png_ptr, png_const_charp error_message)
  * if the character is invalid.
  */
 #define isnonalpha(c) ((c) < 65 || (c) > 122 || ((c) > 90 && (c) < 97))
-static const char png_digit[16] = {
-   '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
-   'A', 'B', 'C', 'D', 'E', 'F'
-};
+static const char png_digit[] = "0123456789ABCDEF";
 
 static void /* PRIVATE */
 png_format_buffer(png_const_structrp png_ptr, png_charp buffer, png_const_charp


### PR DESCRIPTION
At least GCC 15 is not smart enough to detect that `png_digits` is a subset of `digits`. Both are static variables containing `0123456789ABCDEF`, yet `digits` ends with a `\0` while `png_digits` does not.

Defining `png_digits` the same way as `digits` leads to proper removal (32 bytes saved on my system).

Also, remove the `123456789` string when resolving parameter numbers in `png_formatted_warning`. It doesn't take a loop and thus further reduces size and also amount of instructions.

In total, 105 bytes were removed on my system.