### PR TITLE
Add validation for iCCP profile length in png_get_iCCP and png_set_iCCP

### DIFF
--- a/pngget.c
+++ b/pngget.c
@@ -727,6 +727,11 @@ png_get_iCCP(const png_struct *png_ptr, png_info *info_ptr,
    {
       *name = info_ptr->iccp_name;
       *profile = info_ptr->iccp_profile;
+      if (info_ptr->iccp_proflen < 128)
+      {
+         png_warning(png_ptr, "Invalid iCCP profile length (too small)");
+         return 0;
+      }
       *proflen = png_get_uint_32(info_ptr->iccp_profile);
       /* This is somewhat irrelevant since the profile data returned has
        * actually been uncompressed.

--- a/pngset.c
+++ b/pngset.c
@@ -873,6 +873,13 @@ png_set_iCCP(const png_struct *png_ptr, png_info *info_ptr,
    if (compression_type != PNG_COMPRESSION_TYPE_BASE)
       png_app_error(png_ptr, "Invalid iCCP compression method");
 
+   // A valid ICC profile header must be exactly 128 bytes long.
+   if (proflen < 128)
+   {
+      png_app_error(png_ptr, "Invalid iCCP profile length (too small)");
+      return;
+   }
+
    length = strlen(name)+1;
    new_iccp_name = png_voidcast(char *, png_malloc_warn(png_ptr, length));
 


### PR DESCRIPTION
This patch is used to fix the heap-buffer-overflow problem as described in https://github.com/pnggroup/libpng/issues/828.

The root cause of this bug is insufficient validation for the input ICC profile length.

This patch fixes this bug by adding checks in the iCCP setting and getting functions.

As the [ICC Specification](https://www.color.org/specification/ICC.1-2022-05.pdf) (Section 7.2.1) requires at least 128 bytes for ICC header, this patch checks for such a length.