### PR TITLE
Add support for zlib submodule

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,8 +138,14 @@ if(PNG_BUILD_ZLIB)
 endif()
 
 # Find the zlib library.
-find_package(ZLIB REQUIRED)
-set(PNG_LINK_LIBRARIES ZLIB::ZLIB)
+if(TARGET zlibstatic)
+  set(PNG_LINK_LIBRARIES zlibstatic)
+elseif(TARGET zlib)
+  set(PNG_LINK_LIBRARIES zlib)
+else()
+  find_package(ZLIB REQUIRED)
+  set(PNG_LINK_LIBRARIES ZLIB::ZLIB)
+endif()
 
 # Find the math library (unless we already know it's not available or
 # not needed).


### PR DESCRIPTION
This change allows libpng to use zlib compiled as a git submodule instead of always requiring an installed package.

This change shouldn't break compatibility; I needed to add this repository to my project as a Git submodule. Here's my cmakelist.txt:
```
cmake_minimum_required(VERSION 3.20)

project(
    TestLibPng
    VERSION 1.0
    LANGUAGES CXX
    HOMEPAGE_URL https://github.com/ElSuicio/Cone-Mapping-Godot
)

set(CMAKE_CXX_STANDARD 17)

# zlib #
add_subdirectory("third_party/zlib")

# libpng #
add_subdirectory("third_party/libpng")

# main #
file(GLOB_RECURSE SOURCES CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp")

add_executable("${CMAKE_PROJECT_NAME}" "${SOURCES}")

target_link_libraries("${CMAKE_PROJECT_NAME}" PRIVATE zlibstatic png_static)
```