### PR TITLE
pngcp: fix -Wreturn-type warning in better_options

### DIFF
--- a/contrib/tools/pngcp.c
+++ b/contrib/tools/pngcp.c
@@ -2242,6 +2242,11 @@ better_options(const struct display *dp)
    }
 
    assert(0 && "unreached");
+#if defined(__GNUC__) || defined(__clang__)
+   __builtin_unreachable();
+#else
+   return 0;
+#endif
 }
 
 static void


### PR DESCRIPTION
Add a dummy return after the unreachable assert(0) at the end of the function to silence the compiler warning about control reaching the end of a non-void function.

- ref: https://sourceforge.net/p/libpng/code/merge-requests/10/

Fixes:
```c
../contrib/tools/pngcp.c: In function 'better_options':
../contrib/tools/pngcp.c:2172:1: warning: control reaches end of non-void function [-Wreturn-type]
 2172 | }
      | ^
```