### PR TITLE
Validate shift bit depths in png_set_shift to prevent infinite loop

### DIFF
--- a/pngtrans.c
+++ b/pngtrans.c
@@ -87,6 +87,31 @@ png_set_shift(png_struct *png_ptr, const png_color_8 *true_bits)
    if (png_ptr == NULL || true_bits == NULL)
       return;
 
+   if ((png_ptr->color_type & PNG_COLOR_MASK_COLOR) != 0)
+   {
+      if (true_bits->red == 0 || true_bits->green == 0 ||
+          true_bits->blue == 0)
+      {
+         png_app_error(png_ptr, "png_set_shift: invalid shift value");
+         return;
+      }
+   }
+   else
+   {
+      if (true_bits->gray == 0)
+      {
+         png_app_error(png_ptr, "png_set_shift: invalid shift value");
+         return;
+      }
+   }
+
+   if ((png_ptr->color_type & PNG_COLOR_MASK_ALPHA) != 0 &&
+       true_bits->alpha == 0)
+   {
+      png_app_error(png_ptr, "png_set_shift: invalid shift value");
+      return;
+   }
+
    png_ptr->transformations |= PNG_SHIFT;
    png_ptr->shift = *true_bits;
 }


### PR DESCRIPTION
png_set_shift() did not validate that the png_color_8 fields are non-zero. When any channel's bit depth is 0, png_do_shift() enters an infinite loop (j -= 0 never terminates), causing a denial of service.

The read-side sBIT chunk parser (png_handle_sBIT in pngrutil.c) already rejects zero values via:

```
  for (i=0; i<truelen; ++i)
     if (buf[i] == 0 || buf[i] > sample_depth)
```

where truelen = png_ptr->channels covers all active channels including alpha. This commit adds equivalent per-channel validation on the write side: check red/green/blue (for color types) or gray, plus alpha when PNG_COLOR_MASK_ALPHA is set, and report invalid values via png_app_error.

The following PoC reproduces the issue:

```
#include <stdio.h>
#include <string.h>
#include <stdlib.h>
#include <unistd.h>
#include "png.h"

int main(void)
{
    alarm(3);  /* kill self after 3 seconds if stuck */

    png_structp png_ptr = png_create_write_struct(
        PNG_LIBPNG_VER_STRING, NULL, NULL, NULL);
    png_infop info_ptr = png_create_info_struct(png_ptr);

    FILE *fp = fopen("/dev/null", "wb");

    if (setjmp(png_jmpbuf(png_ptr)))
    {
        png_destroy_write_struct(&png_ptr, &info_ptr);
        fclose(fp);
        return 1;
    }

    png_init_io(png_ptr, fp);

    png_set_IHDR(png_ptr, info_ptr, 1, 1, 8,
        PNG_COLOR_TYPE_RGB, PNG_INTERLACE_NONE,
        PNG_COMPRESSION_TYPE_DEFAULT, PNG_FILTER_TYPE_DEFAULT);

    /* red=0 → shift_dec[0]=0 → infinite loop in png_do_shift */
    png_color_8 bits;
    memset(&bits, 0, sizeof(bits));
    bits.red   = 0;
    bits.green = 5;
    bits.blue  = 5;

    png_set_shift(png_ptr, &bits);
    png_write_info(png_ptr, info_ptr);

    png_byte row[3] = { 0xFF, 0x80, 0x40 };
    png_bytep rp = row;
    png_write_row(png_ptr, rp);  /* triggers png_do_shift → hangs */

    png_write_end(png_ptr, NULL);
    png_destroy_write_struct(&png_ptr, &info_ptr);
    fclose(fp);
    return 0;
}
```

Build it:
```
cc -fsanitize=address -g -o poc_shift_zero poc_shift_zero.c \
   -I. -Ibuild_asan build_asan/libpng18.a -lz -lm
```

Before fix: the process hangs in an infinite loop until killed.
After fix:

```
$ ./poc_shift_zero
libpng error: png_set_shift: invalid shift value
```

Fixes #804