### PR TITLE
Fix two copy-paste typos in colormap read and sPLT write

### DIFF
--- a/pngread.c
+++ b/pngread.c
@@ -2683,7 +2683,7 @@ png_image_read_colormap(void *argument)
                   {
                      r = back_r;
                      g = back_g;
-                     b = back_g;
+                     b = back_b;
                   }
 
                   /* Compare the newly-created color-map entry with the one the

--- a/pngwutil.c
+++ b/pngwutil.c
@@ -1271,7 +1271,7 @@ png_write_sPLT(png_struct *png_ptr, const png_sPLT_t *spalette)
    }
 #else
    ep=spalette->entries;
-   for (i = 0; i>spalette->nentries; i++)
+   for (i = 0; i<spalette->nentries; i++)
    {
       if (spalette->depth == 8)
       {


### PR DESCRIPTION
Fix wrong blue channel in png_image_read_colormap(): `b = back_g` should be `b = back_b` (pngread.c:2686). This caused PNG_RGB_INDEX() to compute the wrong 6x6x6 cube index when the background has green != blue, forcing a lossier compositing path.

Fix dead loop in png_write_sPLT(): `i > spalette->nentries` should be `i < spalette->nentries` (pngwutil.c:1274). The loop body never executed, producing a malformed sPLT chunk with CRC mismatch. Only affects builds without PNG_POINTER_INDEXING_SUPPORTED.

Closes #800