### PR TITLE
Fix double-free of struct member pointers on allocation failure

### DIFF
--- a/pngrtran.c
+++ b/pngrtran.c
@@ -495,6 +495,7 @@ png_set_quantize(png_struct *png_ptr, png_color *palette,
        * this function more than once per png_struct.
        */
       png_free(png_ptr, png_ptr->quantize_index);
+      png_ptr->quantize_index = NULL;
       png_ptr->quantize_index = (png_byte *)png_malloc(png_ptr,
           PNG_MAX_PALETTE_LENGTH);
       for (i = 0; i < PNG_MAX_PALETTE_LENGTH; i++)

--- a/pngrutil.c
+++ b/pngrutil.c
@@ -4789,7 +4789,9 @@ defined(PNG_USER_TRANSFORM_PTR_SUPPORTED)
    if (row_bytes + 48 > png_ptr->old_big_row_buf_size)
    {
       png_free(png_ptr, png_ptr->big_row_buf);
+      png_ptr->big_row_buf = NULL;
       png_free(png_ptr, png_ptr->big_prev_row);
+      png_ptr->big_prev_row = NULL;
 
       if (png_ptr->interlaced != 0)
          png_ptr->big_row_buf = (png_byte *)png_calloc(png_ptr,

--- a/pngset.c
+++ b/pngset.c
@@ -809,6 +809,7 @@ png_set_PLTE(png_struct *png_ptr, png_info *info_ptr,
     * regardless of num_palette.
     */
    png_free(png_ptr, png_ptr->palette);
+   png_ptr->palette = NULL;
    png_ptr->palette = png_voidcast(png_color *, png_calloc(png_ptr,
        PNG_MAX_PALETTE_LENGTH * (sizeof (png_color))));
    info_ptr->palette = png_voidcast(png_colorp, png_calloc(png_ptr,
@@ -1221,6 +1222,7 @@ png_set_tRNS(png_struct *png_ptr, png_info *info_ptr,
            * functions (e.g. png_do_expand_palette).
            */
           png_free(png_ptr, png_ptr->trans_alpha);
+          png_ptr->trans_alpha = NULL;
           png_ptr->trans_alpha = png_voidcast(png_bytep,
               png_malloc(png_ptr, PNG_MAX_PALETTE_LENGTH));
           memset(png_ptr->trans_alpha, 0xff, PNG_MAX_PALETTE_LENGTH);


### PR DESCRIPTION
## Summary

Four double-free vulnerabilities caused by `png_free()` not NULLing struct member pointers before a subsequent call that can `longjmp` via `png_error()`. If the allocation fails, the cleanup function `png_read_destroy()` frees the dangling pointer again.

### Fix 1: `big_row_buf` + `big_prev_row` in `png_read_start_row()` (pngrutil.c)

`png_read_destroy()` line 856 frees the dangling pointer.  Reachable from any PNG read path.

### Fix 2: `palette` in `png_set_PLTE()` (pngset.c)

`png_read_destroy()` line 873 frees the dangling pointer.  Reachable from untrusted PNG input via `png_handle_PLTE()`.

### Fix 3: `trans_alpha` in `png_set_tRNS()` (pngset.c)

`png_read_destroy()` line 881 frees the dangling pointer.  Reachable from untrusted PNG input via `png_handle_tRNS()`.  The correct pattern already exists at line 1231 of the same function, where `trans_alpha` IS NULLed after free.

### Fix 4: `quantize_index` in `png_set_quantize()` (pngrtran.c)

`png_read_destroy()` line 866 frees the dangling pointer.  Reachable when applications call `png_set_quantize()` (code at line 494 explicitly says repeated calls are allowed).

### Root cause

libpng uses `setjmp`/`longjmp` for error handling.  When `png_malloc()` fails, it calls `png_error()` which performs a `longjmp` to the application error handler.  This skips the pointer assignment that would have overwritten the freed address.  The cleanup function `png_read_destroy()` then frees the still-stored (now dangling) pointer — a double-free.

### Impact

- **Bug class:** CWE-415 (Double Free)
- **Trigger:** Crafted PNG combined with memory pressure causing `png_malloc` to fail
- **Fixes 1–3 reachable from:** Untrusted PNG input (read path)
- **Fix 4 reachable from:** Application API (`png_set_quantize()`)

### Testing

Library builds cleanly with `-Wall -Werror -fsanitize=address,undefined`.  pngtest passes.