### PR TITLE
Backport security fixes from libpng18

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -650,6 +650,13 @@ if(PNG_TESTS AND PNG_SHARED)
     endforeach()
   endforeach()
 
+  # Regression test:
+  # Use stride_extra > 32767 to trigger row_bytes > 65535 for linear images.
+  png_add_test(NAME pngstest-large-stride
+               COMMAND pngstest
+               OPTIONS --stride-extra 33000 --tmpfile "large-stride-" --log
+               FILES "${CMAKE_CURRENT_SOURCE_DIR}/contrib/testpngs/rgb-alpha-16-linear.png")
+
   add_executable(pngunknown ${pngunknown_sources})
   target_link_libraries(pngunknown
                         PRIVATE png_shared)

--- a/contrib/libtests/pngstest.c
+++ b/contrib/libtests/pngstest.c
@@ -3577,6 +3577,33 @@ main(int argc, char **argv)
          opts |= NO_RESEED;
       else if (strcmp(arg, "--fault-gbg-warning") == 0)
          opts |= GBG_ERROR;
+      else if (strcmp(arg, "--stride-extra") == 0)
+      {
+         if (c+1 < argc)
+         {
+            char *ep;
+            unsigned long val = strtoul(argv[++c], &ep, 0);
+
+            if (ep > argv[c] && *ep == 0 && val <= 65535)
+               stride_extra = (int)val;
+
+            else
+            {
+               fflush(stdout);
+               fprintf(stderr, "%s: bad argument for --stride-extra: %s\n",
+                  argv[0], argv[c]);
+               exit(99);
+            }
+         }
+
+         else
+         {
+            fflush(stdout);
+            fprintf(stderr, "%s: missing argument for --stride-extra\n",
+               argv[0]);
+            exit(99);
+         }
+      }
       else if (strcmp(arg, "--tmpfile") == 0)
       {
          if (c+1 < argc)

--- a/pngread.c
+++ b/pngread.c
@@ -3225,9 +3225,11 @@ png_image_read_direct_scaled(void *argument)
        argument);
    png_image *image = display->image;
    png_struct *png_ptr = image->opaque->png_ptr;
+   png_info *info_ptr = image->opaque->info_ptr;
    png_byte *local_row = png_voidcast(png_byte *, display->local_row);
    png_byte *first_row = png_voidcast(png_byte *, display->first_row);
    ptrdiff_t row_bytes = display->row_bytes;
+   size_t copy_bytes = png_get_rowbytes(png_ptr, info_ptr);
    int passes;
 
    /* Handle interlacing. */
@@ -3257,7 +3259,7 @@ png_image_read_direct_scaled(void *argument)
          png_read_row(png_ptr, local_row, NULL);
 
          /* Copy from local_row to user buffer. */
-         memcpy(output_row, local_row, (size_t)row_bytes);
+         memcpy(output_row, local_row, copy_bytes);
          output_row += row_bytes;
       }
    }

--- a/pngrtran.c
+++ b/pngrtran.c
@@ -689,8 +689,8 @@ png_set_quantize(png_struct *png_ptr, png_color *palette,
                          break;
 
                      t->next = hash[d];
-                     t->left = (png_byte)i;
-                     t->right = (png_byte)j;
+                     t->left = png_ptr->palette_to_index[i];
+                     t->right = png_ptr->palette_to_index[j];
                      hash[d] = t;
                   }
                }

--- a/pngwrite.c
+++ b/pngwrite.c
@@ -1697,7 +1697,7 @@ png_write_image_16bit(void *argument)
 
       png_write_row(png_ptr,
           png_voidcast(const png_byte *, display->local_row));
-      input_row += (png_uint_16)display->row_bytes/(sizeof (png_uint_16));
+      input_row += display->row_bytes / 2;
    }
 
    return 1;
@@ -1823,7 +1823,7 @@ png_write_image_8bit(void *argument)
 
          png_write_row(png_ptr, png_voidcast(const png_byte *,
              display->local_row));
-         input_row += (png_uint_16)display->row_bytes/(sizeof (png_uint_16));
+         input_row += display->row_bytes / 2;
       } /* while y */
    }
 
@@ -1848,7 +1848,7 @@ png_write_image_8bit(void *argument)
          }
 
          png_write_row(png_ptr, output_row);
-         input_row += (png_uint_16)display->row_bytes/(sizeof (png_uint_16));
+         input_row += display->row_bytes / 2;
       }
    }
 
@@ -2167,7 +2167,7 @@ png_image_write_main(void *argument)
       ptrdiff_t row_bytes = display->row_stride;
 
       if (linear != 0)
-         row_bytes *= (sizeof (png_uint_16));
+         row_bytes *= 2;
 
       if (row_bytes < 0)
          row += (image->height-1) * (-row_bytes);

--- a/tests/pngstest-large-stride
+++ b/tests/pngstest-large-stride
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# Regression test:
+# Use stride_extra > 32767 to trigger row_bytes > 65535 for linear images.
+exec ./pngstest \
+     --stride-extra 33000 \
+     --tmpfile "large-stride-" \
+     --log "${srcdir}/contrib/testpngs/rgb-alpha-16-linear.png"


### PR DESCRIPTION
Backport CVE-addressed security fixes into develop. 

This is necessary because develop is the only branch that supports APNG.