### PR TITLE
fix: use actual row width for memcpy in png_image_read_direct_scaled

### DIFF
--- a/pngread.c
+++ b/pngread.c
@@ -21,13 +21,13 @@
 #ifdef PNG_READ_SUPPORTED
 
 /* Create a PNG structure for reading, and allocate any memory needed. */
-PNG_FUNCTION(png_structp,PNGAPI
-png_create_read_struct,(png_const_charp user_png_ver, png_voidp error_ptr,
+PNG_FUNCTION(png_struct *,
+png_create_read_struct,(const char *user_png_ver, void *error_ptr,
     png_error_ptr error_fn, png_error_ptr warn_fn),
     PNG_ALLOCATED)
 {
 #ifndef PNG_USER_MEM_SUPPORTED
-   png_structp png_ptr = png_create_png_struct(user_png_ver, error_ptr,
+   png_struct *png_ptr = png_create_png_struct(user_png_ver, error_ptr,
         error_fn, warn_fn, NULL, NULL, NULL);
 #else
    return png_create_read_struct_2(user_png_ver, error_ptr, error_fn,
@@ -37,13 +37,13 @@ png_create_read_struct,(png_const_charp user_png_ver, png_voidp error_ptr,
 /* Alternate create PNG structure for reading, and allocate any memory
  * needed.
  */
-PNG_FUNCTION(png_structp,PNGAPI
-png_create_read_struct_2,(png_const_charp user_png_ver, png_voidp error_ptr,
-    png_error_ptr error_fn, png_error_ptr warn_fn, png_voidp mem_ptr,
+PNG_FUNCTION(png_struct *,
+png_create_read_struct_2,(const char *user_png_ver, void *error_ptr,
+    png_error_ptr error_fn, png_error_ptr warn_fn, void *mem_ptr,
     png_malloc_ptr malloc_fn, png_free_ptr free_fn),
     PNG_ALLOCATED)
 {
-   png_structp png_ptr = png_create_png_struct(user_png_ver, error_ptr,
+   png_struct *png_ptr = png_create_png_struct(user_png_ver, error_ptr,
        error_fn, warn_fn, mem_ptr, malloc_fn, free_fn);
 #endif /* USER_MEM */
 
@@ -69,6 +69,15 @@ png_create_read_struct_2,(png_const_charp user_png_ver, png_voidp error_ptr,
 #        endif
 #     endif
 
+#     ifdef PNG_TARGET_CODE_IMPLEMENTATION /* target specific code */
+         /* Current support is read-only so this happens here, not in the
+          * general creation.  It could easily be moved.
+          */
+         png_target_init(png_ptr);
+         if (png_ptr->target_state != 0U)
+            png_set_option(png_ptr, PNG_TARGET_SPECIFIC_CODE, 1);
+#     endif
+
       /* TODO: delay this, it can be done in png_init_io (if the app doesn't
        * do it itself) avoiding setting the default function if it is not
        * required.
@@ -89,8 +98,8 @@ png_create_read_struct_2,(png_const_charp user_png_ver, png_voidp error_ptr,
  * here.  The application can then have access to the signature bytes we
  * read if it is determined that this isn't a valid PNG file.
  */
-void PNGAPI
-png_read_info(png_structrp png_ptr, png_inforp info_ptr)
+void
+png_read_info(png_struct *png_ptr, png_info *info_ptr)
 {
 #ifdef PNG_HANDLE_AS_UNKNOWN_SUPPORTED
    int keep;
@@ -157,9 +166,23 @@ png_read_info(png_structrp png_ptr, png_inforp info_ptr)
 
       else if (chunk_name == png_IDAT)
       {
+#ifdef PNG_READ_APNG_SUPPORTED
+         png_have_info(png_ptr, info_ptr);
+#endif
          png_ptr->idat_size = length;
          break;
       }
+
+#ifdef PNG_READ_APNG_SUPPORTED
+      else if (chunk_name == png_acTL)
+         png_handle_acTL(png_ptr, info_ptr, length);
+
+      else if (chunk_name == png_fcTL)
+         png_handle_fcTL(png_ptr, info_ptr, length);
+
+      else if (chunk_name == png_fdAT)
+         png_handle_fdAT(png_ptr, info_ptr, length);
+#endif
 
       else
          png_handle_chunk(png_ptr, info_ptr, length);
@@ -167,9 +190,74 @@ png_read_info(png_structrp png_ptr, png_inforp info_ptr)
 }
 #endif /* SEQUENTIAL_READ */
 
-/* Optional call to update the users info_ptr structure */
+#ifdef PNG_READ_APNG_SUPPORTED
 void PNGAPI
-png_read_update_info(png_structrp png_ptr, png_inforp info_ptr)
+png_read_frame_head(png_struct *png_ptr, png_info *info_ptr)
+{
+   png_byte have_chunk_after_DAT; /* after IDAT or after fdAT */
+
+   png_debug(1, "Reading frame head");
+
+   if (!(png_ptr->mode & PNG_HAVE_acTL))
+      png_error(png_ptr, "Cannot read APNG frame: missing acTL");
+
+   /* Do nothing for the main IDAT. */
+   if (png_ptr->num_frames_read == 0)
+      return;
+
+   png_read_reset(png_ptr);
+   png_ptr->flags &= ~PNG_FLAG_ROW_INIT;
+   png_ptr->mode &= ~PNG_HAVE_fcTL;
+
+   have_chunk_after_DAT = 0;
+   for (;;)
+   {
+      png_uint_32 length = png_read_chunk_header(png_ptr);
+
+      if (png_ptr->chunk_name == png_IDAT)
+      {
+         /* Discard trailing IDATs for the first frame. */
+         if (have_chunk_after_DAT || png_ptr->num_frames_read > 1)
+            png_error(png_ptr, "Misplaced IDAT in APNG stream");
+         png_crc_finish(png_ptr, length);
+      }
+      else if (png_ptr->chunk_name == png_fcTL)
+      {
+         png_handle_fcTL(png_ptr, info_ptr, length);
+         have_chunk_after_DAT = 1;
+      }
+      else if (png_ptr->chunk_name == png_fdAT)
+      {
+         png_ensure_sequence_number(png_ptr, length);
+
+         /* Discard trailing fdATs for all frames except the first. */
+         if (!have_chunk_after_DAT && png_ptr->num_frames_read > 1)
+         {
+            png_crc_finish(png_ptr, length - 4);
+         }
+         else if (png_ptr->mode & PNG_HAVE_fcTL)
+         {
+            png_ptr->idat_size = length - 4;
+            png_ptr->mode |= PNG_HAVE_IDAT;
+            break;
+         }
+         else
+         {
+            png_error(png_ptr, "Misplaced fdAT in APNG stream");
+         }
+      }
+      else
+      {
+         png_warning(png_ptr, "Ignoring unexpected chunk in APNG sequence");
+         png_crc_finish(png_ptr, length);
+      }
+   }
+}
+#endif /* PNG_READ_APNG_SUPPORTED */
+
+/* Optional call to update the users info_ptr structure */
+void
+png_read_update_info(png_struct *png_ptr, png_info *info_ptr)
 {
    png_debug(1, "in png_read_update_info");
 
@@ -199,8 +287,8 @@ png_read_update_info(png_structrp png_ptr, png_inforp info_ptr)
  * the user to obtain a gamma-corrected palette, for example.
  * If the user doesn't call this, we will do it ourselves.
  */
-void PNGAPI
-png_start_read_image(png_structrp png_ptr)
+void
+png_start_read_image(png_struct *png_ptr)
 {
    png_debug(1, "in png_start_read_image");
 
@@ -223,7 +311,7 @@ png_start_read_image(png_structrp png_ptr)
  * NOTE: this is apparently only supported in the 'sequential' reader.
  */
 static void
-png_do_read_intrapixel(png_row_infop row_info, png_bytep row)
+png_do_read_intrapixel(png_row_info *row_info, png_byte *row)
 {
    png_debug(1, "in png_do_read_intrapixel");
 
@@ -235,7 +323,7 @@ png_do_read_intrapixel(png_row_infop row_info, png_bytep row)
 
       if (row_info->bit_depth == 8)
       {
-         png_bytep rp;
+         png_byte *rp;
          png_uint_32 i;
 
          if (row_info->color_type == PNG_COLOR_TYPE_RGB)
@@ -255,7 +343,7 @@ png_do_read_intrapixel(png_row_infop row_info, png_bytep row)
       }
       else if (row_info->bit_depth == 16)
       {
-         png_bytep rp;
+         png_byte *rp;
          png_uint_32 i;
 
          if (row_info->color_type == PNG_COLOR_TYPE_RGB)
@@ -284,8 +372,8 @@ png_do_read_intrapixel(png_row_infop row_info, png_bytep row)
 }
 #endif /* MNG_FEATURES */
 
-void PNGAPI
-png_read_row(png_structrp png_ptr, png_bytep row, png_bytep dsp_row)
+void
+png_read_row(png_struct *png_ptr, png_byte *row, png_byte *dsp_row)
 {
    png_row_info row_info;
 
@@ -549,13 +637,13 @@ png_read_row(png_structrp png_ptr, png_bytep row, png_bytep dsp_row)
  * [*] png_handle_alpha() does not exist yet, as of this version of libpng
  */
 
-void PNGAPI
-png_read_rows(png_structrp png_ptr, png_bytepp row,
-    png_bytepp display_row, png_uint_32 num_rows)
+void
+png_read_rows(png_struct *png_ptr, png_byte **row,
+    png_byte **display_row, png_uint_32 num_rows)
 {
    png_uint_32 i;
-   png_bytepp rp;
-   png_bytepp dp;
+   png_byte **rp;
+   png_byte **dp;
 
    png_debug(1, "in png_read_rows");
 
@@ -567,8 +655,8 @@ png_read_rows(png_structrp png_ptr, png_bytepp row,
    if (rp != NULL && dp != NULL)
       for (i = 0; i < num_rows; i++)
       {
-         png_bytep rptr = *rp++;
-         png_bytep dptr = *dp++;
+         png_byte *rptr = *rp++;
+         png_byte *dptr = *dp++;
 
          png_read_row(png_ptr, rptr, dptr);
       }
@@ -576,7 +664,7 @@ png_read_rows(png_structrp png_ptr, png_bytepp row,
    else if (rp != NULL)
       for (i = 0; i < num_rows; i++)
       {
-         png_bytep rptr = *rp;
+         png_byte *rptr = *rp;
          png_read_row(png_ptr, rptr, NULL);
          rp++;
       }
@@ -584,7 +672,7 @@ png_read_rows(png_structrp png_ptr, png_bytepp row,
    else if (dp != NULL)
       for (i = 0; i < num_rows; i++)
       {
-         png_bytep dptr = *dp;
+         png_byte *dptr = *dp;
          png_read_row(png_ptr, NULL, dptr);
          dp++;
       }
@@ -604,12 +692,12 @@ png_read_rows(png_structrp png_ptr, png_bytepp row,
  *
  * [*] png_handle_alpha() does not exist yet, as of this version of libpng
  */
-void PNGAPI
-png_read_image(png_structrp png_ptr, png_bytepp image)
+void
+png_read_image(png_struct *png_ptr, png_byte **image)
 {
    png_uint_32 i, image_height;
    int pass, j;
-   png_bytepp rp;
+   png_byte **rp;
 
    png_debug(1, "in png_read_image");
 
@@ -670,8 +758,8 @@ png_read_image(png_structrp png_ptr, png_bytepp image)
  * file, will verify the end is accurate, and will read any comments
  * or time information at the end of the file, if info is not NULL.
  */
-void PNGAPI
-png_read_end(png_structrp png_ptr, png_inforp info_ptr)
+void
+png_read_end(png_struct *png_ptr, png_info *info_ptr)
 {
 #ifdef PNG_HANDLE_AS_UNKNOWN_SUPPORTED
    int keep;
@@ -757,7 +845,7 @@ png_read_end(png_structrp png_ptr, png_inforp info_ptr)
 
 /* Free all memory used in the read struct */
 static void
-png_read_destroy(png_structrp png_ptr)
+png_read_destroy(png_struct *png_ptr)
 {
    png_debug(1, "in png_read_destroy");
 
@@ -812,11 +900,10 @@ png_read_destroy(png_structrp png_ptr)
    png_ptr->chunk_list = NULL;
 #endif
 
-#if defined(PNG_READ_EXPAND_SUPPORTED) && \
-    (defined(PNG_ARM_NEON_IMPLEMENTATION) || \
-     defined(PNG_RISCV_RVV_IMPLEMENTATION))
-   png_free(png_ptr, png_ptr->riffled_palette);
-   png_ptr->riffled_palette = NULL;
+#ifdef PNG_TARGET_STORES_DATA
+   if (png_ptr->target_data != NULL)
+      png_target_free_data(png_ptr);
+   png_ptr->target_data = NULL;
 #endif
 
    /* NOTE: the 'setjmp' buffer may still be allocated and the memory and error
@@ -826,11 +913,11 @@ png_read_destroy(png_structrp png_ptr)
 }
 
 /* Free all memory used by the read */
-void PNGAPI
-png_destroy_read_struct(png_structpp png_ptr_ptr, png_infopp info_ptr_ptr,
-    png_infopp end_info_ptr_ptr)
+void
+png_destroy_read_struct(png_struct **png_ptr_ptr, png_info **info_ptr_ptr,
+    png_info **end_info_ptr_ptr)
 {
-   png_structrp png_ptr = NULL;
+   png_struct *png_ptr = NULL;
 
    png_debug(1, "in png_destroy_read_struct");
 
@@ -852,8 +939,8 @@ png_destroy_read_struct(png_structpp png_ptr_ptr, png_infopp info_ptr_ptr,
    png_destroy_png_struct(png_ptr);
 }
 
-void PNGAPI
-png_set_read_status_fn(png_structrp png_ptr, png_read_status_ptr read_row_fn)
+void
+png_set_read_status_fn(png_struct *png_ptr, png_read_status_ptr read_row_fn)
 {
    if (png_ptr == NULL)
       return;
@@ -864,9 +951,9 @@ png_set_read_status_fn(png_structrp png_ptr, png_read_status_ptr read_row_fn)
 
 #ifdef PNG_SEQUENTIAL_READ_SUPPORTED
 #ifdef PNG_INFO_IMAGE_SUPPORTED
-void PNGAPI
-png_read_png(png_structrp png_ptr, png_inforp info_ptr,
-    int transforms, png_voidp params)
+void
+png_read_png(png_struct *png_ptr, png_info *info_ptr,
+    int transforms, void *params)
 {
    png_debug(1, "in png_read_png");
 
@@ -877,7 +964,7 @@ png_read_png(png_structrp png_ptr, png_inforp info_ptr,
     * PNG file before the first IDAT (image data chunk).
     */
    png_read_info(png_ptr, info_ptr);
-   if (info_ptr->height > PNG_UINT_32_MAX/(sizeof (png_bytep)))
+   if (info_ptr->height > PNG_UINT_32_MAX/(sizeof (png_byte *)))
       png_error(png_ptr, "Image is too high to process with png_read_png()");
 
    /* -------------- image transformations start here ------------------- */
@@ -1046,8 +1133,8 @@ png_read_png(png_structrp png_ptr, png_inforp info_ptr,
    {
       png_uint_32 iptr;
 
-      info_ptr->row_pointers = png_voidcast(png_bytepp, png_malloc(png_ptr,
-          info_ptr->height * (sizeof (png_bytep))));
+      info_ptr->row_pointers = png_voidcast(png_byte **, png_malloc(png_ptr,
+          info_ptr->height * (sizeof (png_byte *))));
 
       for (iptr=0; iptr<info_ptr->height; iptr++)
          info_ptr->row_pointers[iptr] = NULL;
@@ -1055,7 +1142,7 @@ png_read_png(png_structrp png_ptr, png_inforp info_ptr,
       info_ptr->free_me |= PNG_FREE_ROWS;
 
       for (iptr = 0; iptr < info_ptr->height; iptr++)
-         info_ptr->row_pointers[iptr] = png_voidcast(png_bytep,
+         info_ptr->row_pointers[iptr] = png_voidcast(png_byte *,
              png_malloc(png_ptr, info_ptr->rowbytes));
    }
 
@@ -1104,15 +1191,15 @@ png_read_png(png_structrp png_ptr, png_inforp info_ptr,
 typedef struct
 {
    /* Arguments */
-   png_imagep image;
-   png_voidp buffer;
+   png_image *image;
+   void *buffer;
    png_int_32 row_stride;
-   png_voidp colormap;
-   png_const_colorp background;
+   void *colormap;
+   const png_color *background;
 
    /* Instance variables */
-   png_voidp local_row;
-   png_voidp first_row;
+   void *local_row;
+   void *first_row;
    ptrdiff_t row_step;              /* step between rows */
    int file_encoding;               /* E_ values above */
    png_fixed_point gamma_to_linear; /* For P_FILE, reciprocal of gamma */
@@ -1125,11 +1212,11 @@ typedef struct
  * instead so that control is returned safely back to this routine.
  */
 static int
-png_image_read_init(png_imagep image)
+png_image_read_init(png_image *image)
 {
    if (image->opaque == NULL)
    {
-      png_structp png_ptr = png_create_read_struct(PNG_LIBPNG_VER_STRING, image,
+      png_struct *png_ptr = png_create_read_struct(PNG_LIBPNG_VER_STRING, image,
           png_safe_error, png_safe_warning);
 
       /* And set the rest of the structure to NULL to ensure that the various
@@ -1140,11 +1227,11 @@ png_image_read_init(png_imagep image)
 
       if (png_ptr != NULL)
       {
-         png_infop info_ptr = png_create_info_struct(png_ptr);
+         png_info *info_ptr = png_create_info_struct(png_ptr);
 
          if (info_ptr != NULL)
          {
-            png_controlp control = png_voidcast(png_controlp,
+            png_control *control = png_voidcast(png_control *,
                 png_malloc_warn(png_ptr, (sizeof *control)));
 
             if (control != NULL)
@@ -1174,7 +1261,7 @@ png_image_read_init(png_imagep image)
 
 /* Utility to find the base format of a PNG file from a png_struct. */
 static png_uint_32
-png_image_format(png_structrp png_ptr)
+png_image_format(png_struct *png_ptr)
 {
    png_uint_32 format = 0;
 
@@ -1246,7 +1333,7 @@ png_gamma_not_sRGB(png_fixed_point g)
  * unlike the init routine above.
  */
 static int
-png_image_is_not_sRGB(png_const_structrp png_ptr)
+png_image_is_not_sRGB(const png_struct *png_ptr)
 {
    /* Does the colorspace **not** match sRGB?  The flag is only set if the
     * answer can be determined reliably.
@@ -1273,11 +1360,11 @@ png_image_is_not_sRGB(png_const_structrp png_ptr)
 }
 
 static int
-png_image_read_header(png_voidp argument)
+png_image_read_header(void *argument)
 {
-   png_imagep image = png_voidcast(png_imagep, argument);
-   png_structrp png_ptr = image->opaque->png_ptr;
-   png_inforp info_ptr = image->opaque->info_ptr;
+   png_image *image = png_voidcast(png_image *, argument);
+   png_struct *png_ptr = image->opaque->png_ptr;
+   png_info *info_ptr = image->opaque->info_ptr;
 
 #ifdef PNG_BENIGN_ERRORS_SUPPORTED
    png_set_benign_errors(png_ptr, 1/*warn*/);
@@ -1333,8 +1420,8 @@ png_image_read_header(png_voidp argument)
 }
 
 #ifdef PNG_STDIO_SUPPORTED
-int PNGAPI
-png_image_begin_read_from_stdio(png_imagep image, FILE *file)
+int
+png_image_begin_read_from_stdio(png_image *image, FILE *file)
 {
    if (image != NULL && image->version == PNG_IMAGE_VERSION)
    {
@@ -1363,8 +1450,8 @@ png_image_begin_read_from_stdio(png_imagep image, FILE *file)
    return 0;
 }
 
-int PNGAPI
-png_image_begin_read_from_file(png_imagep image, const char *file_name)
+int
+png_image_begin_read_from_file(png_image *image, const char *file_name)
 {
    if (image != NULL && image->version == PNG_IMAGE_VERSION)
    {
@@ -1402,18 +1489,18 @@ png_image_begin_read_from_file(png_imagep image, const char *file_name)
 }
 #endif /* STDIO */
 
-static void PNGCBAPI
-png_image_memory_read(png_structp png_ptr, png_bytep out, size_t need)
+static void
+png_image_memory_read(png_struct *png_ptr, png_byte *out, size_t need)
 {
    if (png_ptr != NULL)
    {
-      png_imagep image = png_voidcast(png_imagep, png_ptr->io_ptr);
+      png_image *image = png_voidcast(png_image *, png_ptr->io_ptr);
       if (image != NULL)
       {
-         png_controlp cp = image->opaque;
+         png_control *cp = image->opaque;
          if (cp != NULL)
          {
-            png_const_bytep memory = cp->memory;
+            const png_byte *memory = cp->memory;
             size_t size = cp->size;
 
             if (memory != NULL && size >= need)
@@ -1432,8 +1519,8 @@ png_image_memory_read(png_structp png_ptr, png_bytep out, size_t need)
    }
 }
 
-int PNGAPI png_image_begin_read_from_memory(png_imagep image,
-    png_const_voidp memory, size_t size)
+int png_image_begin_read_from_memory(png_image *image,
+    const void *memory, size_t size)
 {
    if (image != NULL && image->version == PNG_IMAGE_VERSION)
    {
@@ -1445,7 +1532,7 @@ int PNGAPI png_image_begin_read_from_memory(png_imagep image,
              * store it into io_ptr.  Again do this in-place to avoid calling a
              * libpng function that requires error handling.
              */
-            image->opaque->memory = png_voidcast(png_const_bytep, memory);
+            image->opaque->memory = png_voidcast(const png_byte *, memory);
             image->opaque->size = size;
             image->opaque->png_ptr->io_ptr = image;
             image->opaque->png_ptr->read_data_fn = png_image_memory_read;
@@ -1471,7 +1558,7 @@ int PNGAPI png_image_begin_read_from_memory(png_imagep image,
  */
 #ifdef PNG_HANDLE_AS_UNKNOWN_SUPPORTED
 static void
-png_image_skip_unused_chunks(png_structrp png_ptr)
+png_image_skip_unused_chunks(png_struct *png_ptr)
 {
    /* Prepare the reader to ignore all recognized chunks whose data will not
     * be used, i.e., all chunks recognized by libpng except for those
@@ -1527,7 +1614,7 @@ png_image_skip_unused_chunks(png_structrp png_ptr)
 static void
 set_file_encoding(png_image_read_control *display)
 {
-   png_structrp png_ptr = display->image->opaque->png_ptr;
+   png_struct *png_ptr = display->image->opaque->png_ptr;
    png_fixed_point g = png_resolve_file_gamma(png_ptr);
 
    /* PNGv3: the result may be 0 however the 'default_gamma' should have been
@@ -1633,7 +1720,7 @@ png_create_colormap_entry(png_image_read_control *display,
     png_uint_32 ip, png_uint_32 red, png_uint_32 green, png_uint_32 blue,
     png_uint_32 alpha, int encoding)
 {
-   png_imagep image = display->image;
+   png_image *image = display->image;
    int output_encoding = (image->format & PNG_FORMAT_FLAG_LINEAR) != 0 ?
        P_LINEAR : P_sRGB;
    int convert_to_Y = (image->format & PNG_FORMAT_FLAG_COLOR) == 0 &&
@@ -1758,7 +1845,7 @@ png_create_colormap_entry(png_image_read_control *display,
 
       if (output_encoding == P_LINEAR)
       {
-         png_uint_16p entry = png_voidcast(png_uint_16p, display->colormap);
+         png_uint_16 *entry = png_voidcast(png_uint_16 *, display->colormap);
 
          entry += ip * PNG_IMAGE_SAMPLE_CHANNELS(image->format);
 
@@ -1813,7 +1900,7 @@ png_create_colormap_entry(png_image_read_control *display,
 
       else /* output encoding is P_sRGB */
       {
-         png_bytep entry = png_voidcast(png_bytep, display->colormap);
+         png_byte *entry = png_voidcast(png_byte *, display->colormap);
 
          entry += ip * PNG_IMAGE_SAMPLE_CHANNELS(image->format);
 
@@ -1957,13 +2044,13 @@ make_rgb_colormap(png_image_read_control *display)
    ((png_byte)(6 * (6 * PNG_DIV51(r) + PNG_DIV51(g)) + PNG_DIV51(b)))
 
 static int
-png_image_read_colormap(png_voidp argument)
+png_image_read_colormap(void *argument)
 {
    png_image_read_control *display =
       png_voidcast(png_image_read_control*, argument);
-   png_imagep image = display->image;
+   png_image *image = display->image;
 
-   png_structrp png_ptr = image->opaque->png_ptr;
+   png_struct *png_ptr = image->opaque->png_ptr;
    png_uint_32 output_format = image->format;
    int output_encoding = (output_format & PNG_FORMAT_FLAG_LINEAR) != 0 ?
       P_LINEAR : P_sRGB;
@@ -2602,9 +2689,9 @@ png_image_read_colormap(png_voidp argument)
                    * match, add the new one and set this as the background
                    * index.
                    */
-                  if (memcmp((png_const_bytep)display->colormap +
+                  if (memcmp((const png_byte *)display->colormap +
                       sample_size * cmap_entries,
-                      (png_const_bytep)display->colormap +
+                      (const png_byte *)display->colormap +
                           sample_size * PNG_RGB_INDEX(r,g,b),
                      sample_size) != 0)
                   {
@@ -2675,8 +2762,8 @@ png_image_read_colormap(png_voidp argument)
           */
          {
             unsigned int num_trans = png_ptr->num_trans;
-            png_const_bytep trans = num_trans > 0 ? png_ptr->trans_alpha : NULL;
-            png_const_colorp colormap = png_ptr->palette;
+            const png_byte *trans = num_trans > 0 ? png_ptr->trans_alpha : NULL;
+            const png_color *colormap = png_ptr->palette;
             int do_background = trans != NULL &&
                (output_format & PNG_FORMAT_FLAG_ALPHA) == 0;
             unsigned int i;
@@ -2810,12 +2897,12 @@ png_image_read_colormap(png_voidp argument)
 
 /* The final part of the color-map read called from png_image_finish_read. */
 static int
-png_image_read_and_map(png_voidp argument)
+png_image_read_and_map(void *argument)
 {
    png_image_read_control *display = png_voidcast(png_image_read_control*,
        argument);
-   png_imagep image = display->image;
-   png_structrp png_ptr = image->opaque->png_ptr;
+   png_image *image = display->image;
+   png_struct *png_ptr = image->opaque->png_ptr;
    int passes;
 
    /* Called when the libpng data must be transformed into the color-mapped
@@ -2840,7 +2927,7 @@ png_image_read_and_map(png_voidp argument)
       png_uint_32 height = image->height;
       png_uint_32 width = image->width;
       int proc = display->colormap_processing;
-      png_bytep first_row = png_voidcast(png_bytep, display->first_row);
+      png_byte *first_row = png_voidcast(png_byte *, display->first_row);
       ptrdiff_t row_step = display->row_step;
       int pass;
 
@@ -2870,9 +2957,9 @@ png_image_read_and_map(png_voidp argument)
 
          for (; y<height; y += stepy)
          {
-            png_bytep inrow = png_voidcast(png_bytep, display->local_row);
-            png_bytep outrow = first_row + y * row_step;
-            png_const_bytep row_end = outrow + width;
+            png_byte *inrow = png_voidcast(png_byte *, display->local_row);
+            png_byte *outrow = first_row + y * row_step;
+            png_byte *row_end = outrow + width;
 
             /* Read the libpng data into the temporary buffer. */
             png_read_row(png_ptr, inrow, NULL);
@@ -2999,14 +3086,14 @@ png_image_read_and_map(png_voidp argument)
 }
 
 static int
-png_image_read_colormapped(png_voidp argument)
+png_image_read_colormapped(void *argument)
 {
    png_image_read_control *display = png_voidcast(png_image_read_control*,
        argument);
-   png_imagep image = display->image;
-   png_controlp control = image->opaque;
-   png_structrp png_ptr = control->png_ptr;
-   png_inforp info_ptr = control->info_ptr;
+   png_image *image = display->image;
+   png_control *control = image->opaque;
+   png_struct *png_ptr = control->png_ptr;
+   png_info *info_ptr = control->info_ptr;
 
    int passes = 0; /* As a flag */
 
@@ -3079,7 +3166,7 @@ png_image_read_colormapped(png_voidp argument)
     * size libpng requires and call the relevant processing routine safely.
     */
    {
-      png_voidp first_row = display->buffer;
+      void *first_row = display->buffer;
       ptrdiff_t row_step = display->row_stride;
 
       /* The following adjustment is to ensure that calculations are correct,
@@ -3089,7 +3176,7 @@ png_image_read_colormapped(png_voidp argument)
       {
          char *ptr = png_voidcast(char*, first_row);
          ptr += (image->height-1) * (-row_step);
-         first_row = png_voidcast(png_voidp, ptr);
+         first_row = png_voidcast(void *, ptr);
       }
 
       display->first_row = first_row;
@@ -3099,7 +3186,7 @@ png_image_read_colormapped(png_voidp argument)
    if (passes == 0)
    {
       int result;
-      png_voidp row = png_malloc(png_ptr, png_get_rowbytes(png_ptr, info_ptr));
+      void *row = png_malloc(png_ptr, png_get_rowbytes(png_ptr, info_ptr));
 
       display->local_row = row;
       result = png_safe_execute(image, png_image_read_and_map, display);
@@ -3116,7 +3203,7 @@ png_image_read_colormapped(png_voidp argument)
       while (--passes >= 0)
       {
          png_uint_32 y = image->height;
-         png_bytep row = png_voidcast(png_bytep, display->first_row);
+         png_byte *row = png_voidcast(png_byte *, display->first_row);
 
          for (; y > 0; --y)
          {
@@ -3131,15 +3218,15 @@ png_image_read_colormapped(png_voidp argument)
 
 /* Row reading for interlaced 16-to-8 bit depth conversion with local buffer. */
 static int
-png_image_read_direct_scaled(png_voidp argument)
+png_image_read_direct_scaled(void *argument)
 {
    png_image_read_control *display = png_voidcast(png_image_read_control*,
        argument);
-   png_imagep image = display->image;
-   png_structrp png_ptr = image->opaque->png_ptr;
-   png_inforp info_ptr = image->opaque->info_ptr;
-   png_bytep local_row = png_voidcast(png_bytep, display->local_row);
-   png_bytep first_row = png_voidcast(png_bytep, display->first_row);
+   png_image *image = display->image;
+   png_struct *png_ptr = image->opaque->png_ptr;
+   png_info *info_ptr = image->opaque->info_ptr;
+   png_byte *local_row = png_voidcast(png_byte *, display->local_row);
+   png_byte *first_row = png_voidcast(png_byte *, display->first_row);
    ptrdiff_t row_step = display->row_step;
    size_t row_bytes = png_get_rowbytes(png_ptr, info_ptr);
    int passes;
@@ -3163,7 +3250,7 @@ png_image_read_direct_scaled(png_voidp argument)
    while (--passes >= 0)
    {
       png_uint_32 y = image->height;
-      png_bytep output_row = first_row;
+      png_byte *output_row = first_row;
 
       for (; y > 0; --y)
       {
@@ -3176,7 +3263,8 @@ png_image_read_direct_scaled(png_voidp argument)
           * to respect the caller's stride for padding or negative (bottom-up)
           * layouts.
           */
-         memcpy(output_row, local_row, row_bytes);
+         memcpy(output_row, local_row,
+                 png_get_rowbytes(png_ptr, info_ptr));
          output_row += row_step;
       }
    }
@@ -3186,12 +3274,12 @@ png_image_read_direct_scaled(png_voidp argument)
 
 /* Just the row reading part of png_image_read. */
 static int
-png_image_read_composite(png_voidp argument)
+png_image_read_composite(void *argument)
 {
    png_image_read_control *display = png_voidcast(png_image_read_control*,
        argument);
-   png_imagep image = display->image;
-   png_structrp png_ptr = image->opaque->png_ptr;
+   png_image *image = display->image;
+   png_struct *png_ptr = image->opaque->png_ptr;
    int passes;
 
    switch (png_ptr->interlaced)
@@ -3244,14 +3332,14 @@ png_image_read_composite(png_voidp argument)
 
          for (; y<height; y += stepy)
          {
-            png_bytep inrow = png_voidcast(png_bytep, display->local_row);
-            png_bytep outrow;
-            png_const_bytep row_end;
+            png_byte *inrow = png_voidcast(png_byte *, display->local_row);
+            png_byte *outrow;
+            png_byte *row_end;
 
             /* Read the row, which is packed: */
             png_read_row(png_ptr, inrow, NULL);
 
-            outrow = png_voidcast(png_bytep, display->first_row);
+            outrow = png_voidcast(png_byte *, display->first_row);
             outrow += y * row_step;
             row_end = outrow + width * channels;
 
@@ -3338,13 +3426,13 @@ png_image_read_composite(png_voidp argument)
  * row and handles the removal or pre-multiplication of the alpha channel.
  */
 static int
-png_image_read_background(png_voidp argument)
+png_image_read_background(void *argument)
 {
    png_image_read_control *display = png_voidcast(png_image_read_control*,
        argument);
-   png_imagep image = display->image;
-   png_structrp png_ptr = image->opaque->png_ptr;
-   png_inforp info_ptr = image->opaque->info_ptr;
+   png_image *image = display->image;
+   png_struct *png_ptr = image->opaque->png_ptr;
+   png_info *info_ptr = image->opaque->info_ptr;
    png_uint_32 height = image->height;
    png_uint_32 width = image->width;
    int pass, passes;
@@ -3396,7 +3484,7 @@ png_image_read_background(png_voidp argument)
           * Unlike the code above ALPHA_OPTIMIZED has *not* been done.
           */
          {
-            png_bytep first_row = png_voidcast(png_bytep, display->first_row);
+            png_byte *first_row = png_voidcast(png_byte *, display->first_row);
             ptrdiff_t row_step = display->row_step;
 
             for (pass = 0; pass < passes; ++pass)
@@ -3427,10 +3515,10 @@ png_image_read_background(png_voidp argument)
                {
                   for (; y<height; y += stepy)
                   {
-                     png_bytep inrow = png_voidcast(png_bytep,
+                     png_byte *inrow = png_voidcast(png_byte *,
                          display->local_row);
-                     png_bytep outrow = first_row + y * row_step;
-                     png_const_bytep row_end = outrow + width;
+                     png_byte *outrow = first_row + y * row_step;
+                     png_byte *row_end = outrow + width;
 
                      /* Read the row, which is packed: */
                      png_read_row(png_ptr, inrow, NULL);
@@ -3472,10 +3560,10 @@ png_image_read_background(png_voidp argument)
 
                   for (; y<height; y += stepy)
                   {
-                     png_bytep inrow = png_voidcast(png_bytep,
+                     png_byte *inrow = png_voidcast(png_byte *,
                          display->local_row);
-                     png_bytep outrow = first_row + y * row_step;
-                     png_const_bytep row_end = outrow + width;
+                     png_byte *outrow = first_row + y * row_step;
+                     png_byte *row_end = outrow + width;
 
                      /* Read the row, which is packed: */
                      png_read_row(png_ptr, inrow, NULL);
@@ -3517,7 +3605,7 @@ png_image_read_background(png_voidp argument)
           * handles the alpha-first option.
           */
          {
-            png_uint_16p first_row = png_voidcast(png_uint_16p,
+            png_uint_16 *first_row = png_voidcast(png_uint_16 *,
                 display->first_row);
             /* The division by two is safe because the caller passed in a
              * stride which was multiplied by 2 (below) to get row_step.
@@ -3563,14 +3651,14 @@ png_image_read_background(png_voidp argument)
 
                for (; y<height; y += stepy)
                {
-                  png_const_uint_16p inrow;
-                  png_uint_16p outrow = first_row + y * row_step;
-                  png_uint_16p row_end = outrow + width * outchannels;
+                  const png_uint_16 *inrow;
+                  png_uint_16 *outrow = first_row + y * row_step;
+                  png_uint_16 *row_end = outrow + width * outchannels;
 
                   /* Read the row, which is packed: */
-                  png_read_row(png_ptr, png_voidcast(png_bytep,
+                  png_read_row(png_ptr, png_voidcast(png_byte *,
                       display->local_row), NULL);
-                  inrow = png_voidcast(png_const_uint_16p, display->local_row);
+                  inrow = png_voidcast(const png_uint_16 *, display->local_row);
 
                   /* Now do the pre-multiplication on each pixel in this row.
                    */
@@ -3615,13 +3703,13 @@ png_image_read_background(png_voidp argument)
 
 /* The guts of png_image_finish_read as a png_safe_execute callback. */
 static int
-png_image_read_direct(png_voidp argument)
+png_image_read_direct(void *argument)
 {
    png_image_read_control *display = png_voidcast(png_image_read_control*,
        argument);
-   png_imagep image = display->image;
-   png_structrp png_ptr = image->opaque->png_ptr;
-   png_inforp info_ptr = image->opaque->info_ptr;
+   png_image *image = display->image;
+   png_struct *png_ptr = image->opaque->png_ptr;
+   png_info *info_ptr = image->opaque->info_ptr;
 
    png_uint_32 format = image->format;
    int linear = (format & PNG_FORMAT_FLAG_LINEAR) != 0;
@@ -3916,7 +4004,7 @@ png_image_read_direct(png_voidp argument)
       {
          png_uint_16 le = 0x0001;
 
-         if ((*(png_const_bytep) & le) != 0)
+         if ((*(const png_byte *) & le) != 0)
             png_set_swap(png_ptr);
       }
 
@@ -4000,7 +4088,7 @@ png_image_read_direct(png_voidp argument)
     * display acts as a flag.
     */
    {
-      png_voidp first_row = display->buffer;
+      void *first_row = display->buffer;
       ptrdiff_t row_step = display->row_stride;
 
       if (linear != 0)
@@ -4013,7 +4101,7 @@ png_image_read_direct(png_voidp argument)
       {
          char *ptr = png_voidcast(char*, first_row);
          ptr += (image->height - 1) * (-row_step);
-         first_row = png_voidcast(png_voidp, ptr);
+         first_row = png_voidcast(void *, ptr);
       }
 
       display->first_row = first_row;
@@ -4023,7 +4111,7 @@ png_image_read_direct(png_voidp argument)
    if (do_local_compose != 0)
    {
       int result;
-      png_voidp row = png_malloc(png_ptr, png_get_rowbytes(png_ptr, info_ptr));
+      void *row = png_malloc(png_ptr, png_get_rowbytes(png_ptr, info_ptr));
 
       display->local_row = row;
       result = png_safe_execute(image, png_image_read_composite, display);
@@ -4036,7 +4124,7 @@ png_image_read_direct(png_voidp argument)
    else if (do_local_background == 2)
    {
       int result;
-      png_voidp row = png_malloc(png_ptr, png_get_rowbytes(png_ptr, info_ptr));
+      void *row = png_malloc(png_ptr, png_get_rowbytes(png_ptr, info_ptr));
 
       display->local_row = row;
       result = png_safe_execute(image, png_image_read_background, display);
@@ -4054,7 +4142,7 @@ png_image_read_direct(png_voidp argument)
        * occur if png_combine_row wrote 16-bit data directly to the user buffer.
        */
       int result;
-      png_voidp row = png_malloc(png_ptr, png_get_rowbytes(png_ptr, info_ptr));
+      void *row = png_malloc(png_ptr, png_get_rowbytes(png_ptr, info_ptr));
 
       display->local_row = row;
       result = png_safe_execute(image, png_image_read_direct_scaled, display);
@@ -4071,7 +4159,7 @@ png_image_read_direct(png_voidp argument)
       while (--passes >= 0)
       {
          png_uint_32 y = image->height;
-         png_bytep row = png_voidcast(png_bytep, display->first_row);
+         png_byte *row = png_voidcast(png_byte *, display->first_row);
 
          for (; y > 0; --y)
          {
@@ -4084,8 +4172,8 @@ png_image_read_direct(png_voidp argument)
    }
 }
 
-int PNGAPI
-png_image_finish_read(png_imagep image, png_const_colorp background,
+int
+png_image_finish_read(png_image *image, const png_color *background,
     void *buffer, png_int_32 row_stride, void *colormap)
 {
    if (image != NULL && image->version == PNG_IMAGE_VERSION)


### PR DESCRIPTION
Fixes #778

## Summary

`png_image_read_direct_scaled()` copies data from `local_row` to the user's output buffer using `row_bytes` (derived from the caller's `row_stride`) as the copy length. However, `local_row` is allocated with only `png_get_rowbytes()` bytes -- the actual transformed row width.

When `row_stride > png_get_rowbytes()` (which the API explicitly allows for padding), the `memcpy` reads past the end of `local_row`, causing a **heap buffer over-read** (CWE-125). This leaks heap memory into the output buffer and can crash with `SIGSEGV` on unmapped pages.

## Root Cause

The function was introduced in commit `218612ddd` to fix CVE-2025-65018. The `memcpy` at line 3266 incorrectly uses `row_bytes` (caller stride) instead of the actual buffer size:

```c
// BEFORE (vulnerable):
memcpy(output_row, local_row, row_bytes);  // row_bytes = stride, can exceed buffer

// AFTER (fixed):
memcpy(output_row, local_row, png_get_rowbytes(png_ptr, info_ptr));  // actual row width
```

The `row_step` variable (used for advancing `output_row`) correctly uses stride for padding -- only the `memcpy` length was wrong.

## Impact

- **Information Disclosure**: Heap contents beyond `local_row` are copied into user-visible output
- **Crash**: `SIGSEGV` if the over-read crosses into unmapped memory
- **Trigger**: Any interlaced 16-bit PNG read with 8-bit output and `row_stride > row_width`
