### PR TITLE
fix: resolve use-after-free on png_ptr->trans_alpha

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -15,6 +15,7 @@ Authors, for copyright and licensing purposes.
  * Glenn Randers-Pehrson
  * Greg Roelofs
  * Guy Eric Schalnat
+ * Halil Oktay
  * James Yu
  * John Bowler
  * Joshua Inscoe

--- a/pngread.c
+++ b/pngread.c
@@ -788,12 +788,11 @@ png_read_destroy(png_structrp png_ptr)
 
 #if defined(PNG_tRNS_SUPPORTED) || \
     defined(PNG_READ_EXPAND_SUPPORTED) || defined(PNG_READ_BACKGROUND_SUPPORTED)
-   if ((png_ptr->free_me & PNG_FREE_TRNS) != 0)
-   {
-      png_free(png_ptr, png_ptr->trans_alpha);
-      png_ptr->trans_alpha = NULL;
-   }
-   png_ptr->free_me &= ~PNG_FREE_TRNS;
+   /* png_ptr->trans_alpha is always independently allocated (not aliased
+    * with info_ptr->trans_alpha), so free it unconditionally.
+    */
+   png_free(png_ptr, png_ptr->trans_alpha);
+   png_ptr->trans_alpha = NULL;
 #endif
 
    inflateEnd(&png_ptr->zstream);

--- a/pngrutil.c
+++ b/pngrutil.c
@@ -1771,10 +1771,6 @@ png_handle_tRNS(png_structrp png_ptr, png_inforp info_ptr, png_uint_32 length)
       return handled_error;
    }
 
-   /* TODO: this is a horrible side effect in the palette case because the
-    * png_struct ends up with a pointer to the tRNS buffer owned by the
-    * png_info.  Fix this.
-    */
    png_set_tRNS(png_ptr, info_ptr, readbuf, png_ptr->num_trans,
        &(png_ptr->trans_color));
    return handled_ok;

--- a/pngset.c
+++ b/pngset.c
@@ -1158,9 +1158,13 @@ png_set_tRNS(png_structrp png_ptr, png_inforp info_ptr,
 
        if (num_trans > 0 && num_trans <= PNG_MAX_PALETTE_LENGTH)
        {
-          /* Allocate info_ptr's copy of the transparency data. */
+          /* Allocate info_ptr's copy of the transparency data.
+           * Initialize all entries to fully opaque (0xff), then overwrite
+           * the first num_trans entries with the actual values.
+           */
           info_ptr->trans_alpha = png_voidcast(png_bytep,
               png_malloc(png_ptr, PNG_MAX_PALETTE_LENGTH));
+          memset(info_ptr->trans_alpha, 0xff, PNG_MAX_PALETTE_LENGTH);
           memcpy(info_ptr->trans_alpha, trans_alpha, (size_t)num_trans);
           info_ptr->free_me |= PNG_FREE_TRNS;
           info_ptr->valid |= PNG_INFO_tRNS;
@@ -1176,6 +1180,7 @@ png_set_tRNS(png_structrp png_ptr, png_inforp info_ptr,
           png_free(png_ptr, png_ptr->trans_alpha);
           png_ptr->trans_alpha = png_voidcast(png_bytep,
               png_malloc(png_ptr, PNG_MAX_PALETTE_LENGTH));
+          memset(png_ptr->trans_alpha, 0xff, PNG_MAX_PALETTE_LENGTH);
           memcpy(png_ptr->trans_alpha, trans_alpha, (size_t)num_trans);
        }
        else

--- a/pngset.c
+++ b/pngset.c
@@ -1154,28 +1154,35 @@ png_set_tRNS(png_structrp png_ptr, png_inforp info_ptr,
 
    if (trans_alpha != NULL)
    {
-       /* It may not actually be necessary to set png_ptr->trans_alpha here;
-        * we do it for backward compatibility with the way the png_handle_tRNS
-        * function used to do the allocation.
-        *
-        * 1.6.0: The above statement is incorrect; png_handle_tRNS effectively
-        * relies on png_set_tRNS storing the information in png_struct
-        * (otherwise it won't be there for the code in pngrtran.c).
-        */
-
        png_free_data(png_ptr, info_ptr, PNG_FREE_TRNS, 0);
 
        if (num_trans > 0 && num_trans <= PNG_MAX_PALETTE_LENGTH)
        {
-         /* Changed from num_trans to PNG_MAX_PALETTE_LENGTH in version 1.2.1 */
+          /* Allocate info_ptr's copy of the transparency data. */
           info_ptr->trans_alpha = png_voidcast(png_bytep,
               png_malloc(png_ptr, PNG_MAX_PALETTE_LENGTH));
           memcpy(info_ptr->trans_alpha, trans_alpha, (size_t)num_trans);
-
           info_ptr->free_me |= PNG_FREE_TRNS;
           info_ptr->valid |= PNG_INFO_tRNS;
+
+          /* Allocate an independent copy for png_struct, so that the
+           * lifetime of png_ptr->trans_alpha is decoupled from the
+           * lifetime of info_ptr->trans_alpha.  Previously these two
+           * pointers were aliased, which caused a use-after-free if
+           * png_free_data freed info_ptr->trans_alpha while
+           * png_ptr->trans_alpha was still in use by the row transform
+           * functions (e.g. png_do_expand_palette).
+           */
+          png_free(png_ptr, png_ptr->trans_alpha);
+          png_ptr->trans_alpha = png_voidcast(png_bytep,
+              png_malloc(png_ptr, PNG_MAX_PALETTE_LENGTH));
+          memcpy(png_ptr->trans_alpha, trans_alpha, (size_t)num_trans);
        }
-       png_ptr->trans_alpha = info_ptr->trans_alpha;
+       else
+       {
+          png_free(png_ptr, png_ptr->trans_alpha);
+          png_ptr->trans_alpha = NULL;
+       }
    }
 
    if (trans_color != NULL)

--- a/pngwrite.c
+++ b/pngwrite.c
@@ -1010,6 +1010,12 @@ png_write_destroy(png_structrp png_ptr)
    png_ptr->chunk_list = NULL;
 #endif
 
+#if defined(PNG_tRNS_SUPPORTED)
+   /* Free the independent copy of trans_alpha owned by png_struct. */
+   png_free(png_ptr, png_ptr->trans_alpha);
+   png_ptr->trans_alpha = NULL;
+#endif
+
    /* The error handling and memory handling information is left intact at this
     * point: the jmp_buf may still have to be freed.  See png_destroy_png_struct
     * for how this happens.


### PR DESCRIPTION
`png_set_tRNS()` aliases `png_ptr->trans_alpha` directly to `info_ptr->trans_alpha`  same heap buffer, two owners. Calling `png_free_data(PNG_FREE_TRNS)` frees the buffer through `info_ptr` but leaves `png_ptr->trans_alpha` dangling. Next row read hits `png_do_expand_palette()` and dereferences freed memory.

There was already a TODO about this in `png_handle_tRNS`:
```
/* TODO: this is a horrible side effect in the palette case because the
 * png_struct ends up with a pointer to the tRNS buffer owned by the
 * png_info.  Fix this.
 */
```

The fix gives `png_struct` its own copy of the buffer. Both `libpng16` and `libpng18` are affected.

ASan trace and screenshot below

<img width="1920" height="974" alt="lib" src="https://github.com/user-attachments/assets/e82be04f-ea6a-424d-b1ee-8f128103db6e" />


<details>
<summary>ASan trace (click to expand)</summary>

```bash
=================================================================
==28374==ERROR: AddressSanitizer: heap-use-after-free on address 0x511000000183 at pc 0x7f9623da3e58 bp 0x7ffffc866780 sp 0x7ffffc866778
READ of size 1 at 0x511000000183 thread T0
    #0 0x7f9623da3e57 in png_do_expand_palette /home/oblivionsage/Desktop/libpng/pngrtran.c:4455
    #1 0x7f9623da6e76 in png_do_read_transformations /home/oblivionsage/Desktop/libpng/pngrtran.c:4906
    #2 0x7f9623d7b3fe in png_read_row /home/oblivionsage/Desktop/libpng/pngread.c:481
    #3 0x55e1fab3250c in main /home/oblivionsage/Desktop/libpng/build/poc_trns_uaf.c:120
    #4 0x7f9623a93ca7 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #5 0x7f9623a93d64 in __libc_start_main_impl ../csu/libc-start.c:360
    #6 0x55e1fab31340 in _start (/home/oblivionsage/Desktop/libpng/build/poc_trns_uaf+0x2340) (BuildId: 5a43ca40b308725dc5d80627d27636c17fe7db80)

0x511000000183 is located 3 bytes inside of 256-byte region [0x511000000180,0x511000000280)
freed by thread T0 here:
    #0 0x7f9623ef38f8 in free ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:52
    #1 0x7f9623d73eb9 in png_free_default /home/oblivionsage/Desktop/libpng/pngmem.c:255
    #2 0x7f9623d73e8a in png_free /home/oblivionsage/Desktop/libpng/pngmem.c:244
    #3 0x7f9623d5f182 in png_free_data /home/oblivionsage/Desktop/libpng/png.c:522
    #4 0x55e1fab32423 in main /home/oblivionsage/Desktop/libpng/build/poc_trns_uaf.c:109
    #5 0x7f9623a93ca7 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58

previously allocated by thread T0 here:
    #0 0x7f9623ef4c57 in malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:69
    #1 0x7f9623d73b58 in png_malloc_base /home/oblivionsage/Desktop/libpng/pngmem.c:98
    #2 0x7f9623d73d26 in png_malloc /home/oblivionsage/Desktop/libpng/pngmem.c:181
    #3 0x7f9623dc196a in png_set_tRNS /home/oblivionsage/Desktop/libpng/pngset.c:1171
    #4 0x7f9623db04ae in png_handle_tRNS /home/oblivionsage/Desktop/libpng/pngrutil.c:1778
    #5 0x7f9623db6df8 in png_handle_chunk /home/oblivionsage/Desktop/libpng/pngrutil.c:3201
    #6 0x7f9623d79c81 in png_read_info /home/oblivionsage/Desktop/libpng/pngread.c:165
    #7 0x55e1fab3207b in main /home/oblivionsage/Desktop/libpng/build/poc_trns_uaf.c:88
    #8 0x7f9623a93ca7 in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58

SUMMARY: AddressSanitizer: heap-use-after-free /home/oblivionsage/Desktop/libpng/pngrtran.c:4455 in png_do_expand_palette
Shadow bytes around the buggy address:
  0x510fffffff00: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x510fffffff80: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x511000000000: fa fa fa fa fa fa fa fa fd fd fd fd fd fd fd fd
  0x511000000080: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x511000000100: fd fd fd fd fd fd fd fd fa fa fa fa fa fa fa fa
=>0x511000000180:[fd]fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x511000000200: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x511000000280: fa fa fa fa fa fa fa fa 00 00 00 00 00 00 00 00
  0x511000000300: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x511000000380: 00 00 00 00 00 00 00 00 fa fa fa fa fa fa fa fa
  0x511000000400: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==28374==ABORTING
```

</details>

