### PR TITLE
png_handle_sPLT: Add explicit INT32_MAX guard before casting to png_i…

### DIFF
--- a/pngrutil.c
+++ b/pngrutil.c
@@ -1629,7 +1629,7 @@ png_handle_sPLT(png_struct *png_ptr, png_info *info_ptr, png_uint_32 length)
    dl = (png_uint_32)(data_length / (unsigned int)entry_size);
    max_dl = PNG_SIZE_MAX / (sizeof (png_sPLT_entry));
 
-   if (dl > max_dl)
+   if (dl > 0x7fffffffUL || dl > max_dl)
    {
       png_warning(png_ptr, "sPLT chunk too long");
       return handled_error;


### PR DESCRIPTION
Although current chunk length constraints prevent dl from exceeding INT32_MAX in practice, casting png_uint_32 to png_int_32 without an explicit bound check relies on implicit guarantees.

This patch adds an explicit INT32_MAX guard before the cast to eliminate implementation-defined behavior and improve defensive robustness.