### PR TITLE
Fix wrong channel indices in png_image_read_and_map() RGB_ALPHA path

### DIFF
--- a/pngread.c
+++ b/pngread.c
@@ -3065,10 +3065,10 @@ png_image_read_and_map(void *argument)
                          */
                         if (inrow[0] & 0x80) back_i += 9; /* red */
                         if (inrow[0] & 0x40) back_i += 9;
-                        if (inrow[0] & 0x80) back_i += 3; /* green */
-                        if (inrow[0] & 0x40) back_i += 3;
-                        if (inrow[0] & 0x80) back_i += 1; /* blue */
-                        if (inrow[0] & 0x40) back_i += 1;
+                        if (inrow[1] & 0x80) back_i += 3; /* green */
+                        if (inrow[1] & 0x40) back_i += 3;
+                        if (inrow[2] & 0x80) back_i += 1; /* blue */
+                        if (inrow[2] & 0x40) back_i += 1;
 
                         *outrow = (png_byte)back_i;
                      }


### PR DESCRIPTION
In the PNG_CMAP_RGB_ALPHA case for semi-transparent pixels (alpha 64-195), all six bit checks used inrow[0] (red channel). The green and blue channels were never read, causing the colormap index to depend solely on the red value. Fix by using inrow[1] for green and inrow[2] for blue, matching the fully-opaque branch at line 3041.

Bug introduced in commit 871b1d0 (libpng 1.6.1beta05, 2013-03-02).

Closes #796 