### PR TITLE
OSS-Fuzz build check fixes:

### DIFF
--- a/contrib/oss-fuzz/build.sh
+++ b/contrib/oss-fuzz/build.sh
@@ -41,32 +41,27 @@ for f in libpng_read_fuzzer \
          libpng_readapi_fuzzer \
          libpng_transformations_fuzzer;
 do
-# build libpng_read_fuzzer.
-$CXX $CXXFLAGS -std=c++11 -I. \
-     $SRC/libpng/contrib/oss-fuzz/${f}.cc \
-     -o $OUT/${f} \
-     -lFuzzingEngine .libs/libpng16.a -lz
+    # build libpng_read_fuzzer.
+    $CXX $CXXFLAGS -std=c++11 -I. \
+         $SRC/libpng/contrib/oss-fuzz/${f}.cc \
+         -o $OUT/${f} \
+         -lFuzzingEngine .libs/libpng16.a -lz
 
-# only libfuzzer can run the nalloc targets
-if test "x$FUZZING_ENGINE" == 'xlibfuzzer'
-then
+    # only libfuzzer can run the nalloc targets
+    if test "x$FUZZING_ENGINE" == 'xlibfuzzer'
+    then
 
-# wrapper script to duplicate target, run with env var NALLOC_FREQ=32
-# having a separate target with allocations failures
-cat << EOF > $OUT/${f}_nalloc
-#!/bin/sh
-# LLVMFuzzerTestOneInput for fuzzer detection.
-this_dir=\$(dirname "\$0")
-NALLOC_FREQ=32 \$this_dir/${f} \$@
-EOF
-chmod +x $OUT/${f}_nalloc
+        # Duplicate fuzzer with '_nalloc' suffix
+        cp -p $OUT/${f} $OUT/${f}_nalloc
 
-# add seed corpus.
-find $SRC/libpng -name "*.png" | \
-     xargs zip $OUT/${f}_seed_corpus.zip
+        # add seed corpus.
+        find $SRC/libpng -name "*.png" | \
+            xargs zip $OUT/${f}_seed_corpus.zip
+        find $SRC/libpng -name "*.png" | \
+            xargs zip $OUT/${f}_nalloc_seed_corpus.zip
 
-cp $SRC/libpng/contrib/oss-fuzz/png.dict $OUT/${f}.dict
-fi
+        cp $SRC/libpng/contrib/oss-fuzz/png.dict $OUT/${f}.dict
+    fi
 done
 
 cp $SRC/libpng/contrib/oss-fuzz/*.dict \

--- a/contrib/oss-fuzz/libpng_colormap_fuzzer.cc
+++ b/contrib/oss-fuzz/libpng_colormap_fuzzer.cc
@@ -4,6 +4,12 @@
 #include <setjmp.h>
 #include <png.h>
 
+// A custom fuzzer initialization function
+extern "C" int LLVMFuzzerInitialize(int *argcp,char ***argvp) {
+
+  return 0;
+}
+
 /* Test png_image API and colormap functions */
 static void test_png_image_colormap(const uint8_t *data, size_t size) {
     png_image image;

--- a/contrib/oss-fuzz/libpng_read_fuzzer.cc
+++ b/contrib/oss-fuzz/libpng_read_fuzzer.cc
@@ -18,6 +18,7 @@
 #include <string.h>
 
 #include <vector>
+#include <string>
 
 #define PNG_INTERNAL
 #include "png.h"
@@ -95,6 +96,30 @@ void default_free(png_structp, png_voidp ptr) {
 }
 
 static const int kPngHeaderSize = 8;
+
+// Test string for suffix
+bool endsWith(const std::string& str, const std::string& suffix) {
+  if (str.length() >= suffix.length()) {
+    return str.compare(str.length() - suffix.length(), suffix.length(), suffix) == 0;
+  } else {
+    return false;
+  }
+}
+
+// A custom fuzzer initialization function
+extern "C" int LLVMFuzzerInitialize(int *argcp,char ***argvp) {
+  int argc = *argcp;
+  std::string exe_path = (*argvp)[0];
+  std::string nalloc_suffix("_nalloc");
+
+  if (endsWith(exe_path, nalloc_suffix))
+    {
+      setenv("NALLOC_FREQ","32",1);
+    }
+  nalloc_init(nullptr);
+
+  return 0;
+}
 
 // Entry point for LibFuzzer.
 // Roughly follows the libpng book example:

--- a/contrib/oss-fuzz/libpng_readapi_fuzzer.cc
+++ b/contrib/oss-fuzz/libpng_readapi_fuzzer.cc
@@ -4,6 +4,12 @@
 #include <setjmp.h>
 #include <png.h>
 
+// A custom fuzzer initialization function
+extern "C" int LLVMFuzzerInitialize(int *argcp,char ***argvp) {
+
+  return 0;
+}
+
 /* Memory buffer structure for PNG reading */
 struct png_mem_buffer {
     const uint8_t *data;

--- a/contrib/oss-fuzz/libpng_transformations_fuzzer.cc
+++ b/contrib/oss-fuzz/libpng_transformations_fuzzer.cc
@@ -4,6 +4,13 @@
 #include <setjmp.h>
 #include <png.h>
 
+
+// A custom fuzzer initialization function
+extern "C" int LLVMFuzzerInitialize(int *argcp,char ***argvp) {
+
+  return 0;
+}
+
 /* Memory buffer structure for PNG reading */
 struct png_mem_buffer {
     const uint8_t *data;


### PR DESCRIPTION
See libpng issue 815 for more details.

1. Replace FOO_nalloc scripts with binaries.
2. Add LLVMFuzzerInitialize() functions to all fuzzers.
3. The LLVMFuzzerInitialize() function in libpng_read_fuzzer adds NALLOC_FREQ=32 to the environment, and calls nalloc_init().
4. Add a seed corpus for FOO_nalloc fuzzers.