### PR TITLE
Harden GitHub Actions workflow permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,6 +13,9 @@ on:
       - libpng16
       - libpng18
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/verify-linux.yml
+++ b/.github/workflows/verify-linux.yml
@@ -13,16 +13,22 @@ on:
       - libpng16
       - libpng18
 
+permissions:
+  contents: read
+
 jobs:
   verify-linux:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - name: Install dependencies
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          REF_NAME: ${{ github.ref }}
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y --no-install-recommends build-essential zlib1g-dev
-          if [[ "${{ github.ref }}" != refs/*/libpng16 && "${{ github.base_ref }}" != libpng16 ]]
+          if [[ "$REF_NAME" != refs/*/libpng16 && "$BASE_REF" != libpng16 ]]
           then
             sudo apt-get install -y --no-install-recommends autoconf automake libtool m4
           fi

--- a/.github/workflows/verify-macos.yml
+++ b/.github/workflows/verify-macos.yml
@@ -13,6 +13,9 @@ on:
       - libpng16
       - libpng18
 
+permissions:
+  contents: read
+
 jobs:
   verify-macos:
     runs-on: macos-latest

--- a/.github/workflows/verify-windows.yml
+++ b/.github/workflows/verify-windows.yml
@@ -13,6 +13,9 @@ on:
       - libpng16
       - libpng18
 
+permissions:
+  contents: read
+
 jobs:
   verify-windows:
     strategy:


### PR DESCRIPTION
This tightens the GitHub Actions workflow security posture without changing the lint or verification jobs.

- set the workflow `GITHUB_TOKEN` permissions to read-only contents access
- avoid direct GitHub context interpolation in the Linux dependency-install shell condition
- pass the ref values through environment variables and quote them before use

I verified the workflow YAML still parses, `git diff --check` passes, and `zizmor` no longer reports the previous excessive-permissions or template-injection findings. The remaining findings are action pinning warnings, which I left out of this focused change.
