### PR TITLE
Spell check on pngstruct

### DIFF
--- a/png.h
+++ b/png.h
@@ -1000,6 +1000,10 @@ PNG_EXPORT(void, png_convert_from_struct_tm,
 /* Convert from time_t to png_time.  Uses gmtime() */
 PNG_EXPORT(void, png_convert_from_time_t,
    (png_time *ptime, time_t ttime));
+
+/* Raise error on invalid time */
+PNG_EXPORT(void, png_convert_from_time_t_strict,
+   (png_struct *png_ptr, png_time *ptime, time_t ttime));
 #endif /* CONVERT_tIME */
 
 #ifdef PNG_READ_EXPAND_SUPPORTED

--- a/pngstruct.h
+++ b/pngstruct.h
@@ -1,6 +1,6 @@
 /* pngstruct.h - internal structures for libpng
  *
- * Copyright (c) 2018-2025 Cosmin Truta
+ * Copyright (c) 2018-2026 Cosmin Truta
  * Copyright (c) 1998-2002,2004,2006-2018 Glenn Randers-Pehrson
  * Copyright (c) 1996-1997 Andreas Dilger
  * Copyright (c) 1995-1996 Guy Eric Schalnat, Group 42, Inc.
@@ -104,7 +104,7 @@ typedef enum
    (((png_ptr)->chunks & png_chunk_flag_from_index(i)) != 0)
    /* The chunk has been recorded in png_struct */
 
-#define png_file_add_chunk(pnt_ptr, i)\
+#define png_file_add_chunk(png_ptr, i)\
    ((void)((png_ptr)->chunks |= png_chunk_flag_from_index(i)))
    /* Record the chunk in the png_struct */
 

--- a/pngwrite.c
+++ b/pngwrite.c
@@ -537,12 +537,23 @@ png_convert_from_time_t(png_time *ptime, time_t ttime)
    tbuf = gmtime(&ttime);
    if (tbuf == NULL)
    {
-      /* TODO: add a safe function which takes a png_ptr argument and raises
-       * a png_error if the ttime argument is invalid and the call to gmtime
-       * fails as a consequence.
-       */
       memset(ptime, 0, sizeof(*ptime));
       return;
+   }
+
+   png_convert_from_struct_tm(ptime, tbuf);
+}
+
+void
+png_convert_from_time_t_strict(png_struct *png_ptr, png_time *ptime,
+   time_t ttime)
+{
+   struct tm *tbuf;
+
+   tbuf = gmtime(&ttime);
+   if (tbuf == NULL)
+   {
+      png_error(png_ptr, "invalid time value");
    }
 
    png_convert_from_struct_tm(ptime, tbuf);


### PR DESCRIPTION
The old pngstruct.h had the `png_ptr` set as `pnt_ptr` in `png_file_add_chunk` macro. Dates in  line 3 was also changed from 2025 to 2026.