### PR TITLE
fix: add overflow-checked size arithmetic for rowbytes computation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -390,6 +390,9 @@ set(pngstest_sources
 set(pnggetset_sources
     contrib/libtests/pnggetset.c
 )
+set(pngoverflow_sources
+    contrib/libtests/pngoverflow.c
+)
 set(pngunknown_sources
     contrib/libtests/pngunknown.c
 )
@@ -560,6 +563,15 @@ if(PNG_TESTS AND PNG_SHARED)
 
   png_add_test(NAME pnggetset
                COMMAND pnggetset)
+
+  # pngoverflow test:
+  # Overflow-checking primitives: png_mul_size, PNG_ROWBYTES.
+  add_executable(pngoverflow ${pngoverflow_sources})
+  target_link_libraries(pngoverflow
+                        PRIVATE png_shared)
+
+  png_add_test(NAME pngoverflow
+               COMMAND pngoverflow)
 
   # pngvalid tests:
   # Internal validation of standard and progressive reading,

--- a/Makefile.am
+++ b/Makefile.am
@@ -13,7 +13,7 @@ ACLOCAL_AMFLAGS = -I scripts/autoconf
 
 # test programs - run on make check, make distcheck
 if ENABLE_TESTS
-check_PROGRAMS= pngtest pnggetset pngunknown pngstest pngvalid pngimage pngcp
+check_PROGRAMS= pngtest pnggetset pngunknown pngstest pngvalid pngimage pngoverflow pngcp
 if HAVE_CLOCK_GETTIME
 check_PROGRAMS += timepng
 endif
@@ -59,6 +59,9 @@ pngimage_LDADD = libpng@PNGLIB_MAJOR@@PNGLIB_MINOR@.la
 
 timepng_SOURCES = contrib/libtests/timepng.c
 timepng_LDADD = libpng@PNGLIB_MAJOR@@PNGLIB_MINOR@.la
+
+pngoverflow_SOURCES = contrib/libtests/pngoverflow.c
+pngoverflow_LDADD = libpng@PNGLIB_MAJOR@@PNGLIB_MINOR@.la
 
 pngcp_SOURCES = contrib/tools/pngcp.c
 pngcp_LDADD = libpng@PNGLIB_MAJOR@@PNGLIB_MINOR@.la
@@ -110,7 +113,8 @@ TESTS =\
    tests/pngunknown-save\
    tests/pngunknown-vpAg\
    tests/pngimage-quick\
-   tests/pngimage-full
+   tests/pngimage-full\
+   tests/pngoverflow
 endif
 
 # man pages

--- a/arm/arm_init.c
+++ b/arm/arm_init.c
@@ -145,7 +145,7 @@ png_target_do_expand_palette_neon(png_struct *png_ptr, png_row_info *row_info,
           * way despite the fact that the comments in the neon palette code
           * obfuscate what is happening.
           */
-         png_byte *dp = row + (4/*RGBA*/*row_width - 1);
+         png_byte *dp = row + (4/*RGBA*/*(size_t)row_width - 1);
 
          /* Cosmin Truta: "Sometimes row_info->bit_depth has been changed to 8.
           * In these cases, the palette hasn't been riffled."
@@ -186,7 +186,7 @@ png_target_do_expand_palette_neon(png_struct *png_ptr, png_row_info *row_info,
          /* Finally update row_info to reflect the expanded output: */
          row_info->bit_depth = 8;
          row_info->pixel_depth = 32;
-         row_info->rowbytes = (size_t)row_width * 4;
+         row_info->rowbytes = png_rowbytes_checked(png_ptr, 32, row_width);
          row_info->color_type = 6;
          row_info->channels = 4;
          return 1;
@@ -213,7 +213,7 @@ png_target_do_expand_palette_neon(png_struct *png_ptr, png_row_info *row_info,
 
          row_info->bit_depth = 8;
          row_info->pixel_depth = 24;
-         row_info->rowbytes = (size_t)row_width * 3;
+         row_info->rowbytes = png_rowbytes_checked(png_ptr, 24, row_width);
          row_info->color_type = 2;
          row_info->channels = 3;
          return 1;

--- a/contrib/libtests/pngoverflow.c
+++ b/contrib/libtests/pngoverflow.c
@@ -1,0 +1,168 @@
+/* pngoverflow.c
+ *
+ * Copyright (c) 2026 Mohammad Seet
+ *
+ * This code is released under the libpng license.
+ * For conditions of distribution and use, see the disclaimer
+ * and license in png.h
+ *
+ * Test the overflow-checking primitives: png_mul_size,
+ * png_rowbytes_checked, and the updated PNG_ROWBYTES macro.
+ */
+
+/* pngpriv.h must be included before any system header or png.h */
+#include "../../pngpriv.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int errors = 0;
+
+static void
+check_mul_size(size_t a, size_t b, size_t expected, int expect_zero,
+    const char *desc)
+{
+   size_t result = png_mul_size(a, b);
+
+   if (expect_zero)
+   {
+      if (result != 0)
+      {
+         fprintf(stderr, "FAIL: %s: png_mul_size(%lu, %lu) = %lu,"
+             " expected 0 (overflow)\n",
+             desc, (unsigned long)a, (unsigned long)b,
+             (unsigned long)result);
+         errors++;
+      }
+   }
+
+   else
+   {
+      if (result != expected)
+      {
+         fprintf(stderr, "FAIL: %s: png_mul_size(%lu, %lu) = %lu,"
+             " expected %lu\n",
+             desc, (unsigned long)a, (unsigned long)b,
+             (unsigned long)result, (unsigned long)expected);
+         errors++;
+      }
+   }
+}
+
+static void
+check_rowbytes(unsigned int pixel_depth, png_uint_32 width,
+    size_t expected, const char *desc)
+{
+   size_t result = PNG_ROWBYTES(pixel_depth, width);
+
+   if (result != expected)
+   {
+      fprintf(stderr, "FAIL: %s: PNG_ROWBYTES(%u, %lu) = %lu,"
+          " expected %lu\n",
+          desc, pixel_depth, (unsigned long)width,
+          (unsigned long)result, (unsigned long)expected);
+      errors++;
+   }
+}
+
+int
+main(void)
+{
+   printf("Testing overflow-checking primitives...\n");
+
+   /* png_mul_size: normal cases */
+   check_mul_size(0, 0, 0, 0, "0*0");
+   check_mul_size(1, 0, 0, 0, "1*0");
+   check_mul_size(0, 1, 0, 0, "0*1");
+   check_mul_size(1, 1, 1, 0, "1*1");
+   check_mul_size(100, 200, 20000, 0, "100*200");
+   check_mul_size(1000000, 8, 8000000, 0, "1M*8");
+
+   /* png_mul_size: overflow cases */
+   check_mul_size(PNG_SIZE_MAX, 2, 0, 1, "SIZE_MAX*2");
+   check_mul_size(2, PNG_SIZE_MAX, 0, 1, "2*SIZE_MAX");
+   check_mul_size(PNG_SIZE_MAX / 2 + 1, 2, 0, 1, "SIZE_MAX/2+1 * 2");
+
+   /* png_mul_size: boundary */
+   check_mul_size(PNG_SIZE_MAX / 2, 2, (PNG_SIZE_MAX / 2) * 2, 0,
+       "SIZE_MAX/2 * 2");
+   check_mul_size(PNG_SIZE_MAX / 8, 8, (PNG_SIZE_MAX / 8) * 8, 0,
+       "SIZE_MAX/8 * 8");
+
+   /* PNG_ROWBYTES: normal cases (>= 8 bits per pixel) */
+   check_rowbytes(8, 100, 100, "8bpp 100w");
+   check_rowbytes(16, 100, 200, "16bpp 100w");
+   check_rowbytes(24, 100, 300, "24bpp 100w");
+   check_rowbytes(32, 100, 400, "32bpp 100w");
+   check_rowbytes(64, 100, 800, "64bpp 100w");
+
+   /* PNG_ROWBYTES: sub-byte pixels */
+   check_rowbytes(1, 1, 1, "1bpp 1w");
+   check_rowbytes(1, 8, 1, "1bpp 8w");
+   check_rowbytes(1, 9, 2, "1bpp 9w");
+   check_rowbytes(2, 4, 1, "2bpp 4w");
+   check_rowbytes(4, 2, 1, "4bpp 2w");
+   check_rowbytes(4, 3, 2, "4bpp 3w");
+
+   /* PNG_ROWBYTES: large widths that fit on this platform.  On 64-bit
+    * systems png_uint_32 * 8 always fits in size_t; on 32-bit systems
+    * the IHDR check limits width so that width * 8 <= SIZE_MAX.
+    */
+   check_rowbytes(32, 1000000, 4000000, "32bpp 1Mpx");
+   check_rowbytes(64, 1000000, 8000000, "64bpp 1Mpx");
+
+   /* Verify png_mul_size overflow detection with size_t-range values.
+    * These cannot be tested through PNG_ROWBYTES because png_uint_32
+    * width limits how large the inputs can be.
+    */
+   check_mul_size(PNG_SIZE_MAX / 4 + 1, 8, 0, 1,
+       "SIZE_MAX/4+1 * 8 overflow");
+
+   /* PNG_ROWBYTES >= 8 path at large png_uint_32 widths.  These
+    * exercise the updated macro's png_mul_size integration at scale.
+    *
+    * Use a runtime sizeof check instead of a preprocessor #if on
+    * SIZE_MAX, because SIZE_MAX is a constant expression, not a
+    * preprocessor integer constant, in many C89 environments.
+    */
+   if (sizeof(size_t) > 4)
+   {
+      /* 64-bit size_t: png_uint_32 * 8 always fits. */
+      check_rowbytes(8, (png_uint_32)0xFFFFFFFEUL,
+          (size_t)0xFFFFFFFEUL, "8bpp max-1 width 64bit");
+      check_rowbytes(24, (png_uint_32)0xFFFFFFFEUL,
+          (size_t)0xFFFFFFFEUL * 3, "24bpp max-1 width 64bit");
+      check_rowbytes(32, (png_uint_32)0xFFFFFFFEUL,
+          (size_t)0xFFFFFFFEUL * 4, "32bpp max-1 width 64bit");
+      check_rowbytes(64, (png_uint_32)0xFFFFFFFEUL,
+          (size_t)0xFFFFFFFEUL * 8, "64bpp max-1 width 64bit");
+   }
+
+   else
+   {
+      /* 32-bit size_t: 8 bpp still fits, higher bpp overflow to 0. */
+      check_rowbytes(8, (png_uint_32)0xFFFFFFFEUL,
+          (size_t)0xFFFFFFFEUL, "8bpp max-1 width 32bit");
+      check_rowbytes(32, (png_uint_32)0xFFFFFFFEUL,
+          0, "32bpp max-1 width 32bit overflow");
+      check_rowbytes(64, (png_uint_32)0xFFFFFFFEUL,
+          0, "64bpp max-1 width 32bit overflow");
+   }
+
+   /* NOTE: png_rowbytes_checked (the function that calls png_error on
+    * overflow) is PNG_INTERNAL and not exported by the shared library,
+    * so it cannot be tested from an external test binary.  On 64-bit
+    * targets, overflow through png_rowbytes_checked is also unreachable
+    * because png_uint_32 * 8 always fits in a 64-bit size_t.
+    */
+
+   if (errors == 0)
+   {
+      printf("PASS: all overflow checks passed\n");
+      return 0;
+   }
+
+   fprintf(stderr, "FAIL: %d overflow check(s) failed\n", errors);
+   return 1;
+}

--- a/png.c
+++ b/png.c
@@ -130,6 +130,40 @@ png_zfree(voidpf png_ptr, voidpf ptr)
    png_free(png_voidcast(const png_struct *,png_ptr), ptr);
 }
 
+/* Checked version of PNG_ROWBYTES: compute the number of bytes in a row
+ * given pixel_depth (bits per pixel) and width (pixels).  Calls png_error
+ * if the result would overflow size_t.
+ */
+size_t /* PRIVATE */
+png_rowbytes_checked(png_const_structrp png_ptr, unsigned int pixel_depth,
+    png_uint_32 width)
+{
+   size_t rowbytes;
+
+   if (pixel_depth >= 8)
+   {
+      size_t bytes_per_pixel = pixel_depth >> 3;
+
+      rowbytes = png_mul_size(width, bytes_per_pixel);
+
+      if (rowbytes == 0 && width != 0 && bytes_per_pixel != 0)
+         png_error(png_ptr, "Row has too many bytes to allocate in memory");
+   }
+
+   else
+   {
+      /* Sub-byte pixels: pixel_depth is 1, 2, or 4.  Since width fits in
+       * png_uint_32 and pixel_depth <= 4, the full intermediate
+       * (width * pixel_depth + 7) fits in 35 bits, which cannot overflow
+       * size_t (>= 32 bits on all supported platforms, and the 32-bit
+       * case is limited by png_check_IHDR).
+       */
+      rowbytes = ((size_t)width * pixel_depth + 7) >> 3;
+   }
+
+   return rowbytes;
+}
+
 /* Reset the CRC variable to 32 bits of 1's.  Care must be taken
  * in case CRC is > 32 bits to leave the top bits 0.
  */

--- a/pngpread.c
+++ b/pngpread.c
@@ -377,7 +377,7 @@ png_push_read_chunk(png_struct *png_ptr, png_info *info_ptr)
       png_ptr->process_mode = PNG_READ_IDAT_MODE;
       png_push_have_info(png_ptr, info_ptr);
       png_ptr->zstream.avail_out =
-          (uInt) PNG_ROWBYTES(png_ptr->pixel_depth,
+          (uInt) png_rowbytes_checked(png_ptr, png_ptr->pixel_depth,
           png_ptr->iwidth) + 1;
       png_ptr->zstream.next_out = png_ptr->row_buf;
       return;
@@ -714,8 +714,8 @@ png_process_IDAT_data(png_struct *png_ptr, png_byte *buffer,
       if (!(png_ptr->zstream.avail_out > 0))
       {
          /* TODO: WARNING: TRUNCATION ERROR: DANGER WILL ROBINSON: */
-         png_ptr->zstream.avail_out = (uInt)(PNG_ROWBYTES(png_ptr->pixel_depth,
-             png_ptr->iwidth) + 1);
+         png_ptr->zstream.avail_out = (uInt)(png_rowbytes_checked(png_ptr,
+             png_ptr->pixel_depth, png_ptr->iwidth) + 1);
 
          png_ptr->zstream.next_out = png_ptr->row_buf;
       }
@@ -805,7 +805,8 @@ png_push_process_row(png_struct *png_ptr)
    row_info.bit_depth = png_ptr->bit_depth;
    row_info.channels = png_ptr->channels;
    row_info.pixel_depth = png_ptr->pixel_depth;
-   row_info.rowbytes = PNG_ROWBYTES(row_info.pixel_depth, row_info.width);
+   row_info.rowbytes = png_rowbytes_checked(png_ptr, row_info.pixel_depth,
+       row_info.width);
 
    if (png_ptr->row_buf[0] > PNG_FILTER_VALUE_NONE)
    {

--- a/pngpriv.h
+++ b/pngpriv.h
@@ -529,10 +529,28 @@
 #define PNG_DIV65535(v24) (((v24) + 32895) >> 16)
 #define PNG_DIV257(v16) PNG_DIV65535((png_uint_32)(v16) * 255)
 
-/* Added to libpng-1.2.6 JB */
+/* Overflow-checked size_t multiplication.  Returns the product of (a) and
+ * (b) or 0 if the product would overflow size_t.  This uses the same
+ * division-based check as png_malloc_array_checked() in pngmem.c.
+ *
+ * NOTE: this is a macro; (a) and (b) are evaluated multiple times.
+ */
+#define png_mul_size(a, b) \
+    ((size_t)(b) != (size_t)0 && \
+     (size_t)(a) > PNG_SIZE_MAX / (size_t)(b) ? \
+     (size_t)0 : (size_t)(a) * (size_t)(b))
+
+/* Added to libpng-1.2.6 JB
+ *
+ * Since libpng 1.8.0 the >= 8 case uses png_mul_size to return 0 on
+ * overflow instead of silently wrapping.  For sub-byte pixel depths
+ * overflow is not possible because pixel_bits <= 4 and width fits in
+ * png_uint_32, so the full intermediate (width * pixel_bits + 7)
+ * fits in 35 bits.
+ */
 #define PNG_ROWBYTES(pixel_bits, width) \
     ((pixel_bits) >= 8 ? \
-    ((size_t)(width) * (((size_t)(pixel_bits)) >> 3)) : \
+    png_mul_size((width), ((size_t)(pixel_bits)) >> 3) : \
     (( ((size_t)(width) * ((size_t)(pixel_bits))) + 7) >> 3) )
 
 /* This returns the number of trailing bits in the last byte of a row, 0 if the
@@ -1624,6 +1642,16 @@ PNG_INTERNAL_FUNCTION(void, png_check_IHDR,
    (const png_struct *png_ptr,
     png_uint_32 width, png_uint_32 height, int bit_depth, int color_type,
     int interlace_type, int compression_type, int filter_type),
+   PNG_EMPTY);
+
+/* Added at libpng version 1.8.0 */
+/* Checked version of PNG_ROWBYTES that calls png_error on overflow.
+ * Use at allocation and initialization sites where png_structrp is
+ * available.
+ */
+PNG_INTERNAL_FUNCTION(size_t, png_rowbytes_checked,
+   (png_const_structrp png_ptr, unsigned int pixel_depth,
+    png_uint_32 width),
    PNG_EMPTY);
 
 /* Added at libpng version 1.5.10 */

--- a/pngread.c
+++ b/pngread.c
@@ -395,7 +395,8 @@ png_read_row(png_struct *png_ptr, png_byte *row, png_byte *dsp_row)
    row_info.bit_depth = png_ptr->bit_depth;
    row_info.channels = png_ptr->channels;
    row_info.pixel_depth = png_ptr->pixel_depth;
-   row_info.rowbytes = PNG_ROWBYTES(row_info.pixel_depth, row_info.width);
+   row_info.rowbytes = png_rowbytes_checked(png_ptr, row_info.pixel_depth,
+       row_info.width);
 
 #ifdef PNG_WARNINGS_SUPPORTED
    if (png_ptr->row_number == 0 && png_ptr->pass == 0)
@@ -1132,9 +1133,14 @@ png_read_png(png_struct *png_ptr, png_info *info_ptr,
    if (info_ptr->row_pointers == NULL)
    {
       png_uint_32 iptr;
+      size_t row_ptrs_size = png_mul_size(info_ptr->height,
+          (sizeof (png_byte *)));
 
-      info_ptr->row_pointers = png_voidcast(png_byte **, png_malloc(png_ptr,
-          info_ptr->height * (sizeof (png_byte *))));
+      if (row_ptrs_size == 0 && info_ptr->height != 0)
+         png_error(png_ptr, "Image is too tall to process");
+
+      info_ptr->row_pointers = png_voidcast(png_byte **,
+          png_malloc(png_ptr, row_ptrs_size));
 
       for (iptr=0; iptr<info_ptr->height; iptr++)
          info_ptr->row_pointers[iptr] = NULL;

--- a/pngrtran.c
+++ b/pngrtran.c
@@ -2251,7 +2251,8 @@ defined(PNG_READ_USER_TRANSFORM_SUPPORTED)
    info_ptr->pixel_depth = (png_byte)(info_ptr->channels *
        info_ptr->bit_depth);
 
-   info_ptr->rowbytes = PNG_ROWBYTES(info_ptr->pixel_depth, info_ptr->width);
+   info_ptr->rowbytes = png_rowbytes_checked(png_ptr, info_ptr->pixel_depth,
+       info_ptr->width);
 
    /* Adding in 1.5.4: cache the above value in png_struct so that we can later
     * check in png_rowbytes that the user buffer won't get overwritten.  Note
@@ -2361,7 +2362,7 @@ png_do_unpack(png_row_info *row_info, png_byte *row)
       }
       row_info->bit_depth = 8;
       row_info->pixel_depth = (png_byte)(8 * row_info->channels);
-      row_info->rowbytes = (size_t)row_width * row_info->channels;
+      row_info->rowbytes = png_mul_size(row_width, row_info->channels);
    }
 }
 #endif
@@ -2563,7 +2564,8 @@ png_do_scale_16_to_8(png_row_info *row_info, png_byte *row)
 
       row_info->bit_depth = 8;
       row_info->pixel_depth = (png_byte)(8 * row_info->channels);
-      row_info->rowbytes = (size_t)row_info->width * row_info->channels;
+      row_info->rowbytes = png_mul_size(row_info->width,
+          row_info->channels);
    }
 }
 #endif
@@ -2591,7 +2593,8 @@ png_do_chop(png_row_info *row_info, png_byte *row)
 
       row_info->bit_depth = 8;
       row_info->pixel_depth = (png_byte)(8 * row_info->channels);
-      row_info->rowbytes = (size_t)row_info->width * row_info->channels;
+      row_info->rowbytes = png_mul_size(row_info->width,
+          row_info->channels);
    }
 }
 #endif
@@ -2827,7 +2830,7 @@ png_do_read_filler(png_row_info *row_info, png_byte *row,
             *(--dp) = lo_filler;
             row_info->channels = 2;
             row_info->pixel_depth = 16;
-            row_info->rowbytes = (size_t)row_width * 2;
+            row_info->rowbytes = png_mul_size(row_width, 2);
          }
 
          else
@@ -2842,7 +2845,7 @@ png_do_read_filler(png_row_info *row_info, png_byte *row,
             }
             row_info->channels = 2;
             row_info->pixel_depth = 16;
-            row_info->rowbytes = (size_t)row_width * 2;
+            row_info->rowbytes = png_mul_size(row_width, 2);
          }
       }
 
@@ -2865,7 +2868,7 @@ png_do_read_filler(png_row_info *row_info, png_byte *row,
             *(--dp) = hi_filler;
             row_info->channels = 2;
             row_info->pixel_depth = 32;
-            row_info->rowbytes = (size_t)row_width * 4;
+            row_info->rowbytes = png_mul_size(row_width, 4);
          }
 
          else
@@ -2882,7 +2885,7 @@ png_do_read_filler(png_row_info *row_info, png_byte *row,
             }
             row_info->channels = 2;
             row_info->pixel_depth = 32;
-            row_info->rowbytes = (size_t)row_width * 4;
+            row_info->rowbytes = png_mul_size(row_width, 4);
          }
       }
 #endif
@@ -2906,7 +2909,7 @@ png_do_read_filler(png_row_info *row_info, png_byte *row,
             *(--dp) = lo_filler;
             row_info->channels = 4;
             row_info->pixel_depth = 32;
-            row_info->rowbytes = (size_t)row_width * 4;
+            row_info->rowbytes = png_mul_size(row_width, 4);
          }
 
          else
@@ -2923,7 +2926,7 @@ png_do_read_filler(png_row_info *row_info, png_byte *row,
             }
             row_info->channels = 4;
             row_info->pixel_depth = 32;
-            row_info->rowbytes = (size_t)row_width * 4;
+            row_info->rowbytes = png_mul_size(row_width, 4);
          }
       }
 
@@ -2950,7 +2953,7 @@ png_do_read_filler(png_row_info *row_info, png_byte *row,
             *(--dp) = hi_filler;
             row_info->channels = 4;
             row_info->pixel_depth = 64;
-            row_info->rowbytes = (size_t)row_width * 8;
+            row_info->rowbytes = png_mul_size(row_width, 8);
          }
 
          else
@@ -2972,7 +2975,7 @@ png_do_read_filler(png_row_info *row_info, png_byte *row,
 
             row_info->channels = 4;
             row_info->pixel_depth = 64;
-            row_info->rowbytes = (size_t)row_width * 8;
+            row_info->rowbytes = png_mul_size(row_width, 8);
          }
       }
 #endif
@@ -3063,7 +3066,8 @@ png_do_gray_to_rgb(png_row_info *row_info, png_byte *row)
       row_info->color_type |= PNG_COLOR_MASK_COLOR;
       row_info->pixel_depth = (png_byte)(row_info->channels *
           row_info->bit_depth);
-      row_info->rowbytes = PNG_ROWBYTES(row_info->pixel_depth, row_width);
+      row_info->rowbytes = png_mul_size(row_width,
+          row_info->pixel_depth >> 3);
    }
 }
 #endif
@@ -3310,7 +3314,8 @@ png_do_rgb_to_gray(png_struct *png_ptr, png_row_info *row_info, png_byte *row)
           ~PNG_COLOR_MASK_COLOR);
       row_info->pixel_depth = (png_byte)(row_info->channels *
           row_info->bit_depth);
-      row_info->rowbytes = PNG_ROWBYTES(row_info->pixel_depth, row_width);
+      row_info->rowbytes = png_rowbytes_checked(png_ptr,
+          row_info->pixel_depth, row_width);
    }
    return rgb_error;
 }
@@ -4451,7 +4456,7 @@ png_do_expand_palette(png_row_info *row_info, png_byte *row,
                }
                row_info->bit_depth = 8;
                row_info->pixel_depth = 32;
-               row_info->rowbytes = (size_t)row_width * 4;
+               row_info->rowbytes = png_mul_size(row_width, 4);
                row_info->color_type = 6;
                row_info->channels = 4;
             }
@@ -4470,7 +4475,7 @@ png_do_expand_palette(png_row_info *row_info, png_byte *row,
 
                row_info->bit_depth = 8;
                row_info->pixel_depth = 24;
-               row_info->rowbytes = (size_t)row_width * 3;
+               row_info->rowbytes = png_mul_size(row_width, 3);
                row_info->color_type = 2;
                row_info->channels = 3;
             }
@@ -4636,8 +4641,8 @@ png_do_expand(png_row_info *row_info, png_byte *row,
          row_info->color_type = PNG_COLOR_TYPE_GRAY_ALPHA;
          row_info->channels = 2;
          row_info->pixel_depth = (png_byte)(row_info->bit_depth << 1);
-         row_info->rowbytes = PNG_ROWBYTES(row_info->pixel_depth,
-             row_width);
+         row_info->rowbytes = png_mul_size(row_width,
+             row_info->pixel_depth >> 3);
       }
    }
    else if (row_info->color_type == PNG_COLOR_TYPE_RGB &&
@@ -4703,7 +4708,8 @@ png_do_expand(png_row_info *row_info, png_byte *row,
       row_info->color_type = PNG_COLOR_TYPE_RGB_ALPHA;
       row_info->channels = 4;
       row_info->pixel_depth = (png_byte)(row_info->bit_depth << 2);
-      row_info->rowbytes = PNG_ROWBYTES(row_info->pixel_depth, row_width);
+      row_info->rowbytes = png_mul_size(row_width,
+          row_info->pixel_depth >> 3);
    }
 }
 #endif
@@ -4734,7 +4740,7 @@ png_do_expand_16(png_row_info *row_info, png_byte *row)
          dp[-2] = dp[-1] = *--sp; dp -= 2;
       }
 
-      row_info->rowbytes *= 2;
+      row_info->rowbytes = png_mul_size(row_info->rowbytes, 2);
       row_info->bit_depth = 16;
       row_info->pixel_depth = (png_byte)(row_info->channels * 16);
    }
@@ -4787,7 +4793,8 @@ png_do_quantize(png_row_info *row_info, png_byte *row,
          row_info->color_type = PNG_COLOR_TYPE_PALETTE;
          row_info->channels = 1;
          row_info->pixel_depth = row_info->bit_depth;
-         row_info->rowbytes = PNG_ROWBYTES(row_info->pixel_depth, row_width);
+         row_info->rowbytes = png_mul_size(row_width,
+             row_info->pixel_depth >> 3);
       }
 
       else if (row_info->color_type == PNG_COLOR_TYPE_RGB_ALPHA &&
@@ -4818,7 +4825,8 @@ png_do_quantize(png_row_info *row_info, png_byte *row,
          row_info->color_type = PNG_COLOR_TYPE_PALETTE;
          row_info->channels = 1;
          row_info->pixel_depth = row_info->bit_depth;
-         row_info->rowbytes = PNG_ROWBYTES(row_info->pixel_depth, row_width);
+         row_info->rowbytes = png_mul_size(row_width,
+             row_info->pixel_depth >> 3);
       }
 
       else if (row_info->color_type == PNG_COLOR_TYPE_PALETTE &&
@@ -5128,6 +5136,9 @@ png_do_read_transformations(png_struct *png_ptr, png_row_info *row_info)
       row_info->pixel_depth = (png_byte)(row_info->bit_depth *
           row_info->channels);
 
+      /* Safe: PNG_ROWBYTES uses png_mul_size for >= 8 bpp; sub-byte
+       * depths cannot overflow (width limited by png_check_IHDR).
+       */
       row_info->rowbytes = PNG_ROWBYTES(row_info->pixel_depth, row_info->width);
    }
 #endif

--- a/pngrutil.c
+++ b/pngrutil.c
@@ -943,7 +943,8 @@ png_handle_IHDR(png_struct *png_ptr, png_info *info_ptr, png_uint_32 length)
 
    /* Set up other useful info */
    png_ptr->pixel_depth = (png_byte)(png_ptr->bit_depth * png_ptr->channels);
-   png_ptr->rowbytes = PNG_ROWBYTES(png_ptr->pixel_depth, png_ptr->width);
+   png_ptr->rowbytes = png_rowbytes_checked(png_ptr, png_ptr->pixel_depth,
+       png_ptr->width);
    png_debug1(3, "bit_depth = %d", png_ptr->bit_depth);
    png_debug1(3, "channels = %d", png_ptr->channels);
    png_debug1(3, "rowbytes = %lu", (unsigned long)png_ptr->rowbytes);
@@ -3411,7 +3412,7 @@ png_combine_row(const png_struct *png_ptr, png_byte *dp, int display)
     * this wrong.
     */
    if (png_ptr->info_rowbytes != 0 && png_ptr->info_rowbytes !=
-          PNG_ROWBYTES(pixel_depth, row_width))
+          png_rowbytes_checked(png_ptr, pixel_depth, row_width))
       png_error(png_ptr, "internal row size calculation error");
 
    /* Don't expect this to ever happen: */
@@ -3426,7 +3427,8 @@ png_combine_row(const png_struct *png_ptr, png_byte *dp, int display)
    if (end_mask != 0)
    {
       /* end_ptr == NULL is a flag to say do nothing */
-      end_ptr = dp + PNG_ROWBYTES(pixel_depth, row_width) - 1;
+      end_ptr = dp + png_rowbytes_checked(png_ptr, pixel_depth,
+          row_width) - 1;
       end_byte = *end_ptr;
 #     ifdef PNG_READ_PACKSWAP_SUPPORTED
       if ((png_ptr->transformations & PNG_PACKSWAP) != 0)
@@ -3863,7 +3865,7 @@ png_combine_row(const png_struct *png_ptr, png_byte *dp, int display)
     * from the temporary row buffer (notice that this overwrites the end of the
     * destination row if it is a partial byte.)
     */
-   memcpy(dp, sp, PNG_ROWBYTES(pixel_depth, row_width));
+   memcpy(dp, sp, png_rowbytes_checked(png_ptr, pixel_depth, row_width));
 
    /* Restore the overwritten bits from the last byte if necessary. */
    if (end_ptr != NULL)
@@ -4778,8 +4780,8 @@ defined(PNG_USER_TRANSFORM_PTR_SUPPORTED)
    /* Calculate the maximum bytes needed, adding a byte and a pixel
     * for safety's sake
     */
-   row_bytes = PNG_ROWBYTES(max_pixel_depth, row_bytes) +
-       1 + ((max_pixel_depth + 7) >> 3U);
+   row_bytes = png_rowbytes_checked(png_ptr, max_pixel_depth,
+       (png_uint_32)row_bytes) + 1 + ((max_pixel_depth + 7) >> 3U);
 
 #ifdef PNG_MAX_MALLOC_64K
    if (row_bytes > (png_uint_32)65536L)
@@ -4886,10 +4888,12 @@ png_read_reinit(png_struct *png_ptr, png_info *info_ptr)
 {
    png_ptr->width = info_ptr->next_frame_width;
    png_ptr->height = info_ptr->next_frame_height;
-   png_ptr->rowbytes = PNG_ROWBYTES(png_ptr->pixel_depth,png_ptr->width);
+   png_ptr->rowbytes = png_rowbytes_checked(png_ptr, png_ptr->pixel_depth,
+       png_ptr->width);
    if (png_ptr->info_rowbytes != 0)
       png_ptr->info_rowbytes = info_ptr->rowbytes =
-         PNG_ROWBYTES(info_ptr->pixel_depth, png_ptr->width);
+         png_rowbytes_checked(png_ptr, info_ptr->pixel_depth,
+             png_ptr->width);
    if (png_ptr->prev_row)
       memset(png_ptr->prev_row, 0, png_ptr->rowbytes + 1);
 }
@@ -4929,7 +4933,8 @@ png_progressive_read_reset(png_struct *png_ptr)
    png_ptr->zstream.next_in = 0;
    png_ptr->zstream.next_out = png_ptr->row_buf;
    png_ptr->zstream.avail_out =
-      (uInt)PNG_ROWBYTES(png_ptr->pixel_depth, png_ptr->iwidth) + 1;
+      (uInt)png_rowbytes_checked(png_ptr, png_ptr->pixel_depth,
+          png_ptr->iwidth) + 1;
 }
 #endif /* PNG_PROGRESSIVE_READ_SUPPORTED */
 #endif /* PNG_READ_APNG_SUPPORTED */

--- a/pngset.c
+++ b/pngset.c
@@ -459,7 +459,8 @@ png_set_IHDR(const png_struct *png_ptr, png_info *info_ptr,
 
    info_ptr->pixel_depth = (png_byte)(info_ptr->channels * info_ptr->bit_depth);
 
-   info_ptr->rowbytes = PNG_ROWBYTES(info_ptr->pixel_depth, width);
+   info_ptr->rowbytes = png_rowbytes_checked(png_ptr, info_ptr->pixel_depth,
+       width);
 
 #ifdef PNG_APNG_SUPPORTED
    /* Assume a non-animated PNG in the beginning. This may be overridden after

--- a/pngwrite.c
+++ b/pngwrite.c
@@ -887,7 +887,8 @@ png_write_row(png_struct *png_ptr, const png_byte *row)
    row_info.channels = png_ptr->usr_channels;
    row_info.bit_depth = png_ptr->usr_bit_depth;
    row_info.pixel_depth = (png_byte)(row_info.bit_depth * row_info.channels);
-   row_info.rowbytes = PNG_ROWBYTES(row_info.pixel_depth, row_info.width);
+   row_info.rowbytes = png_rowbytes_checked(png_ptr, row_info.pixel_depth,
+       row_info.width);
 
    png_debug1(3, "row_info->color_type = %d", row_info.color_type);
    png_debug1(3, "row_info->width = %u", row_info.width);
@@ -1169,7 +1170,8 @@ png_set_filter(png_struct *png_ptr, int method, int filters)
          /* Allocate needed row buffers if they have not already been
           * allocated.
           */
-         buf_size = PNG_ROWBYTES(png_ptr->usr_channels * png_ptr->usr_bit_depth,
+         buf_size = png_rowbytes_checked(png_ptr,
+             (unsigned)(png_ptr->usr_channels * png_ptr->usr_bit_depth),
              png_ptr->width) + 1;
 
          if (png_ptr->try_row == NULL)

--- a/pngwtran.c
+++ b/pngwtran.c
@@ -153,6 +153,9 @@ png_do_pack(png_row_info *row_info, png_byte *row, png_uint_32 bit_depth)
 
       row_info->bit_depth = (png_byte)bit_depth;
       row_info->pixel_depth = (png_byte)(bit_depth * row_info->channels);
+      /* Safe: PNG_ROWBYTES uses png_mul_size for >= 8 bpp; sub-byte
+       * depths cannot overflow (width limited by png_check_IHDR).
+       */
       row_info->rowbytes = PNG_ROWBYTES(row_info->pixel_depth,
           row_info->width);
    }

--- a/pngwutil.c
+++ b/pngwutil.c
@@ -820,7 +820,8 @@ png_write_IHDR(png_struct *png_ptr, png_uint_32 width, png_uint_32 height,
    png_ptr->height = height;
 
    png_ptr->pixel_depth = (png_byte)(bit_depth * png_ptr->channels);
-   png_ptr->rowbytes = PNG_ROWBYTES(png_ptr->pixel_depth, width);
+   png_ptr->rowbytes = png_rowbytes_checked(png_ptr, png_ptr->pixel_depth,
+       width);
    /* Set the usr info, so any transformations can modify it */
    png_ptr->usr_width = png_ptr->width;
    png_ptr->usr_bit_depth = png_ptr->bit_depth;
@@ -2039,7 +2040,8 @@ png_write_start_row(png_struct *png_ptr)
    png_debug(1, "in png_write_start_row");
 
    usr_pixel_depth = png_ptr->usr_channels * png_ptr->usr_bit_depth;
-   buf_size = PNG_ROWBYTES(usr_pixel_depth, png_ptr->width) + 1;
+   buf_size = png_rowbytes_checked(png_ptr, (unsigned)usr_pixel_depth,
+       png_ptr->width) + 1;
 
    /* 1.5.6: added to allow checking in the row write code. */
    png_ptr->transformed_pixel_depth = png_ptr->pixel_depth;
@@ -2180,8 +2182,9 @@ png_write_finish_row(png_struct *png_ptr)
       {
          if (png_ptr->prev_row != NULL)
             memset(png_ptr->prev_row, 0,
-                PNG_ROWBYTES(png_ptr->usr_channels *
-                png_ptr->usr_bit_depth, png_ptr->width) + 1);
+                png_rowbytes_checked(png_ptr,
+                (unsigned)(png_ptr->usr_channels *
+                png_ptr->usr_bit_depth), png_ptr->width) + 1);
 
          return;
       }
@@ -2360,6 +2363,9 @@ png_do_write_interlace(png_row_info *row_info, png_byte *row, int pass)
           png_pass_start[pass]) /
           png_pass_inc[pass];
 
+      /* Safe: PNG_ROWBYTES uses png_mul_size for >= 8 bpp; sub-byte
+       * depths cannot overflow (width limited by png_check_IHDR).
+       */
       row_info->rowbytes = PNG_ROWBYTES(row_info->pixel_depth,
           row_info->width);
    }
@@ -2907,7 +2913,8 @@ png_write_reinit(png_struct *png_ptr, png_info *info_ptr,
 
    png_ptr->width = width;
    png_ptr->height = height;
-   png_ptr->rowbytes = PNG_ROWBYTES(png_ptr->pixel_depth, width);
+   png_ptr->rowbytes = png_rowbytes_checked(png_ptr, png_ptr->pixel_depth,
+       width);
    png_ptr->usr_width = png_ptr->width;
 }
 #endif /* PNG_WRITE_APNG_SUPPORTED */

--- a/tests/pngoverflow
+++ b/tests/pngoverflow
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+# pngoverflow test:
+# Overflow-checking primitives for png_mul_size and PNG_ROWBYTES.
+exec ./pngoverflow


### PR DESCRIPTION
## Summary

Several sites across the library compute `row_info->rowbytes` or allocate buffers using bare `size_t` multiplications (`(size_t)width * bytes_per_pixel`) that can silently wrap on overflow. While `png_check_IHDR` limits width to prevent overflow for standard pixel depths, the pattern itself is error-prone and offers no protection for user transforms with custom pixel depths or future code paths.

This patch introduces overflow-checked size arithmetic primitives and systematically replaces all unchecked rowbytes multiplications:

**New primitives (pngpriv.h, png.c):**
- `png_mul_size(a, b)` — overflow-checked `size_t` multiplication macro, returns 0 on overflow. Uses the same division-based check as `png_malloc_array_checked()`.
- `png_rowbytes_checked(png_ptr, pixel_depth, width)` — checked version of `PNG_ROWBYTES` that calls `png_error` on overflow. For use at allocation sites where `png_structrp` is available.

**Updated PNG_ROWBYTES macro (pngpriv.h):**
- The `>= 8 bpp` case now uses `png_mul_size` internally, returning 0 on overflow instead of wrapping to a small value that could cause undersized allocations.

**Allocation and initialization sites (10 files):**
- All `PNG_ROWBYTES` calls at buffer allocation sites replaced with `png_rowbytes_checked`: `png_handle_IHDR`, `png_read_start_row`, `png_write_start_row`, `png_write_IHDR`, `png_set_IHDR`, `png_read_row`, `png_write_row`, `png_push_process_row`, `png_read_reinit` (APNG), `png_write_reinit` (APNG), progressive reader IDAT, and filter buffer allocation.
- `png_read_png` row pointer allocation uses `png_mul_size` with explicit overflow check.

**Transform rowbytes (pngrtran.c, arm/arm_init.c):**
- All 15 bare `(size_t)row_width * N` rowbytes assignments in `png_do_read_filler`, `png_do_unpack`, `png_do_scale_16_to_8`, `png_do_chop`, `png_do_expand_palette`, and `png_do_expand_16` replaced with `png_mul_size` as defense-in-depth.
- ARM NEON palette expansion paths use `png_rowbytes_checked` (has `png_ptr`) and fix a missing `(size_t)` cast on pointer arithmetic.

**Test (contrib/libtests/pngoverflow.c):**
- New test covering `png_mul_size` and `PNG_ROWBYTES` with normal values, boundary conditions, and overflow inputs.

## Testing
- All 38 tests pass (37 existing + 1 new overflow test)
- Tested under AddressSanitizer + UndefinedBehaviorSanitizer with zero warnings
- Clean C89 compilation with `-Wall -Wextra -pedantic`
- No functional change for images within standard limits