### PR TITLE
CMAKE: Fix wrong symlink created for import library on MinGW/CYGWIN

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -879,8 +879,13 @@ if(NOT SKIP_INSTALL_LIBRARIES AND NOT SKIP_INSTALL_ALL)
   if(PNG_SHARED)
     # Create a symlink for libpng.dll.a => libpng18.dll.a on Cygwin
     if(NOT WIN32 OR CYGWIN OR MINGW)
-      create_symlink(libpng${CMAKE_SHARED_LIBRARY_SUFFIX} TARGET png_shared)
-      install(FILES "$<TARGET_LINKER_FILE_DIR:png_shared>/libpng${CMAKE_SHARED_LIBRARY_SUFFIX}"
+      if(CYGWIN OR MINGW)
+        set(libpng_symlink_name "libpng${CMAKE_IMPORT_LIBRARY_SUFFIX}")
+      else()
+        set(libpng_symlink_name "libpng${CMAKE_SHARED_LIBRARY_SUFFIX}")
+      endif()
+      create_symlink(${libpng_symlink_name} TARGET png_shared)
+      install(FILES "$<TARGET_LINKER_FILE_DIR:png_shared>/${libpng_symlink_name}"
               DESTINATION "${CMAKE_INSTALL_LIBDIR}")
     endif()
   endif()


### PR DESCRIPTION
This PR fixes issue #783.

If the target platform is `MINGW` or `CYGWIN`, then the name of the target of the symlink is built with `CMAKE_IMPORT_LIBRARY_SUFFIX`.
Otherwise, it uses `CMAKE_SHARED_LIBRARY_SUFFIX` for replicating the same behaviour of the code and not breaking current status.

This patch also needs to be backported to libpng16 because the support for MinGW and CYGWIN with CMake is broken because of this issue.