### PR TITLE
remove leftover ASM language from cmake project()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ set(PNGLIB_SHARED_VERSION ${PNGLIB_ABI_VERSION}.${PNGLIB_REVISION}.${PNGLIB_SUBR
 
 project(libpng
         VERSION ${PNGLIB_VERSION}
-        LANGUAGES C ASM)
+        LANGUAGES C)
 
 include(CheckCSourceCompiles)
 include(CheckLibraryExists)


### PR DESCRIPTION
Remove `ASM` as a cmake language since it is no longer used, as per comment in https://github.com/pnggroup/libpng/issues/770#issuecomment-3613866682


Close https://github.com/pnggroup/libpng/issues/770

