### PR TITLE
fix: prevent integer overflow in rowbytes computation across transforms

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -29,6 +29,7 @@ Authors, for copyright and licensing purposes.
  * Mans Rullgard
  * Matt Sarett
  * Mike Klein
+ * Mohammad Seet
  * Pascal Massimino
  * Paul Schmidt
  * Petr Simecek

--- a/arm/arm_init.c
+++ b/arm/arm_init.c
@@ -186,7 +186,7 @@ png_target_do_expand_palette_neon(png_struct *png_ptr, png_row_info *row_info,
          /* Finally update row_info to reflect the expanded output: */
          row_info->bit_depth = 8;
          row_info->pixel_depth = 32;
-         row_info->rowbytes = row_width * 4;
+         row_info->rowbytes = (size_t)row_width * 4;
          row_info->color_type = 6;
          row_info->channels = 4;
          return 1;
@@ -194,7 +194,7 @@ png_target_do_expand_palette_neon(png_struct *png_ptr, png_row_info *row_info,
       else
       {
          /* No tRNS chunk (num_trans == 0), expand to RGB not RGBA. */
-         png_byte *dp = row + (3/*RGB*/*row_width - 1);
+         png_byte *dp = row + ((size_t)3/*RGB*/*row_width - 1);
 
          png_uint_32 i = png_target_do_expand_palette_rgb8_neon(palette,
                row_info->width, &sp, &dp);
@@ -213,7 +213,7 @@ png_target_do_expand_palette_neon(png_struct *png_ptr, png_row_info *row_info,
 
          row_info->bit_depth = 8;
          row_info->pixel_depth = 24;
-         row_info->rowbytes = row_width * 3;
+         row_info->rowbytes = (size_t)row_width * 3;
          row_info->color_type = 2;
          row_info->channels = 3;
          return 1;

--- a/pngrtran.c
+++ b/pngrtran.c
@@ -2361,7 +2361,7 @@ png_do_unpack(png_row_info *row_info, png_byte *row)
       }
       row_info->bit_depth = 8;
       row_info->pixel_depth = (png_byte)(8 * row_info->channels);
-      row_info->rowbytes = row_width * row_info->channels;
+      row_info->rowbytes = (size_t)row_width * row_info->channels;
    }
 }
 #endif
@@ -2563,7 +2563,7 @@ png_do_scale_16_to_8(png_row_info *row_info, png_byte *row)
 
       row_info->bit_depth = 8;
       row_info->pixel_depth = (png_byte)(8 * row_info->channels);
-      row_info->rowbytes = row_info->width * row_info->channels;
+      row_info->rowbytes = (size_t)row_info->width * row_info->channels;
    }
 }
 #endif
@@ -2591,7 +2591,7 @@ png_do_chop(png_row_info *row_info, png_byte *row)
 
       row_info->bit_depth = 8;
       row_info->pixel_depth = (png_byte)(8 * row_info->channels);
-      row_info->rowbytes = row_info->width * row_info->channels;
+      row_info->rowbytes = (size_t)row_info->width * row_info->channels;
    }
 }
 #endif
@@ -2827,7 +2827,7 @@ png_do_read_filler(png_row_info *row_info, png_byte *row,
             *(--dp) = lo_filler;
             row_info->channels = 2;
             row_info->pixel_depth = 16;
-            row_info->rowbytes = row_width * 2;
+            row_info->rowbytes = (size_t)row_width * 2;
          }
 
          else
@@ -2842,7 +2842,7 @@ png_do_read_filler(png_row_info *row_info, png_byte *row,
             }
             row_info->channels = 2;
             row_info->pixel_depth = 16;
-            row_info->rowbytes = row_width * 2;
+            row_info->rowbytes = (size_t)row_width * 2;
          }
       }
 
@@ -2865,7 +2865,7 @@ png_do_read_filler(png_row_info *row_info, png_byte *row,
             *(--dp) = hi_filler;
             row_info->channels = 2;
             row_info->pixel_depth = 32;
-            row_info->rowbytes = row_width * 4;
+            row_info->rowbytes = (size_t)row_width * 4;
          }
 
          else
@@ -2882,7 +2882,7 @@ png_do_read_filler(png_row_info *row_info, png_byte *row,
             }
             row_info->channels = 2;
             row_info->pixel_depth = 32;
-            row_info->rowbytes = row_width * 4;
+            row_info->rowbytes = (size_t)row_width * 4;
          }
       }
 #endif
@@ -2906,7 +2906,7 @@ png_do_read_filler(png_row_info *row_info, png_byte *row,
             *(--dp) = lo_filler;
             row_info->channels = 4;
             row_info->pixel_depth = 32;
-            row_info->rowbytes = row_width * 4;
+            row_info->rowbytes = (size_t)row_width * 4;
          }
 
          else
@@ -2923,7 +2923,7 @@ png_do_read_filler(png_row_info *row_info, png_byte *row,
             }
             row_info->channels = 4;
             row_info->pixel_depth = 32;
-            row_info->rowbytes = row_width * 4;
+            row_info->rowbytes = (size_t)row_width * 4;
          }
       }
 
@@ -2950,7 +2950,7 @@ png_do_read_filler(png_row_info *row_info, png_byte *row,
             *(--dp) = hi_filler;
             row_info->channels = 4;
             row_info->pixel_depth = 64;
-            row_info->rowbytes = row_width * 8;
+            row_info->rowbytes = (size_t)row_width * 8;
          }
 
          else
@@ -2972,7 +2972,7 @@ png_do_read_filler(png_row_info *row_info, png_byte *row,
 
             row_info->channels = 4;
             row_info->pixel_depth = 64;
-            row_info->rowbytes = row_width * 8;
+            row_info->rowbytes = (size_t)row_width * 8;
          }
       }
 #endif
@@ -4451,7 +4451,7 @@ png_do_expand_palette(png_row_info *row_info, png_byte *row,
                }
                row_info->bit_depth = 8;
                row_info->pixel_depth = 32;
-               row_info->rowbytes = row_width * 4;
+               row_info->rowbytes = (size_t)row_width * 4;
                row_info->color_type = 6;
                row_info->channels = 4;
             }
@@ -4459,7 +4459,7 @@ png_do_expand_palette(png_row_info *row_info, png_byte *row,
             else
             {
                sp = row + (size_t)row_width - 1;
-               dp = row + (size_t)(row_width * 3) - 1;
+               dp = row + (size_t)row_width * 3 - 1;
                for (i = 0; i < row_width; i++)
                {
                   *dp-- = palette[*sp].blue;
@@ -4470,7 +4470,7 @@ png_do_expand_palette(png_row_info *row_info, png_byte *row,
 
                row_info->bit_depth = 8;
                row_info->pixel_depth = 24;
-               row_info->rowbytes = row_width * 3;
+               row_info->rowbytes = (size_t)row_width * 3;
                row_info->color_type = 2;
                row_info->channels = 3;
             }


### PR DESCRIPTION
## Summary

Several transform functions compute `row_info->rowbytes` as `row_width * N` where `row_width` is `png_uint_32` and `N` is an integer constant. Since `rowbytes` is `size_t` (64-bit on LP64 systems), but the multiplication is performed in 32-bit arithmetic, the result silently truncates when `row_width * N > UINT32_MAX`.

This truncated `rowbytes` value is then used for pointer arithmetic in downstream transform functions (e.g., `png_do_read_swap_alpha`, `png_do_read_invert_alpha`, `png_do_expand_16`) via patterns like `sp = row + row_info->rowbytes`, leading to heap buffer over-read and over-write.

## Trigger condition

The overflow is reachable when applications configure libpng with raised width limits via `png_set_user_limits()` or build with the shipped `nolimits.dfa` configuration (`PNG_USER_WIDTH_MAX = PNG_UINT_31_MAX`). The default limit of 1,000,000 prevents the overflow.

## Changes

This patch casts `row_width` to `size_t` before multiplication in all 15 affected `rowbytes` assignment sites, plus fixes 2 pointer arithmetic sites:

| File | Function | Sites |
|------|----------|-------|
| `pngrtran.c` | `png_do_unpack` | 1 |
| `pngrtran.c` | `png_do_scale_16_to_8` | 1 |
| `pngrtran.c` | `png_do_chop` | 1 |
| `pngrtran.c` | `png_do_read_filler` | 8 |
| `pngrtran.c` | `png_do_expand_palette` | 3 (includes cast-order fix) |
| `arm/arm_init.c` | `png_target_do_expand_palette_neon` | 3 |

The cast-order fix changes `(size_t)(row_width * 3)` to `(size_t)row_width * 3` — the former overflows in 32-bit before the cast.

## Testing

- All 36 existing tests pass (Debug build)
- All 36 tests pass under ASan + UBSan (no warnings)
- No functional change for widths within default limits