### PR TITLE
Libpng18 msvc warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,10 +151,11 @@ if(PNG_HAVE_LIBM_POW)
 endif()
 
 # Silence function deprecation warnings on the Windows compilers that might
-# use the MSVC Runtime library headers.
+# use the MSVC Runtime library headers, and set warnings to "production" level.
 if(WIN32 AND (CMAKE_C_COMPILER_ID MATCHES "MSVC|Intel|Clang"))
   add_definitions(-D_CRT_NONSTDC_NO_DEPRECATE)
   add_definitions(-D_CRT_SECURE_NO_DEPRECATE)
+  add_compile_options(/W3)
 endif()
 
 option(ld-version-script "Enable linker version script" ON)

--- a/pngread.c
+++ b/pngread.c
@@ -4198,7 +4198,7 @@ png_image_finish_read(png_image *image, const png_color *background,
             row_stride = (png_int_32)/*SAFE*/png_row_stride;
 
          if (row_stride < 0)
-            check = -(png_uint_32)row_stride;
+            check = 0 - (png_uint_32)row_stride;
 
          else
             check = (png_uint_32)row_stride;

--- a/pngwrite.c
+++ b/pngwrite.c
@@ -2049,7 +2049,7 @@ png_image_write_main(void *argument)
             display->row_stride = (png_int_32)/*SAFE*/png_row_stride;
 
          if (display->row_stride < 0)
-            check = -(png_uint_32)display->row_stride;
+            check = 0 - (png_uint_32)display->row_stride;
 
          else
             check = (png_uint_32)display->row_stride;


### PR DESCRIPTION
libpng is being included in a product in source form. It is then being built using the product's own build system. On Windows this is resulting in the following warnings being produced for `pngread.c` and `pngwrite.c`:
```
libpng\pngread.c(4201,21): warning C4146: unary minus operator applied to unsigned type, result still unsigned
libpng\pngwrite.c(2052,21): warning C4146: unary minus operator applied to unsigned type, result still unsigned 
```
CMake since 3.15 ([CMP0092](https://cmake.org/cmake/help/latest/policy/CMP0092.html)) lets the warnings flag default to `/W1` for MSVC builds. Warning level 1 does not report this warning, it needs to be at least level 2.

The product mandates warning-free builds and the use of at least warning level 2 with MSVC. For now, local code changes have been made to resolve the warning. Minimising changes to code in 3rd party libraries makes it easier to update the libraries at a later date as well as contributing back to them.

The first commit enables what Microsoft calls production quality level warnings that will show the warning being produced so that any warnings are spotted sooner.  The second commit applies the [recommended](https://devblogs.microsoft.com/oldnewthing/20210518-00/?p=105225) way to avoid the C4146 warning in a portable way.