### PR TITLE
Fix memory leak and API misuse in OSS-Fuzz harnesses

### DIFF
--- a/contrib/oss-fuzz/libpng_readapi_fuzzer.cc
+++ b/contrib/oss-fuzz/libpng_readapi_fuzzer.cc
@@ -40,13 +40,12 @@ static void test_png_read_png_api(const uint8_t *data, size_t size) {
     struct png_mem_buffer buffer = {data, size, 0};
     png_set_read_fn(png_ptr, &buffer, png_read_from_buffer);
 
-    /* Set up transformations before reading */
-    png_set_scale_16(png_ptr);
-    png_set_packing(png_ptr);
-    png_set_expand(png_ptr);
-
-    /* Use png_read_png which should trigger OSS_FUZZ_png_read_png path */
-    png_read_png(png_ptr, info_ptr, PNG_TRANSFORM_IDENTITY, NULL);
+    /* Use png_read_png with transform flags (libpng-manual.txt lines 1170-1171:
+       "You must use png_transforms and not call any png_set_transform()
+       functions when you use png_read_png().") */
+    png_read_png(png_ptr, info_ptr,
+                 PNG_TRANSFORM_SCALE_16 | PNG_TRANSFORM_PACKING | PNG_TRANSFORM_EXPAND,
+                 NULL);
 
     png_destroy_read_struct(&png_ptr, &info_ptr, NULL);
 }

--- a/contrib/oss-fuzz/libpng_transformations_fuzzer.cc
+++ b/contrib/oss-fuzz/libpng_transformations_fuzzer.cc
@@ -32,7 +32,13 @@ static void test_png_transformations(const uint8_t *data, size_t size) {
         return;
     }
 
+    /* Declare heap pointers before setjmp so they can be freed on longjmp.
+       Must be volatile per C standard §7.13.2.1: non-volatile locals modified
+       between setjmp and longjmp have indeterminate values after longjmp. */
+    volatile png_bytep row = NULL;
+
     if (setjmp(png_jmpbuf(png_ptr))) {
+        free((void*)row);
         png_destroy_read_struct(&png_ptr, &info_ptr, NULL);
         return;
     }
@@ -90,15 +96,16 @@ static void test_png_transformations(const uint8_t *data, size_t size) {
 
     /* Read image data to execute transformations */
     size_t rowbytes = png_get_rowbytes(png_ptr, info_ptr);
-    png_bytep row = (png_bytep)malloc(rowbytes);
+    row = (png_bytep)malloc(rowbytes);
     if (row) {
         int y;
         for (y = 0; y < height && y < 100; y++) { /* Limit rows for performance */
             png_read_row(png_ptr, row, NULL);
         }
-        free(row);
     }
 
+    free((void*)row);
+    row = NULL;
     png_destroy_read_struct(&png_ptr, &info_ptr, NULL);
 }
 
@@ -184,13 +191,12 @@ static void test_png_read_png_api(const uint8_t *data, size_t size) {
     struct png_mem_buffer buffer = {data, size, 0};
     png_set_read_fn(png_ptr, &buffer, png_read_from_buffer);
 
-    /* Set up transformations before reading */
-    png_set_scale_16(png_ptr);
-    png_set_packing(png_ptr);
-    png_set_expand(png_ptr);
-
-    /* Use png_read_png which should trigger OSS_FUZZ_png_read_png path */
-    png_read_png(png_ptr, info_ptr, PNG_TRANSFORM_IDENTITY, NULL);
+    /* Use png_read_png with transform flags (libpng-manual.txt lines 1170-1171:
+       "You must use png_transforms and not call any png_set_transform()
+       functions when you use png_read_png().") */
+    png_read_png(png_ptr, info_ptr,
+                 PNG_TRANSFORM_SCALE_16 | PNG_TRANSFORM_PACKING | PNG_TRANSFORM_EXPAND,
+                 NULL);
 
     png_destroy_read_struct(&png_ptr, &info_ptr, NULL);
 }


### PR DESCRIPTION
## Summary

Fixes two bugs in OSS-Fuzz harnesses (`contrib/oss-fuzz/`). These are **not** libpng bugs — they are harness defects that cause false positive reports.

Fixes https://github.com/pnggroup/libpng/issues/809

## Changes

### 1. Memory leak via longjmp (`libpng_transformations_fuzzer`)

`row` is allocated with `malloc` after `setjmp`. When `png_read_row` triggers `png_error` → `longjmp`, the error handler never frees `row`.

LeakSanitizer catches this on the **first seed input**, preventing the fuzzer from starting:

```
==14==ERROR: LeakSanitizer: detected memory leaks
Direct leak of 1 byte(s) allocated from:
    #1 test_png_transformations(...) libpng_transformations_fuzzer.cc:93
INFO: a leak has been found in the initial corpus.
```

**Fix**: Declare `row` as `volatile` before `setjmp` and free it in the error handler (required by C standard §7.13.2.1).

### 2. API misuse in both fuzzers

Both fuzzers call `png_set_scale_16()`, `png_set_packing()`, `png_set_expand()` before `png_read_png(..., PNG_TRANSFORM_IDENTITY, ...)`.

`libpng-manual.txt` (lines 1170–1171):
> "You must use png_transforms and not call any png_set_transform() functions when you use png_read_png()."

**Fix**: Replace `png_set_*` calls with `PNG_TRANSFORM_SCALE_16 | PNG_TRANSFORM_PACKING | PNG_TRANSFORM_EXPAND`.

## False Positive Impact

If left unfixed, any report from these fuzzers is a false positive. In the AI era, buggy harness patterns are increasingly copied by LLM-based harness generators, multiplying false positives across projects.

## Test plan

- [x] Fixed fuzzer runs without LeakSanitizer crash (28,155 executions in 30s, 0 crashes)
- [x] Coverage unchanged (53.5% → 53.6% lines) — confirms behavioral equivalence