### PR TITLE
Require zlib 1.2.8 -- shed maintenance

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -174,6 +174,19 @@ AC_CHECK_LIB([z], [zlibVersion], ,
   [AC_CHECK_LIB([z], [${ZPREFIX}zlibVersion], ,
      [AC_MSG_ERROR([zlib not installed])])])
 
+AC_MSG_CHECKING([zlib version])
+AC_COMPILE_IFELSE(
+  [AC_LANG_SOURCE([
+#include <zlib.h>
+#if !defined(ZLIB_VERNUM) || ZLIB_VERNUM < 0x1280
+#error zlib version 1.2.8 or later is required
+#endif
+int main(void) { return 0; }
+])],
+  [AC_MSG_RESULT([acceptable])],
+  [AC_MSG_RESULT([too old or ZLIB_VERNUM not defined])
+   AC_MSG_ERROR([zlib version 1.2.8 or later is required])])
+
 # The following is for pngvalid, to ensure it catches FP errors even on
 # platforms that don't enable FP exceptions, the function appears in the math
 # library (typically), it's not an error if it is not found.

--- a/contrib/tools/pngfix.c
+++ b/contrib/tools/pngfix.c
@@ -52,22 +52,9 @@
 #  undef const
 #endif
 
-/* zlib.h has mediocre z_const use before 1.2.6, this stuff is for compatibility
- * with older builds.
- */
-#if ZLIB_VERNUM < 0x1260
-#  define PNGZ_MSG_CAST(s) constcast(char*,s)
-#  define PNGZ_INPUT_CAST(b) constcast(png_byte *,b)
-#else
-#  define PNGZ_MSG_CAST(s) (s)
-#  define PNGZ_INPUT_CAST(b) (b)
-#endif
-
 #ifndef PNG_MAXIMUM_INFLATE_WINDOW
 #  error pngfix requires libpng with PNG_MAXIMUM_INFLATE_WINDOW supported
 #endif
-
-#if ZLIB_VERNUM >= 0x1240
 
 /* Copied from pngpriv.h */
 #ifdef __cplusplus
@@ -2653,7 +2640,7 @@ zlib_check(struct file *file, png_uint_32 offset)
 
          case ZLIB_OK:
             /* Truncated stream; unrecoverable, gets converted to ZLIB_FATAL */
-            zlib.z.msg = PNGZ_MSG_CAST("[truncated]");
+            zlib.z.msg = "[truncated]";
             zlib_message(&zlib, 0/*expected*/);
             /* FALLTHROUGH */
 
@@ -2692,8 +2679,7 @@ zlib_check(struct file *file, png_uint_32 offset)
 
                      /* Output the error that wasn't output before: */
                      if (zlib.z.msg == NULL)
-                        zlib.z.msg = PNGZ_MSG_CAST(
-                           "invalid distance too far back");
+                        zlib.z.msg = "invalid distance too far back";
                      zlib_message(&zlib, 0/*stream error*/);
                      zlib_end(&zlib);
                      return 0;
@@ -4008,17 +3994,6 @@ main(int argc, const char **argv)
 
    return global_end(&global);
 }
-
-#else /* ZLIB_VERNUM < 0x1240 */
-int
-main(void)
-{
-   fprintf(stderr,
-      "pngfix needs libpng with a zlib >=1.2.4 (not 0x%x)\n",
-      ZLIB_VERNUM);
-   return 77;
-}
-#endif /* ZLIB_VERNUM */
 
 #else /* No read support */
 

--- a/png.c
+++ b/png.c
@@ -982,48 +982,48 @@ png_zstream_error(png_structrp png_ptr, int ret)
    {
       default:
       case Z_OK:
-         png_ptr->zstream.msg = PNGZ_MSG_CAST("unexpected zlib return code");
+         png_ptr->zstream.msg = "unexpected zlib return code";
          break;
 
       case Z_STREAM_END:
          /* Normal exit */
-         png_ptr->zstream.msg = PNGZ_MSG_CAST("unexpected end of LZ stream");
+         png_ptr->zstream.msg = "unexpected end of LZ stream";
          break;
 
       case Z_NEED_DICT:
          /* This means the deflate stream did not have a dictionary; this
           * indicates a bogus PNG.
           */
-         png_ptr->zstream.msg = PNGZ_MSG_CAST("missing LZ dictionary");
+         png_ptr->zstream.msg = "missing LZ dictionary";
          break;
 
       case Z_ERRNO:
          /* gz APIs only: should not happen */
-         png_ptr->zstream.msg = PNGZ_MSG_CAST("zlib IO error");
+         png_ptr->zstream.msg = "zlib IO error";
          break;
 
       case Z_STREAM_ERROR:
          /* internal libpng error */
-         png_ptr->zstream.msg = PNGZ_MSG_CAST("bad parameters to zlib");
+         png_ptr->zstream.msg = "bad parameters to zlib";
          break;
 
       case Z_DATA_ERROR:
-         png_ptr->zstream.msg = PNGZ_MSG_CAST("damaged LZ stream");
+         png_ptr->zstream.msg = "damaged LZ stream";
          break;
 
       case Z_MEM_ERROR:
-         png_ptr->zstream.msg = PNGZ_MSG_CAST("insufficient memory");
+         png_ptr->zstream.msg = "insufficient memory";
          break;
 
       case Z_BUF_ERROR:
          /* End of input or output; not a problem if the caller is doing
           * incremental read or write.
           */
-         png_ptr->zstream.msg = PNGZ_MSG_CAST("truncated");
+         png_ptr->zstream.msg = "truncated";
          break;
 
       case Z_VERSION_ERROR:
-         png_ptr->zstream.msg = PNGZ_MSG_CAST("unsupported zlib version");
+         png_ptr->zstream.msg = "unsupported zlib version";
          break;
 
       case PNG_UNEXPECTED_ZLIB_RETURN:
@@ -1032,7 +1032,7 @@ png_zstream_error(png_structrp png_ptr, int ret)
           * and change pngpriv.h.  Note that this message is "... return",
           * whereas the default/Z_OK one is "... return code".
           */
-         png_ptr->zstream.msg = PNGZ_MSG_CAST("unexpected zlib return");
+         png_ptr->zstream.msg = "unexpected zlib return";
          break;
    }
 }

--- a/pngpread.c
+++ b/pngpread.c
@@ -724,7 +724,7 @@ png_process_IDAT_data(png_structrp png_ptr, png_byte *buffer,
        * change the current behavior (see comments in inflate.c
        * for why this doesn't happen at present with zlib 1.2.5).
        */
-      ret = PNG_INFLATE(png_ptr, Z_SYNC_FLUSH);
+      ret = png_zlib_inflate(png_ptr, Z_SYNC_FLUSH);
 
       /* Check for any failure before proceeding. */
       if (ret != Z_OK && ret != Z_STREAM_END)

--- a/pngpriv.h
+++ b/pngpriv.h
@@ -1380,7 +1380,6 @@ PNG_INTERNAL_FUNCTION(void, png_read_start_row,
 PNG_INTERNAL_FUNCTION(int, png_zlib_inflate,
    (png_structrp png_ptr, int flush),
    PNG_EMPTY);
-#  define PNG_INFLATE(pp, flush) png_zlib_inflate(pp, flush)
 
 #ifdef PNG_READ_TRANSFORMS_SUPPORTED
 /* Optional call to update the users info structure */

--- a/pngpriv.h
+++ b/pngpriv.h
@@ -1377,14 +1377,10 @@ PNG_INTERNAL_FUNCTION(void, png_read_start_row,
    (png_structrp png_ptr),
    PNG_EMPTY);
 
-#if ZLIB_VERNUM >= 0x1240
 PNG_INTERNAL_FUNCTION(int, png_zlib_inflate,
    (png_structrp png_ptr, int flush),
    PNG_EMPTY);
 #  define PNG_INFLATE(pp, flush) png_zlib_inflate(pp, flush)
-#else /* Zlib < 1.2.4 */
-#  define PNG_INFLATE(pp, flush) inflate(&(pp)->zstream, flush)
-#endif /* Zlib < 1.2.4 */
 
 #ifdef PNG_READ_TRANSFORMS_SUPPORTED
 /* Optional call to update the users info structure */

--- a/pngrutil.c
+++ b/pngrutil.c
@@ -439,14 +439,9 @@ png_inflate_claim(png_structrp png_ptr, png_uint_32 owner)
     * follow that because, for systems with with limited capabilities, we
     * would otherwise reject the application's attempts to use a smaller window
     * size (zlib doesn't have an interface to say "this or lower"!).
-    *
-    * inflateReset2 was added to zlib 1.2.4; before this the window could not be
-    * reset, therefore it is necessary to always allocate the maximum window
-    * size with earlier zlibs just in case later compressed chunks need it.
     */
    {
       int ret; /* zlib return code */
-#if ZLIB_VERNUM >= 0x1240
       int window_bits = 0;
 
       if (((png_ptr->options >> PNG_MAXIMUM_INFLATE_WINDOW) & 3) ==
@@ -460,7 +455,6 @@ png_inflate_claim(png_structrp png_ptr, png_uint_32 owner)
       {
          png_ptr->zstream_start = 1;
       }
-#endif /* ZLIB_VERNUM >= 0x1240 */
 
       /* Set this for safety, just in case the previous owner left pointers to
        * memory allocations.
@@ -472,20 +466,12 @@ png_inflate_claim(png_structrp png_ptr, png_uint_32 owner)
 
       if ((png_ptr->flags & PNG_FLAG_ZSTREAM_INITIALIZED) != 0)
       {
-#if ZLIB_VERNUM >= 0x1240
          ret = inflateReset2(&png_ptr->zstream, window_bits);
-#else
-         ret = inflateReset(&png_ptr->zstream);
-#endif
       }
 
       else
       {
-#if ZLIB_VERNUM >= 0x1240
          ret = inflateInit2(&png_ptr->zstream, window_bits);
-#else
-         ret = inflateInit(&png_ptr->zstream);
-#endif
 
          if (ret == Z_OK)
             png_ptr->flags |= PNG_FLAG_ZSTREAM_INITIALIZED;
@@ -511,7 +497,6 @@ png_inflate_claim(png_structrp png_ptr, png_uint_32 owner)
 #endif
 }
 
-#if ZLIB_VERNUM >= 0x1240
 /* Handle the start of the inflate stream if we called inflateInit2(strm,0);
  * in this case some zlib versions skip validation of the CINFO field and, in
  * certain circumstances, libpng may end up displaying an invalid image, in
@@ -534,7 +519,6 @@ png_zlib_inflate(png_structrp png_ptr, int flush)
 
    return inflate(&png_ptr->zstream, flush);
 }
-#endif /* Zlib >= 1.2.4 */
 
 #ifdef PNG_READ_COMPRESSED_TEXT_SUPPORTED
 #if defined(PNG_READ_zTXt_SUPPORTED) || defined (PNG_READ_iTXt_SUPPORTED)
@@ -569,7 +553,7 @@ png_inflate(png_structrp png_ptr, png_uint_32 owner, int finish,
        * a performance advantage, because it reduces the amount of data accessed
        * at each step and that may give the OS more time to page it in.
        */
-      png_ptr->zstream.next_in = PNGZ_INPUT_CAST(input);
+      png_ptr->zstream.next_in = input;
       /* avail_in and avail_out are set below from 'size' */
       png_ptr->zstream.avail_in = 0;
       png_ptr->zstream.avail_out = 0;
@@ -662,7 +646,7 @@ png_inflate(png_structrp png_ptr, png_uint_32 owner, int finish,
        * pointer, which is not owned by the caller, but this is safe; it's only
        * used on errors!
        */
-      png_ptr->zstream.msg = PNGZ_MSG_CAST("zstream unclaimed");
+      png_ptr->zstream.msg = "zstream unclaimed";
       return Z_STREAM_ERROR;
    }
 }
@@ -886,7 +870,7 @@ png_inflate_read(png_structrp png_ptr, png_byte *read_buffer, uInt read_size,
 
    else
    {
-      png_ptr->zstream.msg = PNGZ_MSG_CAST("zstream unclaimed");
+      png_ptr->zstream.msg = "zstream unclaimed";
       return Z_STREAM_ERROR;
    }
 }

--- a/pngrutil.c
+++ b/pngrutil.c
@@ -614,7 +614,7 @@ png_inflate(png_structrp png_ptr, png_uint_32 owner, int finish,
           * the previous chunk of input data.  Tell zlib if we have reached the
           * end of the output buffer.
           */
-         ret = PNG_INFLATE(png_ptr, avail_out > 0 ? Z_NO_FLUSH :
+         ret = png_zlib_inflate(png_ptr, avail_out > 0 ? Z_NO_FLUSH :
              (finish ? Z_FINISH : Z_SYNC_FLUSH));
       } while (ret == Z_OK);
 
@@ -855,7 +855,7 @@ png_inflate_read(png_structrp png_ptr, png_byte *read_buffer, uInt read_size,
           * the available output is produced; this allows reading of truncated
           * streams.
           */
-         ret = PNG_INFLATE(png_ptr, *chunk_bytes > 0 ?
+         ret = png_zlib_inflate(png_ptr, *chunk_bytes > 0 ?
              Z_NO_FLUSH : (finish ? Z_FINISH : Z_SYNC_FLUSH));
       }
       while (ret == Z_OK && (*out_size > 0 || png_ptr->zstream.avail_out > 0));
@@ -4448,7 +4448,7 @@ png_read_IDAT_data(png_structrp png_ptr, png_byte *output,
        *
        * TODO: deal more elegantly with truncated IDAT lists.
        */
-      ret = PNG_INFLATE(png_ptr, Z_NO_FLUSH);
+      ret = png_zlib_inflate(png_ptr, Z_NO_FLUSH);
 
       /* Take the unconsumed output back. */
       if (output != NULL)

--- a/pngstruct.h
+++ b/pngstruct.h
@@ -30,17 +30,6 @@
 #  undef const
 #endif
 
-/* zlib.h has mediocre z_const use before 1.2.6, this stuff is for compatibility
- * with older builds.
- */
-#if ZLIB_VERNUM < 0x1260
-#  define PNGZ_MSG_CAST(s) png_constcast(char*,s)
-#  define PNGZ_INPUT_CAST(b) png_constcast(png_byte *,b)
-#else
-#  define PNGZ_MSG_CAST(s) (s)
-#  define PNGZ_INPUT_CAST(b) (b)
-#endif
-
 /* zlib.h declares a magic type 'uInt' that limits the amount of data that zlib
  * can handle at once.  This type need be no larger than 16 bits (so maximum of
  * 65535), this define allows us to discover how big it is, but limited by the
@@ -248,9 +237,7 @@ struct png_struct_def
                               /* pixel depth used for the row buffers */
    png_byte transformed_pixel_depth;
                               /* pixel depth after read/write transforms */
-#if ZLIB_VERNUM >= 0x1240
    png_byte zstream_start;    /* at start of an input zlib stream */
-#endif /* Zlib >= 1.2.4 */
 #if defined(PNG_READ_FILLER_SUPPORTED) || defined(PNG_WRITE_FILLER_SUPPORTED)
    png_uint_16 filler;           /* filler bytes for pixel expansion */
 #endif

--- a/pngwutil.c
+++ b/pngwutil.c
@@ -330,7 +330,7 @@ png_deflate_claim(png_structrp png_ptr, png_uint_32 owner,
          /* Attempt sane error recovery */
          if (png_ptr->zowner == png_IDAT) /* don't steal from IDAT */
          {
-            png_ptr->zstream.msg = PNGZ_MSG_CAST("in use by IDAT");
+            png_ptr->zstream.msg = "in use by IDAT";
             return Z_STREAM_ERROR;
          }
 
@@ -534,7 +534,7 @@ png_text_compress(png_structrp png_ptr, png_uint_32 chunk_name,
       png_uint_32 output_len;
 
       /* zlib updates these for us: */
-      png_ptr->zstream.next_in = PNGZ_INPUT_CAST(comp->input);
+      png_ptr->zstream.next_in = comp->input;
       png_ptr->zstream.avail_in = 0; /* Set below */
       png_ptr->zstream.next_out = comp->output;
       png_ptr->zstream.avail_out = (sizeof comp->output);
@@ -618,7 +618,7 @@ png_text_compress(png_structrp png_ptr, png_uint_32 chunk_name,
        */
       if (output_len + prefix_len >= PNG_UINT_31_MAX)
       {
-         png_ptr->zstream.msg = PNGZ_MSG_CAST("compressed data too long");
+         png_ptr->zstream.msg = "compressed data too long";
          ret = Z_MEM_ERROR;
       }
 
@@ -985,7 +985,7 @@ png_compress_IDAT(png_structrp png_ptr, const png_byte *input,
     * terminates the operation.  The _out values are maintained across calls to
     * this function, but the input must be reset each time.
     */
-   png_ptr->zstream.next_in = PNGZ_INPUT_CAST(input);
+   png_ptr->zstream.next_in = input;
    png_ptr->zstream.avail_in = 0; /* set below */
    for (;;)
    {


### PR DESCRIPTION
There are some proposals to move to a new zlib backend.

My first step in writing a patch for this was to shed some of the compatibility if statements.

Zlib 1.2.6 was release in 2012 according to the archive history https://zlib.net/fossils/

I think that 13years is pretty generous and should help shed some mental load

xref: https://github.com/pnggroup/libpng/issues/205

cc: @FabioPedretti