### PR TITLE
api: Deprecate legacy pointer typedefs (part 3)

### DIFF
--- a/contrib/examples/pngpixel.c
+++ b/contrib/examples/pngpixel.c
@@ -159,7 +159,7 @@ main(int argc, const char **argv)
       long x = atol(argv[1]);
       long y = atol(argv[2]);
       FILE *f = fopen(argv[3], "rb");
-      volatile png_byte *row = NULL;
+      png_byte * volatile row = NULL;
 
       if (f != NULL)
       {

--- a/contrib/libtests/makepng.c
+++ b/contrib/libtests/makepng.c
@@ -774,8 +774,8 @@ write_png(const char **name, FILE *fp, int color_type, int bit_depth,
 {
    png_struct *png_ptr = png_create_write_struct(PNG_LIBPNG_VER_STRING,
       name, makepng_error, makepng_warning);
-   volatile png_info *info_ptr = NULL;
-   volatile png_byte *row = NULL;
+   png_info * volatile info_ptr = NULL;
+   png_byte * volatile row = NULL;
 
    if (png_ptr == NULL)
    {

--- a/contrib/libtests/pngvalid.c
+++ b/contrib/libtests/pngvalid.c
@@ -3928,7 +3928,7 @@ transform_row(const png_struct *pp, png_byte buffer[TRANSFORM_ROWMAX],
 #elif PNG_LIBPNG_VER != 10700
 #  define set_write_interlace_handling(pp,type) (1)
 static void
-check_interlace_type(int const interlace_type)
+check_interlace_type(int interlace_type)
 {
    /* Prior to 1.7.0 libpng does not support the write of an interlaced image
     * unless PNG_WRITE_INTERLACING_SUPPORTED, even with do_interlace so the
@@ -4045,9 +4045,8 @@ choose_random_filter(png_struct *pp, int start)
 #endif /* !WRITE_FILTER */
 
 static void
-make_transform_image(png_store * const ps, png_byte const colour_type,
-    png_byte const bit_depth, unsigned int palette_number,
-    int interlace_type, const char *name)
+make_transform_image(png_store *ps, png_byte colour_type, png_byte bit_depth,
+    unsigned int palette_number, int interlace_type, const char *name)
 {
    context(ps, fault);
 
@@ -4264,10 +4263,8 @@ size_row(png_byte buffer[SIZE_ROWMAX], png_uint_32 bit_width, png_uint_32 y)
 }
 
 static void
-make_size_image(png_store * const ps, png_byte const colour_type,
-    png_byte const bit_depth, int const interlace_type,
-    png_uint_32 const w, png_uint_32 const h,
-    int const do_interlace)
+make_size_image(png_store *ps, png_byte colour_type, png_byte bit_depth,
+    int interlace_type, png_uint_32 w, png_uint_32 h, int do_interlace)
 {
    context(ps, fault);
 
@@ -4461,8 +4458,7 @@ make_size_image(png_store * const ps, png_byte const colour_type,
 }
 
 static void
-make_size(png_store * const ps, png_byte const colour_type, int bdlo,
-    int const bdhi)
+make_size(png_store *ps, png_byte colour_type, int bdlo, int bdhi)
 {
    for (; bdlo <= bdhi; ++bdlo)
    {
@@ -4579,8 +4575,8 @@ static const struct
     };
 
 static void
-make_error(png_store * const ps, png_byte const colour_type,
-    png_byte bit_depth, int interlace_type, int test, const char *name)
+make_error(png_store *ps, png_byte colour_type, png_byte bit_depth,
+    int interlace_type, int test, const char *name)
 {
    context(ps, fault);
 
@@ -4718,8 +4714,7 @@ make_error(png_store * const ps, png_byte const colour_type,
 }
 
 static int
-make_errors(png_modifier * const pm, png_byte const colour_type,
-    int bdlo, int const bdhi)
+make_errors(png_modifier *pm, png_byte colour_type, int bdlo, int bdhi)
 {
    for (; bdlo <= bdhi; ++bdlo)
    {
@@ -5660,7 +5655,7 @@ standard_end(png_struct *ppIn, png_info *pi)
 
 /* A single test run checking the standard image to ensure it is not damaged. */
 static void
-standard_test(png_store * const psIn, png_uint_32 const id,
+standard_test(png_store *psIn, png_uint_32 id,
    int do_interlace, int use_update_info)
 {
    standard_display d;
@@ -5748,8 +5743,7 @@ standard_test(png_store * const psIn, png_uint_32 const id,
 }
 
 static int
-test_standard(png_modifier * const pm, png_byte const colour_type,
-    int bdlo, int const bdhi)
+test_standard(png_modifier *pm, png_byte colour_type, int bdlo, int bdhi)
 {
    for (; bdlo <= bdhi; ++bdlo)
    {
@@ -5795,8 +5789,7 @@ perform_standard_test(png_modifier *pm)
 
 /********************************** SIZE TESTS ********************************/
 static int
-test_size(png_modifier * const pm, png_byte const colour_type,
-    int bdlo, int const bdhi)
+test_size(png_modifier *pm, png_byte colour_type, int bdlo, int bdhi)
 {
    /* Run the tests on each combination.
     *
@@ -6766,7 +6759,7 @@ transform_image_validate(transform_display *dp, const png_struct *pp,
 
    for (y=0; y<h; ++y)
    {
-      const png_byte * const pRow = store_image_row(ps, pp, 0, y);
+      const png_byte *pRow = store_image_row(ps, pp, 0, y);
       png_uint_32 x;
 
       /* The original, standard, row pre-transforms. */
@@ -6873,7 +6866,7 @@ transform_end(png_struct *ppIn, png_info *pi)
 /* A single test run. */
 static void
 transform_test(png_modifier *pmIn, png_uint_32 idIn,
-    const image_transform *transform_listIn, const char * const name)
+    const image_transform *transform_listIn, const char *name)
 {
    transform_display d;
    context(&pmIn->this, fault);

--- a/contrib/tools/pngfix.c
+++ b/contrib/tools/pngfix.c
@@ -1562,7 +1562,7 @@ chunk_end(struct chunk **chunk_var)
 }
 
 static void
-chunk_init(struct chunk * const chunk, struct file * const file)
+chunk_init(struct chunk *chunk, struct file *file)
    /* When a chunk is initialized the file length/type/pos are copied into the
     * corresponding chunk fields and the new chunk is registered in the file
     * structure.  There can only be one chunk at a time.
@@ -1771,7 +1771,7 @@ IDAT_end(struct IDAT **idat_var)
 }
 
 static void
-IDAT_init(struct IDAT * const idat, struct file * const file)
+IDAT_init(struct IDAT *idat, struct file *file)
    /* When the chunk is png_IDAT instantiate an IDAT control structure in place
     * of a chunk control structure.  The IDAT will instantiate a chunk control
     * structure using the file alloc routine.

--- a/pngwrite.c
+++ b/pngwrite.c
@@ -2236,7 +2236,7 @@ png_image_write_main(void *argument)
 }
 
 static void
-image_memory_write(png_struct *png_ptr, png_byte */*const*/ data, size_t size)
+image_memory_write(png_struct *png_ptr, png_byte *data, size_t size)
 {
    png_image_write_control *display = png_voidcast(png_image_write_control*,
        png_ptr->io_ptr/*backdoor: png_get_io_ptr(png_ptr)*/);


### PR DESCRIPTION
Following up on #743 and #744 with an important fix and a clean-up job.