### PR TITLE
Simplify png_sig_cmp

### DIFF
--- a/png.c
+++ b/png.c
@@ -81,16 +81,13 @@ png_sig_cmp(png_const_bytep sig, size_t start, size_t num_to_check)
 {
    static const png_byte png_signature[8] = {137, 80, 78, 71, 13, 10, 26, 10};
 
-   if (num_to_check > 8)
-      num_to_check = 8;
-
-   else if (num_to_check < 1)
+   if (num_to_check < 1)
       return -1;
 
    if (start > 7)
       return -1;
 
-   if (start + num_to_check > 8)
+   if (num_to_check > 8 - start)
       num_to_check = 8 - start;
 
    return memcmp(&sig[start], &png_signature[start], num_to_check);


### PR DESCRIPTION
The `png_sig_cmp` function verifies that even if the passed amount of bytes to check (`num_to_check`) is too large, no read overflow occurs.

While the first `num_to_check` verification is easy to read, the second one is not.

Since another check verifies that `start` is not larger than 7, the check can be rewritten to bring `num_to_check`, `8` and `start` in same order as in the statement within the if-block. This makes it very easy to see that it's pretty much a `MIN()` statement.

With this reordering, the initial `num_to_check` verification becomes obsolete as well, allowing compilers to optimize much better. Both, clang and gcc, reduce the amount of required jump instructions and the library size shrinks by 16 (clang) or 64 (gcc) bytes on x86_64.