### PR TITLE
Fix heap buffer overflow in `png_write_image_8bit`

### DIFF
--- a/pngwrite.c
+++ b/pngwrite.c
@@ -2173,8 +2173,7 @@ png_image_write_main(png_voidp argument)
     * before it is written.  This only applies when the input is 16-bit and
     * either there is an alpha channel or it is converted to 8-bit.
     */
-   if ((linear != 0 && alpha != 0 ) ||
-       (colormap == 0 && display->convert_to_8bit != 0))
+   if (linear != 0 && (alpha != 0 || display->convert_to_8bit != 0))
    {
       png_bytep row = png_voidcast(png_bytep, png_malloc(png_ptr,
           png_get_rowbytes(png_ptr, info_ptr)));


### PR DESCRIPTION
The condition guarding the pre-transform path incorrectly allowed 8-bit input data to enter `png_write_image_8bit()` which expects 16-bit input. This caused out-of-bounds reads when processing 8-bit grayscale+alpha images with `convert_to_8bit = 1`.

The second part of the condition, i.e.
```colormap == 0 && convert_to_8bit != 0```
failed to verify that input was 16-bit, i.e.
```linear != 0```
contradicting the comment
```/* [...] This only applies when the input is 16-bit [...] */```

The fix consists in restructuring the condition to ensure both the `alpha` path and the `convert_to_8bit` path require linear (16-bit) input:

```if (linear != 0 && (alpha != 0 || display->convert_to_8bit != 0))```

This makes the code match its documentation and prevents treating 8-bit buffers as 16-bit data.

Reported-by: Samsung-PENTEST <Samsung-PENTEST@users.noreply.github.com>
Analyzed-by: degrigis <degrigis@users.noreply.github.com>