### PR TITLE
oss-fuzz: fix build.sh for/if

### DIFF
--- a/contrib/oss-fuzz/build.sh
+++ b/contrib/oss-fuzz/build.sh
@@ -66,10 +66,10 @@ find $SRC/libpng -name "*.png" | \
      xargs zip $OUT/${f}_seed_corpus.zip
 
 cp $SRC/libpng/contrib/oss-fuzz/png.dict $OUT/${f}.dict
+fi
 done
 
 cp $SRC/libpng/contrib/oss-fuzz/*.dict \
      $SRC/libpng/contrib/oss-fuzz/*.options $OUT/
 
-fi
 # end


### PR DESCRIPTION
@ctruta looks like there was a bad typo in #784

See https://oss-fuzz-build-logs.storage.googleapis.com/log-da505c2a-61f8-4eb9-b630-512f4110c5e6.txt