### PR TITLE
Validate palette bounds in png_set_quantize

### DIFF
--- a/pngrtran.c
+++ b/pngrtran.c
@@ -479,6 +479,18 @@ png_set_quantize(png_struct *png_ptr, png_color *palette,
    if (palette == NULL)
       return;
 
+   if (num_palette < 0 || num_palette > PNG_MAX_PALETTE_LENGTH)
+   {
+      png_warning(png_ptr, "Invalid palette length");
+      return;
+   }
+
+   if (maximum_colors <= 0 || maximum_colors > PNG_MAX_PALETTE_LENGTH)
+   {
+      png_warning(png_ptr, "Invalid maximum colors");
+      return;
+   }
+
    png_ptr->transformations |= PNG_QUANTIZE;
 
    if (full_quantize == 0)


### PR DESCRIPTION
## Summary

`png_set_quantize()` accepts caller-provided `num_palette` and `maximum_colors` values, but does not validate either value against the valid PNG palette range before using them in palette reduction and palette-copy logic.

This change adds validation for two related API argument constraints:

1. `num_palette` must be within `[0, PNG_MAX_PALETTE_LENGTH]`, because it can become the copy length for the internal 256-entry palette buffer.
2. `maximum_colors` must be within `[1, PNG_MAX_PALETTE_LENGTH]`, because it is used as the target size for palette reduction and later assigned back to `num_palette`.

This is API argument validation hardening. It is not triggered by PNG input; it requires an application to call `png_set_quantize()` with invalid arguments.

## Concern 1: `num_palette` — palette copy bounds

On the first call (when `png_ptr->palette` has not been allocated), `png_set_quantize()` allocates a fixed-size internal palette buffer and copies `num_palette` entries into it without bounds checking:

```c
png_ptr->palette = png_calloc(png_ptr,
    PNG_MAX_PALETTE_LENGTH * sizeof(png_color));         // 256 entries
memcpy(png_ptr->palette, palette,
    (unsigned int)num_palette * sizeof(png_color));      // unchecked copy length
```

If `num_palette` is negative, the cast to unsigned produces an invalid large copy length. If `num_palette > PNG_MAX_PALETTE_LENGTH`, the copy exceeds the 256-entry destination buffer. The existing `num_palette > maximum_colors` reduction condition does not prevent this when `num_palette <= maximum_colors`.

`png_set_PLTE()` already validates `num_palette` against the palette limit for the same reason (`pngset.c:762-769`). This guard follows that precedent.

## Concern 2: `maximum_colors` — reduction target and downstream `num_palette`

When the reduction block is entered (`num_palette > maximum_colors`), the function eventually assigns:

```c
num_palette = maximum_colors;                            // pngrtran.c:801
```

so an invalid `maximum_colors` becomes the final palette length used by the palette copy and subsequent quantization setup. A value of `maximum_colors <= 0` is not a meaningful reduction target — the no-histogram path reduces colors toward `maximum_colors`, and a target of zero or negative has no achievable termination condition. Both paths also use `maximum_colors` as a loop bound that assumes a positive value.

## Fix

Validate both arguments immediately after the existing `palette == NULL` guard, before setting `PNG_QUANTIZE`:

```c
if (num_palette < 0 || num_palette > PNG_MAX_PALETTE_LENGTH)
{
   png_warning(png_ptr, "Invalid palette length");
   return;
}

if (maximum_colors <= 0 || maximum_colors > PNG_MAX_PALETTE_LENGTH)
{
   png_warning(png_ptr, "Invalid maximum colors");
   return;
}
```

This keeps behavior unchanged for valid callers and avoids mutating transform state when invalid palette arguments are provided.

---

*Note: this is distinct from GHSA-4952, which addressed malformed PNG palette indices reaching `png_do_quantize()`. This change validates caller-supplied arguments to `png_set_quantize()` before palette reduction and copy setup.*
