### PR TITLE
Add CI support for testing libpng on Windows ARM64

### DIFF
--- a/.github/workflows/verify-windows.yml
+++ b/.github/workflows/verify-windows.yml
@@ -12,26 +12,37 @@ on:
 
 jobs:
   verify-windows:
-    runs-on: windows-latest
+    strategy:
+      matrix:
+        include:
+          - os: windows-latest
+            vcpkg_triplet: x64-windows
+            cmake_platform: x64
+            cmake_generator: Visual Studio 17 2022
+          - os: windows-11-arm
+            vcpkg_triplet: arm64-windows
+            cmake_platform: ARM64
+            cmake_generator: Visual Studio 17 2022
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     steps:
       - name: Set up vcpkg cache
         uses: actions/cache@v4
         with:
           path: C:/vcpkg/installed
-          key: ${{ runner.os }}-vcpkg-${{ hashFiles('vcpkg.json', '**/vcpkg.json') }}
-          restore-keys: ${{ runner.os }}-vcpkg-
+          key: ${{ runner.os }}-vcpkg-${{ matrix.vcpkg_triplet }}-${{ hashFiles('vcpkg.json', '**/vcpkg.json') }}
+          restore-keys: ${{ runner.os }}-vcpkg--${{ matrix.vcpkg_triplet }}
       - name: Install dependencies
         run: |
-          vcpkg install zlib:x64-windows
+          vcpkg install zlib:${{ matrix.vcpkg_triplet }}
           vcpkg integrate install
       - name: Check out the code
         uses: actions/checkout@v4
       - name: Run the CMake verification script
         run: bash ./ci/ci_verify_cmake.sh
         env:
-          CI_CMAKE_GENERATOR: Visual Studio 17 2022
-          CI_CMAKE_GENERATOR_PLATFORM: x64
+          CI_CMAKE_GENERATOR: ${{ matrix.cmake_generator }}
+          CI_CMAKE_GENERATOR_PLATFORM: ${{ matrix.cmake_platform }}
           CI_CMAKE_TOOLCHAIN_FILE: C:/vcpkg/scripts/buildsystems/vcpkg.cmake
           CI_CMAKE_BUILD_FLAGS: -j2
           CI_CTEST_FLAGS: -j2


### PR DESCRIPTION
* The PR adds CI support for building and testing libpng on Windows ARM64.
* Modified [verify-windows.yml](https://github.com/pnggroup/libpng/compare/libpng18...MugundanMCW:libpng:libpng18#diff-c820bd3087f7c72fbad5ab9daf9cc1a45cdf237fb6082c6b0faee146f2eead99) to support Windows ARM64 build configuration