### PR TITLE
Typographical Fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,7 +87,7 @@ endif()
 option(PNG_TESTS "Build the libpng tests" ON)
 
 # Same as above, but for the third-party tools.
-# Although these tools are targetted at development environments only,
+# Although these tools are targeted at development environments only,
 # the users are allowed to override the option to build by default.
 if(ANDROID OR IOS)
   option(PNG_TOOLS "Build the libpng tools" OFF)
@@ -723,7 +723,7 @@ function(create_symlink DEST_FILE)
     message(FATAL_ERROR "create_symlink: Missing arguments: FILE or TARGET")
   endif()
   if(_SYM_FILE AND _SYM_TARGET)
-    message(FATAL_ERROR "create_symlink: Mutually-exlusive arguments:"
+    message(FATAL_ERROR "create_symlink: Mutually-exclusive arguments:"
                         "FILE (${_SYM_FILE}) and TARGET (${_SYM_TARGET})")
   endif()
 

--- a/arm/arm_init.c
+++ b/arm/arm_init.c
@@ -99,7 +99,7 @@ png_target_do_expand_palette_neon(png_struct *png_ptr, png_row_info *row_info,
     *    the original code in pngrtran.c  That code is now here.
     *
     * 3) The original code takes pointers to the end of the input and the end of
-    *    the output; this is the way png_do_expand_palette works becuase it
+    *    the output; this is the way png_do_expand_palette works because it
     *    has to copy down from the end (otherwise it would overwrite the input
     *    data before it read it).  Note that the row buffer is aliased by
     *    these two pointers.

--- a/arm/palette_neon_intrinsics.c
+++ b/arm/palette_neon_intrinsics.c
@@ -43,7 +43,7 @@ png_riffle_palette_neon(png_byte *riffled_palette, const png_color *palette,
       riffled_palette[(i << 2) + 3] = trans_alpha[i];
 }
 
-/* Expands a palettized row into RGBA8. */
+/* Expands a palletized row into RGBA8. */
 static png_uint_32
 png_target_do_expand_palette_rgba8_neon(const png_uint_32 *riffled_palette,
     png_uint_32 row_width, const png_byte **ssp, png_byte **ddp)
@@ -85,7 +85,7 @@ png_target_do_expand_palette_rgba8_neon(const png_uint_32 *riffled_palette,
    return i;
 }
 
-/* Expands a palettized row into RGB8. */
+/* Expands a palletized row into RGB8. */
 static png_uint_32
 png_target_do_expand_palette_rgb8_neon(const png_color *paletteIn,
     png_uint_32 row_width, const png_byte **ssp, png_byte **ddp)

--- a/contrib/libtests/pngstest.c
+++ b/contrib/libtests/pngstest.c
@@ -2790,7 +2790,7 @@ compare_two_images(Image *a, Image *b, int via_linear,
     * If an alpha channel has been *added* then it must have the relevant opaque
     * value (255 or 65535).
     *
-    * The fist two the tests (in the order given above) (using the boolean
+    * The first two tests (in the order given above) (using the boolean
     * equivalence !a && !b == !(a || b))
     */
    if (!(((formata ^ formatb) & PNG_FORMAT_FLAG_LINEAR) |

--- a/contrib/libtests/pngvalid.c
+++ b/contrib/libtests/pngvalid.c
@@ -6179,7 +6179,7 @@ image_pixel_add_alpha(image_pixel *this, const standard_display *display,
             this->have_tRNS = 0;
 
             /* Check the input, original, channel value here against the
-             * original tRNS gray chunk valie.
+             * original tRNS gray chunk value.
              */
             if (this->red == display->transparent.red)
                this->alphaf = 0;
@@ -7514,7 +7514,7 @@ static struct
    double green_coefficient;
    double blue_coefficient;
 
-   /* Set if the coeefficients have been overridden. */
+   /* Set if the coefficients have been overridden. */
    int coefficients_overridden;
 } data;
 
@@ -8988,7 +8988,7 @@ image_transform_test_counter(png_uint_32 counter, unsigned int max)
       /* For max 0 or 1 continue until the counter overflows: */
       counter >>= 1;
 
-      /* Continue if any entry hasn't reacked the max. */
+      /* Continue if any entry hasn't reached the max. */
       if (max > 1 && next->local_use < max)
          return 1;
       next = next->list;
@@ -9674,7 +9674,7 @@ gamma_component_validate(const char *name, const validate_info *vi,
        *  od: encoded result from libpng
        */
 
-      /* Now we have the numbers for real errors, both absolute values as as a
+      /* Now we have the numbers for real errors, both absolute values as a
        * percentage of the correct value (output):
        */
       error = fabs(input_sample-output);
@@ -11648,7 +11648,7 @@ main(int argc, char **argv)
 #  endif
 
    /* The following allows results to pass if they correspond to anything in the
-    * transformed range [input-.5,input+.5]; this is is required because of the
+    * transformed range [input-.5,input+.5]; this is required because of the
     * way libpng treats the 16_TO_8 flag when building the gamma tables in
     * releases up to 1.6.0.
     *

--- a/contrib/pngminus/README.txt
+++ b/contrib/pngminus/README.txt
@@ -53,7 +53,7 @@ program are some elementary routines to read / write pgm- and ppm-files.
 It does not handle B&W pbm-files, but instead you could do pgm with bit-
 depth 1.
 
-The downside of this approach is that you can not use them on images
+The downside of this approach is that you cannot use them on images
 that require blocks of memory bigger than 64k (the DOS version). For
 larger images you will get an out-of-memory error.
 

--- a/contrib/visupng/VisualPng.c
+++ b/contrib/visupng/VisualPng.c
@@ -832,7 +832,7 @@ BOOL FillBitmap (
         cxNewSize = cxWinSize - 2 * MARGIN;
         cyNewSize = cyWinSize - 2 * MARGIN;
 
-        /* stretch the image to it's window determined size */
+        /* stretch the image to its window determined size */
 
         /* the following two are mathematically the same, but the first
          * has side-effects because of rounding

--- a/intel/check.h
+++ b/intel/check.h
@@ -9,7 +9,7 @@
  * For conditions of distribution and use, see the disclaimer
  * and license in png.h
  */
-/* PNG_INTEL_SSE_IMPLEMENTATION is used in the actual implementation to selecct
+/* PNG_INTEL_SSE_IMPLEMENTATION is used in the actual implementation to select
  * the correct code.
  */
 #if defined(__SSE4_1__) || defined(__AVX__)

--- a/manuals/libpng-history.txt
+++ b/manuals/libpng-history.txt
@@ -314,7 +314,7 @@ never got around to actually numbering the error messages. The function
 png_set_strip_error_numbers() was removed from the library by default.
 
 The png_zalloc() and png_zfree() functions are no longer exported.
-The png_zalloc() function no longer zeroes out the memory that it
+The png_zalloc() function no longer zeros out the memory that it
 allocates.  Applications that called png_zalloc(png_ptr, number, size)
 can call png_calloc(png_ptr, number*size) instead, and can call
 png_free() instead of png_zfree().

--- a/manuals/libpng-manual.txt
+++ b/manuals/libpng-manual.txt
@@ -2312,7 +2312,7 @@ libpng provides two macros to help you in 1.5 and later versions:
    png_uint_32 height = PNG_PASS_ROWS(image_height, pass_number);
 
 Respectively these tell you the width and height of the sub-image
-corresponding to the numbered pass.  'pass' is in in the range 0 to 6 -
+corresponding to the numbered pass.  'pass' is in the range 0 to 6 -
 this can be confusing because the specification refers to the same passes
 as 1 to 7!  Be careful, you must check both the width and height before
 calling png_read_rows() and not call it for that pass if either is zero.
@@ -3286,7 +3286,7 @@ disclaimer until after, so viewers working over modem connections
 don't have to wait for the disclaimer to go over the modem before
 they start seeing the image.  Finally, keywords should be full
 words, not abbreviations.  Keywords and text are in the ISO 8859-1
-(Latin-1) character set (a superset of regular ASCII) and can not
+(Latin-1) character set (a superset of regular ASCII) and cannot
 contain NUL characters, and should not contain control or other
 unprintable characters.  To make the comments widely readable, stick
 with basic ASCII, and avoid machine specific character set extensions
@@ -3687,7 +3687,7 @@ point to libpng-allocated storage with the following function:
 
 This function may be safely called when the relevant storage has
 already been freed, or has not yet been allocated, or was allocated
-by the user  and not by libpng,  and will in those cases do nothing.
+by the user and not by libpng,  and will in those cases do nothing.
 The "seq" parameter is ignored if only one item of the selected data
 type, such as PLTE, is allowed.  If "seq" is not -1, and multiple items
 are allowed for the data type identified in the mask, such as text or

--- a/png.c
+++ b/png.c
@@ -1142,7 +1142,7 @@ png_xy_from_XYZ(png_xy *xy, const png_XYZ *XYZ)
       return 1;
 
    /* The reference white is simply the sum of the end-point (X,Y,Z) vectors so
-    * the fillowing calculates (X+Y+Z) of the reference white (media white,
+    * the following calculates (X+Y+Z) of the reference white (media white,
     * encoding white) itself:
     */
    d = dblue;
@@ -1187,9 +1187,9 @@ png_XYZ_from_xy(png_XYZ *XYZ, const png_xy *xy)
     * (-0.0770) because the PNG spec itself requires the xy values to be
     * unsigned.  whitey is also required to be 5 or more to avoid overflow.
     *
-    * Instead the upper limits have been relaxed to accomodate ACES AP1 where
+    * Instead the upper limits have been relaxed to accommodate ACES AP1 where
     * redz ends up as -600 (-0.006).  ProPhotoRGB was already "in range."
-    * The new limit accomodates the AP0 and AP1 ranges for z but not AP0 redy.
+    * The new limit accommodates the AP0 and AP1 ranges for z but not AP0 redy.
     */
    const png_fixed_point fpLimit = PNG_FP_1+(PNG_FP_1/10);
    if (xy->redx   < 0 || xy->redx > fpLimit) return 1;
@@ -1300,7 +1300,7 @@ png_XYZ_from_xy(png_XYZ *XYZ, const png_xy *xy)
     *    red-scale + green-scale + blue-scale = 1/white-y = white-scale
     *
     * So now we have a Cramer's rule solution where the determinants are just
-    * 3x3 - far more tractible.  Unfortunately 3x3 determinants still involve
+    * 3x3 - far more tractable.  Unfortunately 3x3 determinants still involve
     * multiplication of three coefficients so we can't guarantee to avoid
     * overflow in the libpng fixed point representation.  Using Cramer's rule in
     * floating point is probably a good choice here, but it's not an option for
@@ -1669,7 +1669,7 @@ png_icc_check_header(const png_struct *png_ptr, const char *name,
     * into R, G and B channels.
     *
     * Previously it was suggested that an RGB profile on grayscale data could be
-    * handled.  However it it is clear that using an RGB profile in this context
+    * handled.  However it is clear that using an RGB profile in this context
     * must be an error - there is no specification of what it means.  Thus it is
     * almost certainly more correct to ignore the profile.
     */
@@ -2887,7 +2887,7 @@ png_gamma_significant(png_fixed_point gamma_val)
     *
     *    2.2/(2+51/256) == 1.00035524
     *
-    * I.e. vanishly small (<4E-4) but still detectable in 16-bit linear (+/-
+    * I.e. vanishingly small (<4E-4) but still detectable in 16-bit linear (+/-
     * 23).  Note that the Adobe choice seems to be something intended to give an
     * exact number with 8 binary fractional digits - it is the closest to 2.2
     * that is possible a base 2 .8p representation.

--- a/png.h
+++ b/png.h
@@ -2260,7 +2260,7 @@ PNG_EXPORT(int, png_get_text,
 #endif
 
 /* Note while png_set_text() will accept a structure whose text,
- * language, and  translated keywords are NULL pointers, the structure
+ * language, and translated keywords are NULL pointers, the structure
  * returned by png_get_text will always contain regular
  * zero-terminated C strings.  They might be empty strings but
  * they will never be NULL pointers.
@@ -3358,7 +3358,7 @@ PNG_EXPORT(int, png_image_write_to_memory,
  *           For backward compatibility the original options are defined as
  *           the 'new' hardware option.  libpng can be compiled without
  *           hardware support (check PNG_TARGET_SPECIFIC_CODE_SUPPORTED and
- *           the documenation in pngtarget.h).
+ *           the documentation in pngtarget.h).
  *
  * SOFTWARE: sometimes software optimizations actually result in performance
  *           decrease on some architectures or systems, or with some sets of

--- a/pngpriv.h
+++ b/pngpriv.h
@@ -743,7 +743,7 @@
  *
  * At present these index values are not exported (not part of the public API)
  * so can be changed at will.  For convenience the names are in lexical sort
- * order but with the critical chunks at the start in the order of occurence in
+ * order but with the critical chunks at the start in the order of occurrence in
  * a PNG.
  *
  * PNG_INFO_ values do not exist for every one of these chunk handles; for
@@ -1798,7 +1798,7 @@ PNG_INTERNAL_FUNCTION(void, png_ascii_from_fixed,
  * not valid it will be the index of a character in the supposed number.
  *
  * The format of a number is defined in the PNG extensions specification
- * and this API is strictly conformant to that spec, not anyone elses!
+ * and this API is strictly conformant to that spec, not anyone else's!
  *
  * The format as a regular expression is:
  *

--- a/pngread.c
+++ b/pngread.c
@@ -779,7 +779,7 @@ png_read_end(png_struct *png_ptr, png_info *info_ptr)
       png_read_finish_IDAT(png_ptr);
 
 #ifdef PNG_READ_CHECK_FOR_INVALID_INDEX_SUPPORTED
-   /* Report invalid palette index; added at libng-1.5.10 */
+   /* Report invalid palette index; added at libpng-1.5.10 */
    if (png_ptr->color_type == PNG_COLOR_TYPE_PALETTE &&
        png_ptr->num_palette_max >= png_ptr->num_palette)
       png_benign_error(png_ptr, "Read palette index exceeding num_palette");
@@ -1342,7 +1342,7 @@ png_image_is_not_sRGB(const png_struct *png_ptr)
     * png_struct::chromaticities always exists since the simplified API
     * requires rgb-to-gray.  The mDCV, cICP and cHRM chunks may all set it to
     * a non-sRGB value, so it needs to be checked but **only** if one of
-    * those chunks occured in the file.
+    * those chunks occurred in the file.
     */
    /* Highest priority: check to be safe. */
    if (png_has_chunk(png_ptr, cICP) || png_has_chunk(png_ptr, mDCV))
@@ -2962,7 +2962,7 @@ png_image_read_and_map(void *argument)
             png_byte *outrow = first_row + y * step_row;
             png_byte *row_end = outrow + width;
 
-            /* Read read the libpng data into the temporary buffer. */
+            /* Read the libpng data into the temporary buffer. */
             png_read_row(png_ptr, inrow, NULL);
 
             /* Now process the row according to the processing option, note

--- a/pngrtran.c
+++ b/pngrtran.c
@@ -213,7 +213,7 @@ png_set_strip_alpha(png_struct *png_ptr)
  *
  * Terminology (assuming power law, "gamma", encodings):
  *    "screen" gamma: a power law imposed by the output device when digital
- *    samples are converted to visible light output.  The EOTF - volage to
+ *    samples are converted to visible light output.  The EOTF - voltage to
  *    luminance on output.
  *
  *    "file" gamma: a power law used to encode luminance levels from the input
@@ -1345,7 +1345,7 @@ png_resolve_file_gamma(const png_struct *png_ptr)
    if (file_gamma != 0)
       return file_gamma;
 
-   /* If png_reciprocal oveflows it returns 0 which indicates to the caller that
+   /* If png_reciprocal overflows it returns 0 which indicates to the caller that
     * there is no usable file gamma.  (The checks added to png_set_gamma and
     * png_set_alpha_mode should prevent a screen_gamma which would overflow.)
     */
@@ -4852,7 +4852,7 @@ png_do_read_transformations(png_struct *png_ptr, png_row_info *row_info)
       {
 #ifdef PNG_TARGET_IMPLEMENTS_EXPAND_PALETTE
          /* Do not call 'png_do_expand_palette' if the SIMD implementation
-          * does it (note that this accomodates SIMD implementations which might
+          * does it (note that this accommodates SIMD implementations which might
           * only handle specific cases).
           */
          if (!png_target_do_expand_palette(png_ptr, row_info))

--- a/pngrutil.c
+++ b/pngrutil.c
@@ -436,7 +436,7 @@ png_inflate_claim(png_struct *png_ptr, png_uint_32 owner)
     * be gained by using this when it is known *if* the zlib stream itself does
     * not record the number; however, this is an illusion: the original writer
     * of the PNG may have selected a lower window size, and we really must
-    * follow that because, for systems with with limited capabilities, we
+    * follow that because, for systems with limited capabilities, we
     * would otherwise reject the application's attempts to use a smaller window
     * size (zlib doesn't have an interface to say "this or lower"!).
     */
@@ -992,7 +992,7 @@ png_handle_PLTE(png_struct *png_ptr, png_info *info_ptr, png_uint_32 length)
     * in the case of an 8-bit display with a decoder which controls the palette.
     *
     * The alternative here is to ignore the error and store the palette anyway;
-    * destroying the tRNS will definately cause problems.
+    * destroying the tRNS will definitely cause problems.
     *
     * NOTE: the case of PNG_COLOR_TYPE_PALETTE need not be considered because
     * the png_handle_ routines for the three 'after PLTE' chunks tRNS, bKGD and
@@ -1253,7 +1253,7 @@ png_handle_cHRM(png_struct *png_ptr, png_info *info_ptr, png_uint_32 length)
 
    /* png_set_cHRM may complain about some of the values but this doesn't matter
     * because it was a cHRM and it did have vaguely (if, perhaps, ridiculous)
-    * values.  Ridiculousity will be checked if the values are used later.
+    * values.  Ridiculosity will be checked if the values are used later.
     */
    png_set_cHRM_fixed(png_ptr, info_ptr, xy.whitex, xy.whitey, xy.redx, xy.redy,
          xy.greenx, xy.greeny, xy.bluex, xy.bluey);
@@ -2020,7 +2020,7 @@ png_handle_eXIf(png_struct *png_ptr, png_info *info_ptr, png_uint_32 length)
       return handled_error;
 
    /* PNGv3: the code used to check the byte order mark at the start for MM or
-    * II, however PNGv3 states that the the first 4 bytes should be checked.
+    * II, however PNGv3 states that the first 4 bytes should be checked.
     * The caller ensures that there are four bytes available.
     */
    {
@@ -3180,7 +3180,7 @@ static const struct
    png_uint_32 max_length :12; /* Length min, max in bytes */
    png_uint_32 min_length :8;
       /* Length errors on critical chunks have special handling to preserve the
-       * existing behaviour in libpng 1.6.  Anciallary chunks are checked below
+       * existing behaviour in libpng 1.6.  Ancillary chunks are checked below
        * and produce a 'benign' error.
        */
    png_uint_32 pos_before :4; /* PNG_HAVE_ values chunk must precede */
@@ -3188,7 +3188,7 @@ static const struct
       /* NOTE: PLTE, tRNS and bKGD require special handling which depends on
        * the colour type of the base image.
        */
-   png_uint_32 multiple   :1; /* Multiple occurences permitted */
+   png_uint_32 multiple   :1; /* Multiple occurrences permitted */
       /* This is enabled for PLTE because PLTE may, in practice, be optional */
 }
 read_chunks[PNG_INDEX_unknown] =
@@ -3222,7 +3222,7 @@ read_chunks[PNG_INDEX_unknown] =
 #  define CDIHDR      13U,   13U,  hIHDR,     0,        0
 #  define CDPLTE  NoCheck,    0U,      0, hIHDR,        1
       /* PLTE errors are only critical for colour-map images, consequently the
-       * hander does all the checks.
+       * handler does all the checks.
        */
 #  define CDIDAT  NoCheck,    0U,  aIDAT, hIHDR,        1
 #  define CDIEND  NoCheck,    0U,      0, aIDAT,        0

--- a/pngset.c
+++ b/pngset.c
@@ -2012,7 +2012,7 @@ png_set_benign_errors(png_struct *png_ptr, int allowed)
 #endif /* BENIGN_ERRORS */
 
 #ifdef PNG_CHECK_FOR_INVALID_INDEX_SUPPORTED
-   /* Whether to report invalid palette index; added at libng-1.5.10.
+   /* Whether to report invalid palette index; added at libpng-1.5.10.
     * It is possible for an indexed (color-type==3) PNG file to contain
     * pixels with invalid (out-of-range) indexes if the PLTE chunk has
     * fewer entries than the image's bit-depth would allow. We recover

--- a/pngsimd.c
+++ b/pngsimd.c
@@ -25,7 +25,7 @@
  *    png_target_impl
  *       string constant
  *       REQUIRED
- *       This must be a string naming the implemenation.
+ *       This must be a string naming the implementation.
  *
  *    png_target_free_data_impl
  *       static void png_target_free_data_impl(png_struct *)

--- a/pngstruct.h
+++ b/pngstruct.h
@@ -95,7 +95,7 @@ typedef enum
  * TODO: C23: convert these macros to C23 inlines (which are static).
  */
 #define png_chunk_flag_from_index(i) (0x80000000U >> (31 - (i)))
-   /* The flag coresponding to the given png_index enum value.  This is defined
+   /* The flag corresponding to the given png_index enum value.  This is defined
     * for png_unknown as well (until it reaches the value 32) but this should
     * not be relied on.
     */

--- a/pngtarget.h
+++ b/pngtarget.h
@@ -29,7 +29,7 @@
  *    PNG_TARGET_CODE_IMPLEMENTATION
  *
  * To the quoted relative path name of a single C file to include to obtain the
- * implementation of the the target specific code.  For example:
+ * implementation of the target specific code.  For example:
  *
  *    "arm/arm_init.c"
  *    "intel/intel_init.c"

--- a/pngwrite.c
+++ b/pngwrite.c
@@ -164,7 +164,7 @@ png_write_info_before_PLTE(png_struct *png_ptr, const png_info *info_ptr)
     * them.
     *
     * PNG v3: Chunks mDCV and cLLI provide ancillary information for the
-    * interpretation of the colourspace chunkgs but do not require support for
+    * interpretation of the colourspace chunks but do not require support for
     * those chunks so are outside the "COLORSPACE" check but before the write of
     * the colourspace chunks themselves.
     */

--- a/pngwutil.c
+++ b/pngwutil.c
@@ -1763,7 +1763,7 @@ png_write_iTXt(png_struct *png_ptr, int compression, const char *key,
    }
 
    new_key[++key_len] = PNG_COMPRESSION_TYPE_BASE;
-   ++key_len; /* for the keywod separator */
+   ++key_len; /* for the keyword separator */
 
    /* We leave it to the application to meet PNG-1.0 requirements on the
     * contents of the text.  PNG-1.0 through PNG-1.2 discourage the use of


### PR DESCRIPTION
Summary
- Corrected typos in comments, headers, manuals, and contrib docs.
- No functional changes.


![steepled-hands.png](https://raw.githubusercontent.com/THE-Spellchecker/THE-Website/refs/heads/main/steeple.png)