### PR TITLE
Fix(genpng): Resolve heap overflow via 64-bit math

### DIFF
--- a/contrib/tools/genpng.c
+++ b/contrib/tools/genpng.c
@@ -792,15 +792,28 @@ main(int argc, const char **argv)
       * I don't see where the image gets rejected when the buffer is too
       * large before the malloc is attempted.
       */
+      
       if (image.height > ((size_t)(-1))/(8*image.width)) {
          fprintf(stderr, "genpng: image buffer would be too big");
          return 1;
       }
+      
 #endif
 
-      /* Create the buffer: */
-      buffer = malloc(PNG_IMAGE_SIZE(image));
-
+      /* Create the buffer:
+       * Buffer uses image dimensions provided directly to avoid overflows 
+       * On the off chance a large input is given, an error will be raised
+       */
+       
+      size_t total_alloc = (size_t)image.width * image.height * 8;
+       
+      if (total_alloc>=1099511627776){
+         fprintf(stderr, "genpng: Maximum size is 1099511627776 bytes. Requested %zu bytes", total_alloc);
+         return 1;
+      }
+       
+      buffer = malloc(total_alloc);
+      
       if (buffer != NULL)
       {
          png_uint_32 y;
@@ -812,7 +825,7 @@ main(int argc, const char **argv)
 
             /* Each pixel in each row: */
             for (x=0; x<image.width; ++x)
-               pixel(buffer + 4*(x + y*image.width), arg_list, nshapes, x, y);
+               pixel(buffer + 4*((size_t)x + y*image.width), arg_list, nshapes, x, y);
          }
 
          /* Write the result (to stdout) */

--- a/pngwutil.c
+++ b/pngwutil.c
@@ -220,26 +220,28 @@ png_write_chunk(png_struct *png_ptr, const png_byte *chunk_string,
 static png_alloc_size_t
 png_image_size(png_struct *png_ptr)
 {
-   /* Only return sizes up to the maximum of a png_uint_32; do this by limiting
-    * the width and height used to 15 bits.
+   /* Only return sizes up to the maximum of a png_uint_64; do this by limiting
+    * the width and height used to 32 bits. Maximum changed to 64-bit from 32-bit 
+    * to allow for larger pngs. Limit is also changed to 32-bit from 16-bit for 
+    * the same reason. Prevents heap-buffer overflow
     */
-   png_uint_32 h = png_ptr->height;
+   png_uint_64 h = png_ptr->height;
 
-   if (png_ptr->rowbytes < 32768 && h < 32768)
+   if (png_ptr->rowbytes < 2147483647 && h < 2147483647)
    {
       if (png_ptr->interlaced != 0)
       {
          /* Interlacing makes the image larger because of the replication of
           * both the filter byte and the padding to a byte boundary.
           */
-         png_uint_32 w = png_ptr->width;
+         png_uint_64 w = png_ptr->width;
          unsigned int pd = png_ptr->pixel_depth;
          png_alloc_size_t cb_base;
          int pass;
 
          for (cb_base=0, pass=0; pass<=6; ++pass)
          {
-            png_uint_32 pw = PNG_PASS_COLS(w, pass);
+            png_uint_64 pw = PNG_PASS_COLS(w, pass);
 
             if (pw > 0)
                cb_base += (PNG_ROWBYTES(pd, pw)+1) * PNG_PASS_ROWS(h, pass);


### PR DESCRIPTION
-Buffer and indexing arithmetic uses size_t 64-bit unsigned integer 
-Maximum limits during Interlacing changed from 16 bits to 32 bits 
-Handles memory requests up to physical RAM limits. Throws an error otherwise

Fixes Issue #777: Potential heap-buffer-overflow crash in genpng.c (Link:https://github.com/pnggroup/libpng/issues/777)