### PR TITLE
Add missing length check to png_handle_tIME; remove dead PNG_UNUSED(length)

### DIFF
--- a/pngrutil.c
+++ b/pngrutil.c
@@ -955,7 +955,6 @@ png_handle_IHDR(png_struct *png_ptr, png_info *info_ptr, png_uint_32 length)
        color_type, interlace_type, compression_type, filter_type);
 
    return handled_ok;
-   PNG_UNUSED(length)
 }
 
 /* Read and check the palette */
@@ -1116,7 +1115,6 @@ png_handle_gAMA(png_struct *png_ptr, png_info *info_ptr, png_uint_32 length)
 #endif /*READ_GAMMA*/
 
    return handled_ok;
-   PNG_UNUSED(length)
 }
 #else
 #  define png_handle_gAMA NULL
@@ -1257,7 +1255,6 @@ png_handle_cHRM(png_struct *png_ptr, png_info *info_ptr, png_uint_32 length)
 #  endif /* READ_RGB_TO_GRAY */
 
    return handled_ok;
-   PNG_UNUSED(length)
 }
 #else
 #  define png_handle_cHRM NULL
@@ -1302,7 +1299,6 @@ png_handle_sRGB(png_struct *png_ptr, png_info *info_ptr, png_uint_32 length)
 #endif /*READ_GAMMA*/
 
    return handled_ok;
-   PNG_UNUSED(length)
 }
 #else
 #  define png_handle_sRGB NULL
@@ -1897,7 +1893,6 @@ png_handle_cICP(png_struct *png_ptr, png_info *info_ptr, png_uint_32 length)
 #endif /*READ_GAMMA*/
 
    return handled_ok;
-   PNG_UNUSED(length)
 }
 #else
 #  define png_handle_cICP NULL
@@ -1920,7 +1915,6 @@ png_handle_cLLI(png_struct *png_ptr, png_info *info_ptr, png_uint_32 length)
    png_set_cLLI_fixed(png_ptr, info_ptr, png_get_uint_32(buf),
          png_get_uint_32(buf+4));
    return handled_ok;
-   PNG_UNUSED(length)
 }
 #else
 #  define png_handle_cLLI NULL
@@ -1974,7 +1968,6 @@ png_handle_mDCV(png_struct *png_ptr, png_info *info_ptr, png_uint_32 length)
 #  endif /* READ_RGB_TO_GRAY */
 
    return handled_ok;
-   PNG_UNUSED(length)
 }
 #else
 #  define png_handle_mDCV NULL
@@ -2088,7 +2081,6 @@ png_handle_pHYs(png_struct *png_ptr, png_info *info_ptr, png_uint_32 length)
    unit_type = buf[8];
    png_set_pHYs(png_ptr, info_ptr, res_x, res_y, unit_type);
    return handled_ok;
-   PNG_UNUSED(length)
 }
 #else
 #  define png_handle_pHYs NULL
@@ -2114,7 +2106,6 @@ png_handle_oFFs(png_struct *png_ptr, png_info *info_ptr, png_uint_32 length)
    unit_type = buf[8];
    png_set_oFFs(png_ptr, info_ptr, offset_x, offset_y, unit_type);
    return handled_ok;
-   PNG_UNUSED(length)
 }
 #else
 #  define png_handle_oFFs NULL
@@ -2328,6 +2319,18 @@ png_handle_tIME(png_struct *png_ptr, png_info *info_ptr, png_uint_32 length)
 
    png_debug(1, "in png_handle_tIME");
 
+   /* Validate chunk length before reading. All other fixed-size chunk handlers
+    * (tRNS, bKGD, gAMA, etc.) guard against wrong lengths here. png_handle_tIME
+    * previously called png_crc_read unconditionally, relying solely on the
+    * dispatch layer to reject wrong-length chunks. Add the explicit check for
+    * defence-in-depth and consistency with every other handler. */
+   if (length != 7)
+   {
+      if (png_crc_finish(png_ptr, length) != 0)
+         return handled_error;
+      png_chunk_benign_error(png_ptr, "invalid chunk length");
+      return handled_error;
+   }
    /* TODO: what is this doing here?  It should be happened in pngread.c and
     * pngpread.c, although it could be moved to png_handle_chunk below and
     * thereby avoid some code duplication.
@@ -2349,7 +2352,6 @@ png_handle_tIME(png_struct *png_ptr, png_info *info_ptr, png_uint_32 length)
 
    png_set_tIME(png_ptr, info_ptr, &mod_time);
    return handled_ok;
-   PNG_UNUSED(length)
 }
 #else
 #  define png_handle_tIME NULL


### PR DESCRIPTION
## Summary

Add the missing length guard to `png_handle_tIME()` in `pngrutil.c`, and remove the dead `PNG_UNUSED(length)` statement that follows an unconditional `return`.

## Problem

Every other fixed-size chunk handler in `pngrutil.c` validates the chunk length before reading data, for example `png_handle_tRNS`, `png_handle_bKGD`, `png_handle_gAMA`:

```c
if (length != expected)
{
   png_crc_finish(png_ptr, length);
   png_chunk_benign_error(png_ptr, "invalid");
   return handled_error;
}
```

`png_handle_tIME` is the only fixed-size handler that skips this check and calls `png_crc_read(png_ptr, buf, 7)` unconditionally. The dispatch layer (`CDtIME 7U, 7U`) currently rejects wrong-length chunks before reaching the handler, so there is no direct exploitable path — but relying solely on the dispatch layer for safety is fragile and inconsistent.

Additionally, `PNG_UNUSED(length)` appears after `return handled_ok` at the end of the function body, making it dead code.

## Fix

1. Add the explicit length check after the debug trace, matching every other handler.
2. Remove the dead `PNG_UNUSED(length)` macro invocation.

Fixes #826.