### PR TITLE
Align NaN handling in floating-point conversion helpers

### DIFF
--- a/png.c
+++ b/png.c
@@ -2699,7 +2699,7 @@ png_fixed(const png_struct *png_ptr, double fp, const char *text)
 {
    double r = floor(100000 * fp + .5);
 
-   if (r > 2147483647. || r < -2147483648.)
+   if (!(r >= -2147483648. && r <= 2147483647.))
       png_fixed_error(png_ptr, text);
 
 #  ifndef PNG_ERROR_TEXT_SUPPORTED
@@ -2718,7 +2718,7 @@ png_fixed_ITU(const png_struct *png_ptr, double fp, const char *text)
 {
    double r = floor(10000 * fp + .5);
 
-   if (r > 2147483647. || r < 0)
+   if (!(r >= 0. && r <= 2147483647.))
       png_fixed_error(png_ptr, text);
 
 #  ifndef PNG_ERROR_TEXT_SUPPORTED

--- a/pngrtran.c
+++ b/pngrtran.c
@@ -304,7 +304,7 @@ convert_gamma_value(png_struct *png_ptr, double output_gamma)
    /* This preserves -1 and -2 exactly: */
    output_gamma = floor(output_gamma + .5);
 
-   if (output_gamma > PNG_FP_MAX || output_gamma < PNG_FP_MIN)
+   if (!(output_gamma >= PNG_FP_MIN && output_gamma <= PNG_FP_MAX))
       png_fixed_error(png_ptr, "gamma value");
 
    return (png_fixed_point)output_gamma;


### PR DESCRIPTION
## Problem

Three floating-point conversion helpers perform range validation using disjunctive predicates:

```c
if (r > 2147483647. || r < -2147483648.)   // png_fixed()
if (r > 2147483647. || r < 0)              // png_fixed_ITU()
if (output_gamma > PNG_FP_MAX || output_gamma < PNG_FP_MIN)  // convert_gamma_value()
```

IEEE 754 ordered comparisons involving NaN evaluate to false, so both sides of the `||` expression are false and NaN bypasses the range check.

The corresponding conversion macros in `pngpriv.h` already use conjunctive range tests:

```c
#define png_fixed(png_ptr, fp, s) ((fp) <= 21474 && (fp) >= -21474 ? ...
#define png_fixed_ITU(png_ptr, fp, s) ((fp) <= 214748 && (fp) >= 0 ? ...
```

For NaN inputs, these macro guards evaluate to false and take the existing error path. As a result, the helper implementations and macro implementations handle NaN differently.

## Fix

Rewrite the helper guards in inverted conjunctive form so that NaN follows the same error path as the macro implementations:

```c
if (!(r >= -2147483648. && r <= 2147483647.))   // png_fixed()
if (!(r >= 0. && r <= 2147483647.))             // png_fixed_ITU()
if (!(output_gamma >= PNG_FP_MIN && output_gamma <= PNG_FP_MAX))  // convert_gamma_value()
```

Behavior for finite values is unchanged: in-range values continue to succeed and out-of-range values continue to be rejected.

