### PR TITLE
ci: pin editorconfig-checker action to full commit SHA

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install yamllint
         run: pip install yamllint
       - name: Install editorconfig-checker
-        uses: editorconfig-checker/action-editorconfig-checker@main
+        uses: editorconfig-checker/action-editorconfig-checker@840e866d93b8e032123c23bac69dece044d4d84c # main
       - name: Check out the code
         uses: actions/checkout@v4
       - name: Run the linting script


### PR DESCRIPTION
The lint workflow uses `editorconfig-checker/action-editorconfig-checker@main` — a mutable reference. Pinning to a full commit SHA hardens the CI supply chain against a compromised or maliciously updated action.

This is a recommended practice per [GitHub's security hardening guide](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) and [OpenSSF Scorecard](https://securityscorecards.dev/).