### PR TITLE
Fixed RISC-V RVV code build.

### DIFF
--- a/riscv/filter_rvv_intrinsics.c
+++ b/riscv/filter_rvv_intrinsics.c
@@ -142,7 +142,7 @@ png_read_filter_row_avg_rvv(size_t len, size_t bpp, unsigned char* row,
       x = __riscv_vle8_v_u8m1(row, vl);
 
       /* a = (a + b) / 2, round to zero with vxrm = 2 */
-      a = __riscv_vaaddu_wx_u8m1(a, b, 2, vl);
+      a = __riscv_vaaddu_vv_u8m1(a, b, 2, vl);
 
       /* a += x */
       a = __riscv_vadd_vv_u8m1(a, x, vl);


### PR DESCRIPTION
`__riscv_vaaddu_wx_u8m1` intrinsic does not exist.

Passes build and tests in OpenCV project with Spacemit K1 board.