### PR TITLE
Fix a heap buffer overflow in `png_image_finish_read`

### DIFF
--- a/pngread.c
+++ b/pngread.c
@@ -4040,6 +4040,20 @@ png_image_finish_read(png_imagep image, png_const_colorp background,
                   int result;
                   png_image_read_control display;
 
+                  /* Reject bit depth mismatches to avoid buffer overflows. */
+                  png_uint_32 ihdr_bit_depth =
+                      image->opaque->png_ptr->bit_depth;
+                  int requested_linear =
+                      (image->format & PNG_FORMAT_FLAG_LINEAR) != 0;
+                  if (ihdr_bit_depth == 16 && !requested_linear)
+                     return png_image_error(image,
+                         "png_image_finish_read: "
+                         "16-bit PNG must use 16-bit output format");
+                  if (ihdr_bit_depth < 16 && requested_linear)
+                     return png_image_error(image,
+                         "png_image_finish_read: "
+                         "8-bit PNG must not use 16-bit output format");
+
                   memset(&display, 0, (sizeof display));
                   display.image = image;
                   display.buffer = buffer;

--- a/pngread.c
+++ b/pngread.c
@@ -3129,6 +3129,54 @@ png_image_read_colormapped(png_voidp argument)
    }
 }
 
+/* Row reading for interlaced 16-to-8 bit depth conversion with local buffer. */
+static int
+png_image_read_direct_scaled(png_voidp argument)
+{
+   png_image_read_control *display = png_voidcast(png_image_read_control*,
+       argument);
+   png_imagep image = display->image;
+   png_structrp png_ptr = image->opaque->png_ptr;
+   png_bytep local_row = png_voidcast(png_bytep, display->local_row);
+   png_bytep first_row = png_voidcast(png_bytep, display->first_row);
+   ptrdiff_t row_bytes = display->row_bytes;
+   int passes;
+
+   /* Handle interlacing. */
+   switch (png_ptr->interlaced)
+   {
+      case PNG_INTERLACE_NONE:
+         passes = 1;
+         break;
+
+      case PNG_INTERLACE_ADAM7:
+         passes = PNG_INTERLACE_ADAM7_PASSES;
+         break;
+
+      default:
+         png_error(png_ptr, "unknown interlace type");
+   }
+
+   /* Read each pass using local_row as intermediate buffer. */
+   while (--passes >= 0)
+   {
+      png_uint_32 y = image->height;
+      png_bytep output_row = first_row;
+
+      for (; y > 0; --y)
+      {
+         /* Read into local_row (gets transformed 8-bit data). */
+         png_read_row(png_ptr, local_row, NULL);
+
+         /* Copy from local_row to user buffer. */
+         memcpy(output_row, local_row, (size_t)row_bytes);
+         output_row += row_bytes;
+      }
+   }
+
+   return 1;
+}
+
 /* Just the row reading part of png_image_read. */
 static int
 png_image_read_composite(png_voidp argument)
@@ -3547,6 +3595,7 @@ png_image_read_direct(png_voidp argument)
    int linear = (format & PNG_FORMAT_FLAG_LINEAR) != 0;
    int do_local_compose = 0;
    int do_local_background = 0; /* to avoid double gamma correction bug */
+   int do_local_scale = 0; /* for interlaced 16-to-8 bit conversion */
    int passes = 0;
 
    /* Add transforms to ensure the correct output format is produced then check
@@ -3680,7 +3729,15 @@ png_image_read_direct(png_voidp argument)
             png_set_expand_16(png_ptr);
 
          else /* 8-bit output */
+         {
             png_set_scale_16(png_ptr);
+
+            /* For interlaced images, use local_row buffer to avoid overflow
+             * in png_combine_row() which writes using IHDR bit-depth.
+             */
+            if (png_ptr->interlaced != 0)
+               do_local_scale = 1;
+         }
 
          change &= ~PNG_FORMAT_FLAG_LINEAR;
       }
@@ -3957,6 +4014,24 @@ png_image_read_direct(png_voidp argument)
       return result;
    }
 
+   else if (do_local_scale != 0)
+   {
+      /* For interlaced 16-to-8 conversion, use an intermediate row buffer
+       * to avoid buffer overflows in png_combine_row. The local_row is sized
+       * for the transformed (8-bit) output, preventing the overflow that would
+       * occur if png_combine_row wrote 16-bit data directly to the user buffer.
+       */
+      int result;
+      png_voidp row = png_malloc(png_ptr, png_get_rowbytes(png_ptr, info_ptr));
+
+      display->local_row = row;
+      result = png_safe_execute(image, png_image_read_direct_scaled, display);
+      display->local_row = NULL;
+      png_free(png_ptr, row);
+
+      return result;
+   }
+
    else
    {
       png_alloc_size_t row_bytes = (png_alloc_size_t)display->row_bytes;
@@ -4039,20 +4114,6 @@ png_image_finish_read(png_imagep image, png_const_colorp background,
                {
                   int result;
                   png_image_read_control display;
-
-                  /* Reject bit depth mismatches to avoid buffer overflows. */
-                  png_uint_32 ihdr_bit_depth =
-                      image->opaque->png_ptr->bit_depth;
-                  int requested_linear =
-                      (image->format & PNG_FORMAT_FLAG_LINEAR) != 0;
-                  if (ihdr_bit_depth == 16 && !requested_linear)
-                     return png_image_error(image,
-                         "png_image_finish_read: "
-                         "16-bit PNG must use 16-bit output format");
-                  if (ihdr_bit_depth < 16 && requested_linear)
-                     return png_image_error(image,
-                         "png_image_finish_read: "
-                         "8-bit PNG must not use 16-bit output format");
 
                   memset(&display, 0, (sizeof display));
                   display.image = image;


### PR DESCRIPTION
Reject bit-depth mismatches between IHDR and the requested output format. When a 16-bit PNG is processed with an 8-bit output format request, `png_combine_row` writes using the IHDR depth before transformation, causing writes beyond the buffer allocated via `PNG_IMAGE_SIZE(image)`.

The validation establishes a safe API contract where `PNG_IMAGE_SIZE(image)` is guaranteed to be sufficient across the transformation pipeline.

Example overflow (32×32 pixels, 16-bit RGB to 8-bit RGBA):
- Input format: 16 bits/channel × 3 channels = 6144 bytes
- Output buffer: 8 bits/channel × 4 channels = 4096 bytes
- Overflow: 6144 bytes - 4096 bytes = 2048 bytes

Larger images produce proportionally larger overflows. For example, for 256×256 pixels, the overflow is 131072 bytes.

Reported-by: yosiimich <yosiimich@users.noreply.github.com>