### PR TITLE
Add null check before closing file pointer

### DIFF
--- a/contrib/tools/checksum-icc.c
+++ b/contrib/tools/checksum-icc.c
@@ -81,7 +81,8 @@ int main(int argc, char **argv)
             printf("/* ERROR: %s */\n", argv[i]);
          }
 
-         (void)fclose(ip);
+         if (ip != NULL)
+            (void)fclose(ip);
       }
    }
 


### PR DESCRIPTION
Please review this change. Thanks!

**Description:**

Avoid calling `fclose()` with a `NULL` file pointer.

`fopen()` may fail and return `NULL`, so check `ip` before calling `fclose(ip)`.