### PR TITLE
fix(cmake): use space-separated string for CMAKE_REQUIRED_FLAGS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,27 +164,32 @@ if(ld-version-script AND NOT (ANDROID OR APPLE))
 VERS_1 { global: sym1; local: *; };
 VERS_2 { global: sym2; main; } VERS_1;
 ")
-  set(_SAVED_CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS})
+  string(REPLACE " " ";" _CMAKE_REQUIRED_FLAGS_LIST "${CMAKE_REQUIRED_FLAGS}")
   if(NOT CMAKE_HOST_SOLARIS)
     # Avoid using CMAKE_SHARED_LIBRARY_C_FLAGS in version script checks on
     # Solaris, because of an incompatibility with the Solaris link editor.
-    list(APPEND CMAKE_REQUIRED_FLAGS ${CMAKE_SHARED_LIBRARY_C_FLAGS})
+    list(APPEND _CMAKE_REQUIRED_FLAGS_LIST ${CMAKE_SHARED_LIBRARY_C_FLAGS})
   endif()
-  list(APPEND CMAKE_REQUIRED_FLAGS
+  list(APPEND _CMAKE_REQUIRED_FLAGS_LIST
               "-Wl,--version-script='${CMAKE_CURRENT_BINARY_DIR}/conftest.map'")
+
+  set(_SAVED_CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS})
+  list(JOIN _CMAKE_REQUIRED_FLAGS_LIST " " CMAKE_REQUIRED_FLAGS)
   check_c_source_compiles("
 void sym1(void) {}
 void sym2(void) {}
 int main(void) { return 0; }
 " HAVE_LD_VERSION_SCRIPT)
+
   if(NOT HAVE_LD_VERSION_SCRIPT)
-    set(CMAKE_REQUIRED_FLAGS ${_SAVED_CMAKE_REQUIRED_FLAGS})
+    string(REPLACE " " ";" _CMAKE_REQUIRED_FLAGS_LIST "${_SAVED_CMAKE_REQUIRED_FLAGS}")
     if(NOT CMAKE_HOST_SOLARIS)
       # Again, avoid using CMAKE_SHARED_LIBRARY_C_FLAGS in version script
       # checks on Solaris.
-      list(APPEND CMAKE_REQUIRED_FLAGS ${CMAKE_SHARED_LIBRARY_C_FLAGS})
+      list(APPEND _CMAKE_REQUIRED_FLAGS_LIST ${CMAKE_SHARED_LIBRARY_C_FLAGS})
     endif()
-    list(APPEND CMAKE_REQUIRED_FLAGS "-Wl,-M -Wl,${CMAKE_CURRENT_BINARY_DIR}/conftest.map")
+    list(APPEND _CMAKE_REQUIRED_FLAGS_LIST "-Wl,-M" "-Wl,${CMAKE_CURRENT_BINARY_DIR}/conftest.map")
+    list(JOIN _CMAKE_REQUIRED_FLAGS_LIST " " CMAKE_REQUIRED_FLAGS)
     check_c_source_compiles("
 void sym1(void) {}
 void sym2(void) {}


### PR DESCRIPTION
 The [CMake documentation](<https://cmake.org/cmake/help/latest/module/CheckCSourceCompiles.html#command:check_c_source_compiles>) specifies that `CMAKE_REQUIRED_FLAGS` must be a space-separated string, but the version-script checks in `CMakeLists.txt` use `list(APPEND)` on it, producing a semicolon-separated value.
This makes CMake 4.4 fail to configure libpng.
```
-- The C compiler identification is GNU 15.2.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Building for target architecture: x86_64
-- Found ZLIB: /usr/lib/x86_64-linux-gnu/libz.so (found version "1.3.1")
-- Looking for pow in m
-- Looking for pow in m - found
-- Performing Test HAVE_LD_VERSION_SCRIPT
CMake Error: The warning category "l,--version-script='/home/user/repos/pnggroup/libpng/build/conftest.map'" is not known.
CMake Error at /opt/cmake-trunk/share/cmake-4.4/Modules/Internal/CheckSourceCompiles.cmake:104 (try_compile):
  Failed to configure test project build system.
Call Stack (most recent call first):
  /opt/cmake-trunk/share/cmake-4.4/Modules/CheckCSourceCompiles.cmake:103 (cmake_check_source_compiles)
  CMakeLists.txt:175 (check_c_source_compiles)


-- Configuring incomplete, errors occurred!
```

This patch builds the flags in a helper list instead, seeded from the original `CMAKE_REQUIRED_FLAGS`, and joins it with `list(JOIN)` into a space-separated string before each check.