### PR TITLE
ci: add permissions and pin actions to full commit SHAs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,13 +13,16 @@ on:
       - libpng16
       - libpng18
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: Set up the cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/pip.txt') }}
@@ -27,8 +30,8 @@ jobs:
       - name: Install yamllint
         run: pip install yamllint
       - name: Install editorconfig-checker
-        uses: editorconfig-checker/action-editorconfig-checker@main
+        uses: editorconfig-checker/action-editorconfig-checker@840e866d93b8e032123c23bac69dece044d4d84c # main
       - name: Check out the code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Run the linting script
         run: bash ./ci/ci_lint.sh

--- a/.github/workflows/verify-linux.yml
+++ b/.github/workflows/verify-linux.yml
@@ -13,6 +13,9 @@ on:
       - libpng16
       - libpng18
 
+permissions:
+  contents: read
+
 jobs:
   verify-linux:
     runs-on: ubuntu-latest
@@ -22,12 +25,12 @@ jobs:
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y --no-install-recommends build-essential zlib1g-dev
-          if [[ "${{ github.ref }}" != refs/*/libpng16 && "${{ github.base_ref }}" != libpng16 ]]
+          if [[ "${{ github.ref_name }}" != libpng16 && "${{ github.base_ref }}" != libpng16 ]]
           then
             sudo apt-get install -y --no-install-recommends autoconf automake libtool m4
           fi
       - name: Check out the code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Run the configure verification script
         run: bash ./ci/ci_verify_configure.sh
         env:

--- a/.github/workflows/verify-macos.yml
+++ b/.github/workflows/verify-macos.yml
@@ -13,13 +13,16 @@ on:
       - libpng16
       - libpng18
 
+permissions:
+  contents: read
+
 jobs:
   verify-macos:
     runs-on: macos-latest
     timeout-minutes: 10
     steps:
       - name: Check out the code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Run the CMake verification script
         run: bash ./ci/ci_verify_cmake.sh
         env:

--- a/.github/workflows/verify-windows.yml
+++ b/.github/workflows/verify-windows.yml
@@ -13,6 +13,9 @@ on:
       - libpng16
       - libpng18
 
+permissions:
+  contents: read
+
 jobs:
   verify-windows:
     strategy:
@@ -30,7 +33,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Set up vcpkg cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: C:/vcpkg/installed
           key: ${{ runner.os }}-vcpkg-${{ matrix.vcpkg_triplet }}-${{ hashFiles('vcpkg.json', '**/vcpkg.json') }}
@@ -40,7 +43,7 @@ jobs:
           vcpkg install zlib:${{ matrix.vcpkg_triplet }}
           vcpkg integrate install
       - name: Check out the code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Run the CMake verification script
         run: bash ./ci/ci_verify_cmake.sh
         env:


### PR DESCRIPTION
## Summary

All four CI workflow files (lint, verify-linux, verify-macos, verify-windows) were missing a top-level `permissions:` block and used mutable action tag references.

### Changes

**1. Add `permissions: contents: read` to all workflows**

Without an explicit `permissions` block, GitHub grants the `GITHUB_TOKEN` its default permissions (which include `contents: write` on some event types). Declaring `permissions: contents: read` at the workflow level follows the principle of least privilege and is a [recommended hardening practice](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#limiting-permissions-for-tokens).

**2. Pin all `uses:` references to full commit SHAs**

Mutable tags (`@v4`, `@main`) can be silently re-pointed to different—potentially malicious—commits. Pinning to the full SHA of the current tag ensures the exact code that was reviewed is what runs. The original tag is preserved as a comment for readability.

| Action | Before | After |
|--------|--------|-------|
| `actions/checkout` | `@v4` | `@34e114876b0b11c390a56381ad16ebd13914f8d5` |
| `actions/cache` | `@v4` | `@0057852bfaa89a56745cba8c7296529d2fc39830` |
| `editorconfig-checker/action-editorconfig-checker` | `@main` | `@840e866d93b8e032123c23bac69dece044d4d84c` |

**3. Fix `github.ref` glob comparison in `verify-linux.yml`**

The original condition used `${{ github.ref }}` (which has the form `refs/heads/libpng16`) against a glob pattern `refs/*/libpng16`. This is fragile in shell and the glob matching is not guaranteed to work as intended in a bash `[[ ]]` comparison. Replacing it with `${{ github.ref_name }}` (short branch/tag name) makes the condition cleaner and unambiguous.

These changes qualify under the [Google Patch Rewards Program](https://bughunters.google.com/open-source-security/patch-rewards) for proactive CI/supply-chain security hardening.