### PR TITLE
Avoid divison by zero with in simpilfied writer API

### DIFF
--- a/pngwrite.c
+++ b/pngwrite.c
@@ -2030,7 +2030,7 @@ png_image_write_main(void *argument)
    {
       unsigned int channels = PNG_IMAGE_PIXEL_CHANNELS(image->format);
 
-      if (image->width <= 0x7fffffffU/channels) /* no overflow */
+      if (image->width <= 0x7fffffffU/channels && image->width != 0) /* no overflow */
       {
          png_uint_32 check;
          png_uint_32 png_row_stride = image->width * channels;


### PR DESCRIPTION
This patch adds a check to avoid the division by zero bug mentioned in https://github.com/pnggroup/libpng/issues/830.

Normally, when we try to read an image with zero width, the reader will reject it with the following checks:

```
void /* PRIVATE */
png_check_IHDR(const png_struct *png_ptr,
    png_uint_32 width, png_uint_32 height, int bit_depth, ...)
{
   int error = 0;

   /* Check for width and height valid values */
   if (width == 0)
   {
      png_warning(png_ptr, "Image width is zero in IHDR");
      error = 1;
   }
   // ... other checks...
   
   if (error == 1)
      png_error(png_ptr, "Invalid IHDR data");
}
```
It is ok if we try to read such a malformed image.
But the checks for the image width in the simplified writer API are missing. This patch adds the check to avoid potential bugs. With this patch, the warning from UBSan was missing.