### PR TITLE
Add missing NULL pointer checks in four public API functions

### DIFF
--- a/pngrtran.c
+++ b/pngrtran.c
@@ -476,6 +476,9 @@ png_set_quantize(png_struct *png_ptr, png_color *palette,
    if (png_rtran_ok(png_ptr, 0) == 0)
       return;
 
+   if (palette == NULL)
+      return;
+
    png_ptr->transformations |= PNG_QUANTIZE;
 
    if (full_quantize == 0)

--- a/pngset.c
+++ b/pngset.c
@@ -324,7 +324,8 @@ png_set_eXIf_1(const png_struct *png_ptr, png_info *info_ptr,
    png_debug1(1, "in %s storage function", "eXIf");
 
    if (png_ptr == NULL || info_ptr == NULL ||
-       (png_ptr->mode & PNG_WROTE_eXIf) != 0)
+       (png_ptr->mode & PNG_WROTE_eXIf) != 0 ||
+       exif == NULL)
       return;
 
    new_exif = png_voidcast(png_byte *, png_malloc_warn(png_ptr, num_exif));
@@ -379,7 +380,7 @@ png_set_hIST(const png_struct *png_ptr, png_info *info_ptr,
 
    png_debug1(1, "in %s storage function", "hIST");
 
-   if (png_ptr == NULL || info_ptr == NULL)
+   if (png_ptr == NULL || info_ptr == NULL || hist == NULL)
       return;
 
    if (info_ptr->num_palette == 0 || info_ptr->num_palette

--- a/pngtrans.c
+++ b/pngtrans.c
@@ -84,7 +84,7 @@ png_set_shift(png_struct *png_ptr, const png_color_8 *true_bits)
 {
    png_debug(1, "in png_set_shift");
 
-   if (png_ptr == NULL)
+   if (png_ptr == NULL || true_bits == NULL)
       return;
 
    png_ptr->transformations |= PNG_SHIFT;


### PR DESCRIPTION
png_set_eXIf_1, png_set_hIST, png_set_shift, and png_set_quantize accept user-provided pointers but do not validate them for NULL before dereferencing, unlike peer functions (png_set_iCCP, png_set_PLTE, png_set_sBIT, png_set_tRNS) which do check.

Passing NULL causes an immediate SIGSEGV (denial of service).

Fixes #802