### PR TITLE
add bounds checking in png_set_sPLT and png_set_unknown_chunks

### DIFF
--- a/pngset.c
+++ b/pngset.c
@@ -1325,6 +1325,15 @@ png_set_sPLT(const png_struct *png_ptr,
          continue;
       }
 
+      if (entries->nentries <= 0 ||
+          (size_t)entries->nentries > (PNG_SIZE_MAX / sizeof(png_sPLT_entry))) {
+        png_app_error(png_ptr, "png_set_sPLT: invalid sPLT entry count");
+        continue;
+      }
+
+      size_t bytes;
+      bytes = (size_t)entries->nentries * sizeof(png_sPLT_entry);
+
       np->depth = entries->depth;
 
       /* In the event of out-of-memory just return - there's no point keeping
@@ -1356,8 +1365,7 @@ png_set_sPLT(const png_struct *png_ptr,
       /* This multiply can't overflow because png_malloc_array has already
        * checked it when doing the allocation.
        */
-      memcpy(np->entries, entries->entries,
-          (unsigned int)entries->nentries * sizeof (png_sPLT_entry));
+      memcpy(np->entries, entries->entries,bytes);
 
       /* Note that 'continue' skips the advance of the out pointer and out
        * count, so an invalid entry is not added.
@@ -1631,6 +1639,13 @@ png_set_unknown_chunks(const png_struct *png_ptr,
 
       else
       {
+         if(unknowns->data == NULL && unknowns->size != 0)
+         {
+            png_chunk_report(png_ptr,
+            "unknown chunk: NULL data with nonzero size",
+            PNG_CHUNK_WRITE_ERROR);
+            continue;
+         }
          np->data = png_voidcast(png_byte *,
              png_malloc_base(png_ptr, unknowns->size));
 

--- a/pngtest.c
+++ b/pngtest.c
@@ -1364,6 +1364,27 @@ test_one_file(const char *inname, const char *outname)
        png_sPLT_t *entries;
 
        int num_entries = png_get_sPLT(read_ptr, read_info_ptr, &entries);
+       {
+           png_sPLT_t corrupted_plt;
+           
+           // Initialize an isolated dummy struct
+           png_structp dummy_write_ptr = png_create_write_struct(PNG_LIBPNG_VER_STRING, NULL, NULL, NULL);
+           
+           if (dummy_write_ptr != NULL)
+           {
+               png_set_benign_errors(dummy_write_ptr, 1);
+
+               corrupted_plt.name = "audit_palette";
+               // Link to the dummy pointer
+               corrupted_plt.entries = (png_sPLT_entry *)dummy_write_ptr;
+               corrupted_plt.depth = 8;
+               corrupted_plt.nentries = (int)(PNG_SIZE_MAX / sizeof(png_sPLT_entry) + 10);
+
+               png_set_sPLT(dummy_write_ptr, write_info_ptr, &corrupted_plt, 1);
+               
+               png_destroy_write_struct(&dummy_write_ptr, NULL);
+           }
+       }             
        if (num_entries != 0)
            png_set_sPLT(write_ptr, write_info_ptr, entries, num_entries);
    }
@@ -1461,6 +1482,28 @@ test_one_file(const char *inname, const char *outname)
       png_unknown_chunk *unknowns;
       int num_unknowns = png_get_unknown_chunks(read_ptr, read_info_ptr,
           &unknowns);
+
+      {
+         png_unknown_chunk corrupted_test_chunk;
+         
+         // Initialize an isolated dummy struct
+         png_structp dummy_write_ptr = png_create_write_struct(PNG_LIBPNG_VER_STRING, NULL, NULL, NULL);
+         
+         if (dummy_write_ptr != NULL)
+         {
+            /* Prevent the dummy struct from aborting on benign/app errors */
+            png_set_benign_errors(dummy_write_ptr, 1);
+
+            memcpy(corrupted_test_chunk.name, "tEXt", 5);
+            corrupted_test_chunk.location = PNG_HAVE_IHDR;
+            corrupted_test_chunk.size = 2048;
+            corrupted_test_chunk.data = NULL;
+
+            png_set_unknown_chunks(dummy_write_ptr, write_info_ptr, &corrupted_test_chunk, 1);
+            
+            png_destroy_write_struct(&dummy_write_ptr, NULL);
+         }
+      }
 
       if (num_unknowns != 0)
          png_set_unknown_chunks(write_ptr, write_info_ptr, unknowns,


### PR DESCRIPTION
Resolves https://github.com/pnggroup/libpng/issues/872

The PR hardens input validation inside pngset.c png_set_sPLT() and png_set_unknown_chunks() and resolves two issues. In png_set_sPLT, passing large nentries triggers signed wrap-around and triggers fatal internal error: 

libpng error: internal error: array alloc
Aborted                    (core dumped)

In png_set_unknown_chunks, chunks with NULL data but non-zero size are unchecked. As a result running test case which sets
`
            corrupted_test_chunk.size = 2048;
            corrupted_test_chunk.data = NULL;
`
throws segmentation fault!

Testing libpng version 1.8.0.git
   with zlib   version 1.3.1

libpng version 1.8.0.git
Copyright (c) 2018-2026 Cosmin Truta
Copyright (c) 1998-2002,2004,2006-2018 Glenn Randers-Pehrson
Copyright (c) 1996-1997 Andreas Dilger
Copyright (c) 1995-1996 Guy Eric Schalnat, Group 42, Inc.
 library (10800): libpng version 1.8.0.git

 pngtest (10800): libpng version 1.8.0.git

Segmentation fault         (core dumped) 